### PR TITLE
Elaborate on what can be included in the createApp root props

### DIFF
--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -63,6 +63,8 @@ const app = createApp(
 </div>
 ```
 
+The root props are raw props, much like those passed to [`h`](#h) to create a VNode. In addition to component props, they can also include attributes and event listeners to be applied to the root component.
+
 ### Typing
 
 ```ts


### PR DESCRIPTION
The props passed to `createApp` are raw props, so they can include attributes and event listeners as well as actual component props. This PR attempts to clarify that.

The original motivation was a Discord conversation about trying to migrate a `$on` call from Vue 2. In some cases it is possible to achieve the same effect by using a root prop like `onClick`. I intend to put in a separate PR to expand the migration guide page about `$on` to cover this use case.