### PR TITLE
Document SFC and <template> DSL spec

### DIFF
--- a/src/guide/spec-single-file-component.md
+++ b/src/guide/spec-single-file-component.md
@@ -1,0 +1,139 @@
+# Vue Single File Component Language Specification
+
+## Overview
+
+> TODO: Write a non-normative overview of SFC.
+
+## Scope
+
+_This section is non-normative._
+
+This specification is limited to providing a markup language to collocate multiple languages used for defining Vue components.
+
+## Terms and definitions
+
+For the purposes of this document, the following terms and definitions apply.
+
+### SFC
+
+An HTML like text file with `.vue` extension. SFC stands for Single File Component.
+
+### Block
+
+Top level elements in an SFC.
+
+### Language Region
+
+Programming language of inner text of a block. There are three pre-defined language regions: `<script>` block defaults to **JavaScript**, `<template>` block defaults to **VueHTML**, and `<style>` block defaults to `CSS`. Language region can be overridden using `lang` attribute on the block tags. e.g. `<script lang="ts">` is a **TypeScript** language region.
+
+## The blocks of SFC
+
+At least one `<script>` or `<template>` block MUST exist.
+
+### The script block
+
+The `<script>` block defines the ES module exported from an SFC. An SFC can have at most two `<script>` blocks: `<script>` and `<script setup>`.
+
+#### Attributes
+
+##### lang
+
+overrides the language region of the block. Default language region of `<script>` block is **JavaScript**. 
+
+Allowed values: `js`, `ts`, or any other programming language file extension.
+##### src
+
+relative path of an external file to be used as contents of `<script>` block.
+
+Allowed values: a relative TypeScript or JavaScript file path. 
+
+_The `src` is disallowed when using `<script setup>`._
+
+##### setup
+
+sets `<script>` block in Vue composition API mode which allows concise JavaScript/TypeScript syntax and reactive variable declaration.
+            
+Allowed values: none (e.g. `<script setup>`), arguments of generated `setup()` function (e.g. `<script setup="props">` or `<script setup="props, { slots }">`)
+
+#### Options API mode
+
+Only one `<script>` block is allowed. 
+
+The `<script>` block acts as a normal JavaScript/TypeScript file, used to define component options as per Vue options API. The `<script>` block MUST have a default export.
+
+#### Composition API mode
+
+An optional `<script>` block and a `<script setup>` block is allowed. 
+
+The `<script setup>` block acts is compiler enhanced JavaScript/TypeScript which defines `setup()` function of Vue composition API.
+
+The `<script>` block (when included with `<script setup>`) defines module scope script.
+
+### The template block
+
+The `<template>` block defines the view rendered by the SFC. At most one `<template>` block is allowed.
+
+#### Attributes
+
+##### lang
+
+overrides the language region of the block. Default language region of `<template>` block is **VueHTML**, a DSL defined by [VueHTML Language Specification](#file-vue-html-md)
+
+Allowed values: `vue-html`, `pug` or any other markup language.
+
+##### functional
+
+**(deprecated)** sets Vue compiler to generate functional component.
+
+##### src
+
+relative path of an external file to be used as contents of `<template>` block.
+
+Allowed values: a relative VueHTML file path. 
+
+### The style block
+
+The `<style>` block defines the stylesheets used by the SFC. Any number of `<style>` blocks can be defined in SFC.
+
+#### Attributes
+
+##### lang
+
+overrides the language region of the block. Default language region of `<style>` block is **CSS**.
+
+Allowed values: `css`, `scss`, `sass`, `styl`, `stylus`, `less`, `postcss` or any other style language.
+
+##### scoped
+
+sets Vue compiler to generate component scoped stylesheet using scope identifier attribute.
+
+Allowed values: none.
+
+_The `scoped` attribute is disallowed when using `<style module>`._
+
+##### module
+
+sets Vue compiler to generate component scoped stylesheet using CSS modules. The module names are provided as `$style` variable in `<script>` and `<template>` blocks. The `$style` variable can be overridden by providing a custom name, e.g., `<style module="CSS">`.
+
+Allowed values: none, or a valid JavaScript identifier.
+
+_The `module` attribute is disallowed when using `<style scoped>`._
+
+##### src
+
+relative path of an external file to be used as contents of `<style>` block.
+
+Allowed values: a relative CSS or any other style language file path. 
+
+## Extensibility
+
+_This section is non-normative._
+
+SFC defines three standard block elements: `<template>`, `<script>`, and `<style>`. But the spec allows other custom block elements.
+
+Known non-standard blocks:
+
+1. `<docs>` — Language Region: `markdown`
+1. `<i18n>` - Language Region: `json`, Used by: [vue-i18n](https://kazupon.github.io/vue-i18n)
+1. `<page-query>` - Language Region: `graphql`, Used by: [Gridsome](https://gridsome.org/docs/querying-data)
+1. `<preview>` - Language Region: `vue-html`, Used by: [Preview](https://github.com/znck/preview)

--- a/src/guide/spec-vue-html.md
+++ b/src/guide/spec-vue-html.md
@@ -1,0 +1,45 @@
+# VueHTML Language Specification
+
+## Overview
+
+The VueHTML Language is a domain specific language built by extending [HTML5](https://html.spec.whatwg.org/) for declaratively defining render logic of Vue components.
+
+## Scope
+
+_This section is non-normative._
+
+This specification is limited to defining the VueHTML DSL by inheriting everything from [HTML5 specification](https://html.spec.whatwg.org/) unless explicitly defined. 
+
+## Terms and definitions
+
+For the purposes of this document, the following terms and definitions apply.
+
+## The elements of VueHTML
+
+VueHTML includes all elements defined by [HTML5](https://html.spec.whatwg.org/#toc-semantics) with following additions or exceptions.
+
+### The DOCTYPE
+
+A **DOCTYPE** is not required.
+
+If DOCTYPE is present, it should be parsed as comment using the [bogus comment state specification](https://html.spec.whatwg.org/#bogus-comment-state).
+
+### The slot element
+
+> TODO
+
+### The template element
+
+> TODO
+
+### The component element
+
+> TODO
+
+## Directives
+
+> TODO
+
+## Parsing VueHTML documents
+
+> TODO: Extend https://html.spec.whatwg.org/#parsing specification to add directive and component parsing.


### PR DESCRIPTION
## Description of Problem

The specification of `.vue` file (SFC) and `<template>` DSL is captured either in first-party tools like `@vue/compiler-sfc` package or in the heads of maintainers. With a lack of formal spec, it's very difficult for the community to build alternative tools.

## Proposed Solution

Add a formal spec to vuejs.org

