### PR TITLE
feature: add example type Function to props

### DIFF
--- a/src/guide/component-props.md
+++ b/src/guide/component-props.md
@@ -194,9 +194,10 @@ app.component('my-component', {
         return ['success', 'warning', 'danger'].indexOf(value) !== -1
       }
     },
-    // Type function, the default will be the default function
+    // Function with a default value
     propG: {
       type: Function,
+      // Unlike object or array default, this is not a factory function - this is a function to serve as a default value
       default: function () {
         return 'Default function'
       },


### PR DESCRIPTION
Just add an example for when the prop type is Function, the behaviour is to treat the `default` as a function value instead of a `factory`.

We need to add a better description when we port this: https://vuejs.org/v2/api/#props
> Specifies a default value for the prop. If the prop is not passed, this value will be used instead. Object or array defaults must be returned from a factory function.

should be something like: 
> Specifies a default value for the prop. If the prop is not passed, this value will be used instead. If prop type is a function default will be used as value instead of factory function. Object or array defaults must be returned from a factory function.

vue-next PR with change: https://github.com/vuejs/vue-next/pull/1349