### PR TITLE
Improve Example for TypeScript Property Annotation

### DIFF
--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -247,6 +247,7 @@ interface Book {
 const Component = defineComponent({
   props: {
     name: String,
+    id: [Number, String],
     success: { type: String },
     callback: {
       type: Function as PropType<() => void>
@@ -254,6 +255,9 @@ const Component = defineComponent({
     book: {
       type: Object as PropType<Book>,
       required: true
+    },
+    metadata: {
+      type: null // metadata is typed as any
     }
   }
 })


### PR DESCRIPTION
## Description of Problem
In the `Annotating Props` section of the chapter `Typescript Support`, it is not clear how to annotate a property with any or a union type. 

## Proposed Solution
Extend the example with a union type property and an any property.

## Additional Information
