### PR TITLE
Change Style Guide for Vue3 API.

### DIFF
--- a/src/style-guide/README.md
+++ b/src/style-guide/README.md
@@ -1311,39 +1311,31 @@ While attribute values without any spaces are not required to have quotes in HTM
 
 This is the default order we recommend for component options. They're split into categories, so you'll know where to add new properties from plugins.
 
-1. **Side Effects** (triggers effects outside the component)
-    - `el`
-
-2. **Global Awareness** (requires knowledge beyond the component)
+1. **Global Awareness** (requires knowledge beyond the component)
     - `name`
-    - `parent`
 
-3. **Component Type** (changes the type of the component)
-    - `functional`
-
-4. **Template Modifiers** (changes the way templates are compiled)
-    - `delimiters`
-    - `comments`
-
-5. **Template Dependencies** (assets used in the template)
+2. **Template Dependencies** (assets used in the template)
     - `components`
     - `directives`
-    - `filters`
 
-6. **Composition** (merges properties into the options)
+3. **Composition** (merges properties into the options)
     - `extends`
     - `mixins`
+    - `provide`/`inject`
 
-7. **Interface** (the interface to the component)
+4. **Interface** (the interface to the component)
     - `inheritAttrs`
-    - `model`
-    - `props`/`propsData`
+    - `props`
+    - `emits`
 
-8. **Local State** (local reactive properties)
+5. **Composition API** (the entry point for using the Composition API)
+    - `setup`
+
+6. **Local State** (local reactive properties)
     - `data`
     - `computed`
 
-9. **Events** (callbacks triggered by reactive events)
+7. **Events** (callbacks triggered by reactive events)
     - `watch`
     - Lifecycle Events (in the order they are called)
         - `beforeCreate`
@@ -1354,15 +1346,17 @@ This is the default order we recommend for component options. They're split into
         - `updated`
         - `activated`
         - `deactivated`
-        - `beforeDestroy`
-        - `destroyed`
+        - `beforeUnmount`
+        - `unmounted`
+        - `errorCaptured`
+        - `renderTracked`
+        - `renderTriggered`
 
-10. **Non-Reactive Properties** (instance properties independent of the reactivity system)
+8.  **Non-Reactive Properties** (instance properties independent of the reactivity system)
     - `methods`
 
-11. **Rendering** (the declarative description of the component output)
+9. **Rendering** (the declarative description of the component output)
     - `template`/`render`
-    - `renderError`
 
 ### Element attribute order <sup data-p="c">recommended</sup>
 
@@ -1717,15 +1711,18 @@ Vuex is the [official flux-like implementation](https://vuejs.org/v2/guide/state
 
 ``` js
 // main.js
-const app = Vue.createApp({
+import { createApp } from 'vue'
+import mitt from 'mitt'
+const app = createApp({
   data() {
     return {
-      todos: []
+      todos: [],
+      emitter: mitt()
     }
   },
 
   created() {
-    this.$on('remove-todo', this.removeTodo)
+    this.emitter.on('remove-todo', this.removeTodo)
   },
 
   methods: {


### PR DESCRIPTION
This PR changes the style guide to use the new API in Vue.js 3.

close #184 

The following is a summary of this PR changes.

- `Component/instance options order` Section
  - Remove **Side Effects** category
    - Remove `el` option
  - Change **Global Awareness** category
    - Remove `parent` option
  - Remove **Component Type** category
    - Remove `functional` option
  - Remove **Template Modifiers** category
    - Remove `delimiters` option
    - Remove `comments` option
  - Change **Template Dependencies** category
    - Remove `filters` option
  - Change **Composition** category
    - Add `provide`/ `inject` option
  - Change **Interface** category
    - Remove `model` option
    - Remove `propsData` option
    - Add `emits` option
  - Add **Composition API** category
    - Add `setup` option
  - Change **Events** category > Lifecycle Events
    - Replace `beforeDestroy` to `beforeUnmount`
    - Replace `destroyed` to `unmounted`
    - Add `errorCaptured` lifecycle
    - Add `renderTracked` lifecycle
    - Add `renderTriggered` lifecycle
  - Change **Rendering** category
    - Remove `renderError` option
- `Non-flux state management` Section
  - Replace use of `$on` to use `mitt`.
  - Replace use of `Vue.createApp` to use `import {createApp} from 'vue'`