### PR TITLE
fix: add `binding.expression` removal to BC list

### DIFF
--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -118,6 +118,7 @@ The following consists a list of breaking changes from 2.x:
 - [`propsData` option](/guide/migration/props-data.html)
 - `$destroy` instance method. Users should no longer manually manage the lifecycle of individual Vue components.
 - Global functions `set` and `delete`, and the instance methods `$set` and `$delete`. They are no longer required with proxy-based change detection.
+- `binding.expression` in [Custom Directives](/guide/migration/custom-directives.html).
 
 ## Supporting Libraries
 


### PR DESCRIPTION
## Description of Problem

The `binding.expression` was removed in Vue 3, but this breaking change has not been document yet.

## Proposed Solution

Add this removal to the list of breaking changes.

## Additional Information

* https://github.com/vuejs/vue-next/issues/3107
* https://forum.vuejs.org/t/where-is-binding-expression-in-vue-3/115041/3