### PR TITLE
feat: make Edit footer less prominent

### DIFF
--- a/src/.vuepress/theme/components/PageEdit.vue
+++ b/src/.vuepress/theme/components/PageEdit.vue
@@ -1,20 +1,26 @@
 <template>
   <footer class="page-edit">
-    <div v-if="editLink" class="edit-link">
-      Caught a mistake or want to contribute to the documentation?
-      <a :href="editLink" target="_blank" rel="noopener noreferrer">{{
-        editLinkText
-      }}</a>
-      <OutboundLink />
-    </div>
-
-    <div>
-      Deployed on <a href="https://url.netlify.com/HJ8X2mxP8">Netlify</a>
-    </div>
-
-    <div v-if="lastUpdated" class="last-updated">
-      <span class="prefix">{{ lastUpdatedText }}:</span>
-      <span class="time">{{ lastUpdated }}</span>
+    <div class="container">
+      <p>
+        Deployed on
+        <a href="https://url.netlify.com/HJ8X2mxP8">Netlify</a>.
+        <span v-if="editLink" class="edit-link">
+          Caught a mistake or want to contribute to the documentation?
+          <a
+            :href="editLink"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ editLinkText }}
+            <OutboundLink />
+          </a>
+        </span>
+        <template v-if="lastUpdated" class="last-updated">
+          <br />
+          <span class="prefix">{{ lastUpdatedText }}:</span>
+          <span class="time">{{ lastUpdated }}</span>
+        </template>
+      </p>
     </div>
   </footer>
 </template>
@@ -104,7 +110,9 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss" scoped>
+@import '@theme/styles/_settings.scss';
+
 /*
   This entire style block is MVP style wise and will likely
   be changed with the new atomic theme. Changes are welcome!
@@ -115,10 +123,20 @@ export default {
 
 .page-edit {
   padding: 0 1.5rem;
-  display: flex;
-  align-items: center;
-  flex-direction: column;
   max-width: 740px;
   margin: 0 auto;
+  font-size: 0.95em;
+  color: $light;
+  text-align: center;
+
+  p {
+    margin: 0.8rem auto;
+  }
+
+  .container {
+    border: 1px solid #eaecef;
+    border-radius: 5px;
+    padding: 0 1.5rem;
+  }
 }
 </style>

--- a/src/.vuepress/theme/components/PageNav.vue
+++ b/src/.vuepress/theme/components/PageNav.vue
@@ -1,13 +1,7 @@
 <template>
-  <div
-    v-if="prev || next"
-    class="page-nav"
-  >
+  <div v-if="prev || next" class="page-nav">
     <p class="inner">
-      <span
-        v-if="prev"
-        class="prev"
-      >
+      <span v-if="prev" class="prev">
         ←
         <a
           v-if="prev.type === 'external'"
@@ -17,23 +11,13 @@
           rel="noopener noreferrer"
         >
           {{ prev.title || prev.path }}
-
           <OutboundLink />
         </a>
 
-        <RouterLink
-          v-else
-          class="prev"
-          :to="prev.path"
-        >
-          {{ prev.title || prev.path }}
-        </RouterLink>
+        <RouterLink v-else class="prev" :to="prev.path">{{ prev.title || prev.path }}</RouterLink>
       </span>
 
-      <span
-        v-if="next"
-        class="next"
-      >
+      <span v-if="next" class="next">
         <a
           v-if="next.type === 'external'"
           :href="next.path"
@@ -41,17 +25,10 @@
           rel="noopener noreferrer"
         >
           {{ next.title || next.path }}
-
           <OutboundLink />
         </a>
 
-        <RouterLink
-          v-else
-          :to="next.path"
-        >
-          {{ next.title || next.path }}
-        </RouterLink>
-        →
+        <RouterLink v-else :to="next.path">{{ next.title || next.path }}</RouterLink>→
       </span>
     </p>
   </div>
@@ -68,21 +45,21 @@ export default {
   props: ['sidebarItems'],
 
   computed: {
-    prev () {
+    prev() {
       return resolvePageLink(LINK_TYPES.PREV, this)
     },
 
-    next () {
+    next() {
       return resolvePageLink(LINK_TYPES.NEXT, this)
     }
   }
 }
 
-function resolvePrev (page, items) {
+function resolvePrev(page, items) {
   return find(page, items, -1)
 }
 
-function resolveNext (page, items) {
+function resolveNext(page, items) {
   return find(page, items, 1)
 }
 
@@ -99,7 +76,7 @@ const LINK_TYPES = {
   }
 }
 
-function resolvePageLink (
+function resolvePageLink(
   linkType,
   { $themeConfig, $page, $route, $site, sidebarItems }
 ) {
@@ -123,7 +100,7 @@ function resolvePageLink (
   }
 }
 
-function find (page, items, offset) {
+function find(page, items, offset) {
   const res = []
   flatten(items, res)
   for (let i = 0; i < res.length; i++) {
@@ -134,7 +111,7 @@ function find (page, items, offset) {
   }
 }
 
-function flatten (items, res) {
+function flatten(items, res) {
   for (let i = 0, l = items.length; i < l; i++) {
     if (items[i].type === 'group') {
       flatten(items[i].children || [], res)
@@ -146,18 +123,22 @@ function flatten (items, res) {
 </script>
 
 <style lang="stylus">
-@require '../styles/wrapper.styl'
+@require '../styles/wrapper.styl';
 
-.page-nav
-  @extend $wrapper
-  padding-top 1rem
-  padding-bottom 0
-  .inner
-    min-height 2rem
-    margin-top 0
-    border-top 1px solid $borderColor
-    padding-top 1rem
-    overflow auto // clear float
-  .next
-    float right
+.page-nav {
+  @extend $wrapper;
+  padding-top: 1rem;
+  padding-bottom: 0;
+
+  .inner {
+    min-height: 2rem;
+    margin-top: 0;
+    padding-top: 1rem;
+    overflow: auto; // clear float
+  }
+
+  .next {
+    float: right;
+  }
+}
 </style>


### PR DESCRIPTION
I've always felt the current Edit footer is a bit too "in the face" with it sharing the same font size and color as with the main content's. This is my attempt to make it less prominent.

Before:

![image](https://user-images.githubusercontent.com/8056274/87713240-2a85c900-c7aa-11ea-8417-ab37b57404a3.png)


After:

![image](https://user-images.githubusercontent.com/8056274/87713216-23f75180-c7aa-11ea-88a1-16099b7f4d88.png)
