### PR TITLE
Correct vue.config.js example

### DIFF
--- a/src/guide/migration/migration-build.md
+++ b/src/guide/migration/migration-build.md
@@ -91,6 +91,7 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
              }
            }
          })
+     }
    }
    ```
 


### PR DESCRIPTION
A bracket is missing from the vue.config.js configuration example, this change would add in the missing bracket so the code example is valid.

## Description of Problem

In the code example for vue.config.js to add the compat rule, a bracket is missing which results in an error when copy/pasted.

## Proposed Solution

The proposed solution would be to add in the bracket, so that the code example is correct and valid.

## Additional Information