### PR TITLE
fix: exclude style example blocks from banner styles

### DIFF
--- a/src/.vuepress/theme/components/BannerTop.vue
+++ b/src/.vuepress/theme/components/BannerTop.vue
@@ -155,13 +155,15 @@ $topBannerHeightMobile ?= 3.125rem
 // Adjust titles margin and padding for anchor links
 .theme-container.has-top-banner
   {$contentClass}:not(.custom)
-    h1, h2, h3, h4, h5, h6
-      margin-top (0.5rem - $topBannerHeight - $navbarHeight)
-      padding-top ($navbarHeight + $topBannerHeight + 1rem)
+    :not(.style-example)
+      h1, h2, h3, h4, h5, h6
+        margin-top (0.5rem - $topBannerHeight - $navbarHeight)
+        padding-top ($navbarHeight + $topBannerHeight + 1rem)
 @media (min-width: 680px)
   .theme-container.has-top-banner
     {$contentClass}:not(.custom)
-      h1, h2, h3, h4, h5, h6
-        margin-top (0.5rem - $topBannerHeightMobile - $navbarHeight)
-        padding-top ($navbarHeight + $topBannerHeightMobile + 1rem)
+      :not(.style-example)
+        h1, h2, h3, h4, h5, h6
+          margin-top (0.5rem - $topBannerHeightMobile - $navbarHeight)
+          padding-top ($navbarHeight + $topBannerHeightMobile + 1rem)
 </style>


### PR DESCRIPTION
## Description of Problem
If the Vue School banner is open, the style example blocks on the Style Guide will have too much top margin and padding. Detail blocks directly above a style example block will also be unexpandable.

![firefox_2UwExWwJSt](https://user-images.githubusercontent.com/1782590/122952756-ce132c80-d3b0-11eb-9408-673b036b1ce8.png)

This is because the styles in BannerTop.vue mistakenly apply top margin and padding to the header in style example blocks. This causes the blocks to be too tall, as well as oveflow their container, overlaying the detail block above and blocking clicks to the <detail> element.

![firefox_UbeGD8WVp7](https://user-images.githubusercontent.com/1782590/122952429-9b693400-d3b0-11eb-98e5-9b5d7c555d7d.png)

## Proposed Solution
Let's fix the styles for headers in BannerTop.vue to exclude those in style example blocks.

