### PR TITLE
fix typo in composition-api-template-refs.md

### DIFF
--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -133,7 +133,7 @@ Therefore, watchers that use template refs should be defined with the `flush: 'p
       const root = ref(null)
 
       watchEffect(() => {
-        console.log(root.value) // => <div></div>
+        console.log(root.value) // => <div>This is a root element</div>
       }, 
       {
         flush: 'post'


### PR DESCRIPTION
## Description of Problem
when using the `flush: 'post'` option,  print error 
```javascript
 //<div></div>
```
## Proposed Solution
 modify
```javascript
 //<div>This is a root element</div>
```
## Additional Information
