### PR TITLE
add vue school links to supplement component documentation with video…

### DIFF
--- a/src/guide/component-basics.md
+++ b/src/guide/component-basics.md
@@ -1,5 +1,7 @@
 # Components Basics
 
+<VideoLesson href="https://vueschool.io/courses/vue-js-3-components-fundamentals?friend=vuejs" title="Free Vue.js Components Fundamentals Course">Learn component basics with a free video course on Vue School</VideoLesson>
+
 ## Base Example
 
 Here's an example of a Vue component:

--- a/src/guide/component-props.md
+++ b/src/guide/component-props.md
@@ -2,6 +2,8 @@
 
 > This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
+<VideoLesson href="https://vueschool.io/lessons/vue-3-reusable-components-with-props?friend=vuejs" title="Free Vue.js Component Props Lesson">Learn how component props work with a free lesson on Vue School</VideoLesson>
+
 ## Prop Types
 
 So far, we've only seen props listed as an array of strings:

--- a/src/guide/component-registration.md
+++ b/src/guide/component-registration.md
@@ -1,5 +1,7 @@
 # Component Registration
 
+<VideoLesson href="https://vueschool.io/lessons/vue-3-global-vs-local-vue-components?friend=vuejs" title="Free Vue.js Component Registration lesson">Learn how component registration works with a free lesson on Vue School</VideoLesson>
+
 > This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
 ## Component Names

--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -2,6 +2,8 @@
 
 > This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
+<VideoLesson href="https://vueschool.io/lessons/vue-3-component-slots?friend=vuejs" title="Free Vue.js Slots lesson">Learn slot basics with a free lesson on Vue School</VideoLesson>
+
 ## Slot Content
 
 Vue implements a content distribution API inspired by the [Web Components spec draft](https://github.com/w3c/webcomponents/blob/gh-pages/proposals/Slots-Proposal.md), using the `<slot>` element to serve as distribution outlets for content.

--- a/src/guide/single-file-component.md
+++ b/src/guide/single-file-component.md
@@ -1,6 +1,6 @@
 # Single File Components
 
-<VideoLesson href="https://vueschool.io/courses/vue-3-single-file-components?friend=vuejs" title="Free Vue.js Single File Components Course">Learn about single file components with a free video course on Vue School</VideoLesson>
+<VideoLesson href="https://vueschool.io/lessons/vue-3-introduction-to-single-file-components?friend=vuejs" title="Free Vue.js Single File Components Lesson">Learn about single file components with a free video lesson on Vue School</VideoLesson>
 
 ## Introduction
 

--- a/src/guide/single-file-component.md
+++ b/src/guide/single-file-component.md
@@ -1,5 +1,7 @@
 # Single File Components
 
+<VideoLesson href="https://vueschool.io/courses/vue-3-single-file-components?friend=vuejs" title="Free Vue.js Single File Components Course">Learn about single file components with a free video course on Vue School</VideoLesson>
+
 ## Introduction
 
 In many Vue projects, global components will be defined using `app.component()`, followed by `app.mount('#app')` to target a container element in the body of every page.


### PR DESCRIPTION
This PR adds Vue School links to the documentation to supplement the documentation with free training videos about components.

The lessons are up-to-date, V3 versions of component lessons currently on the v2 documentation site.

Screenshots of the placements can be seen [here](https://gist.github.com/danielkellyio/9c43246c1a50a8b8a617861827010764)

Links:
[Component Basics](https://vueschool.io/courses/vue-js-3-components-fundamentals)
[Component Props](https://vueschool.io/lessons/vue-3-reusable-components-with-props)
[Component Registration](https://vueschool.io/lessons/vue-3-global-vs-local-vue-components)
[Component Slots](https://vueschool.io/lessons/vue-3-component-slots)
[Single File Components](https://vueschool.io/courses/vue-3-single-file-components)

Thanks!