### PR TITLE
chore: minor re-alignment for custom block icons

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -21,7 +21,7 @@
 
   &::before {
     position: absolute;
-    top: 14px;
+    top: 19px;
     left: -14px;
     color: #fff;
     width: 20px;


### PR DESCRIPTION
Before:

<img src="https://user-images.githubusercontent.com/8056274/87007119-00d50c80-c1c2-11ea-8ba7-2b47f3a30341.png" width="332"/>

After:

<img src="https://user-images.githubusercontent.com/8056274/87007139-0b8fa180-c1c2-11ea-8056-1f2e08971103.png" width="332"/>

/cc @bencodezen 