### PR TITLE
Extra examples of migrating keyCode modifiers

### DIFF
--- a/src/guide/migration/keycode-modifiers.md
+++ b/src/guide/migration/keycode-modifiers.md
@@ -46,7 +46,10 @@ Since [`KeyboardEvent.keyCode` has been deprecated](https://developer.mozilla.or
 
 ```html
 <!-- Vue 3 Key Modifier on v-on -->
-<input v-on:keyup.delete="confirmDelete" />
+<input v-on:keyup.page-down="nextPage">
+
+<!-- Matches both q and Q -->
+<input v-on:keypress.q="quit">
 ```
 
 As a result, this means that `config.keyCodes` is now also deprecated and will no longer be supported.
@@ -54,6 +57,14 @@ As a result, this means that `config.keyCodes` is now also deprecated and will n
 ## Migration Strategy
 
 For those using `keyCode` in their codebase, we recommend converting them to their kebab-cased named equivalents.
+
+The keys for some punctuation marks can just be included literally. e.g. For the `,` key:
+
+```html
+<input v-on:keypress.,="commaPress">
+```
+
+Limitations of the syntax prevent certain characters from being matched, such as `"`, `'`, `/`, `=`, `>`, and `.`. For those characters you should check `event.key` inside the listener instead.
 
 [Migration build flags:](migration-build.html#compat-configuration)
 


### PR DESCRIPTION
The original motivation here is trying to explain how to handle punctuation characters. The RFC doesn't seem to acknowledge this problem. `event.key` exposes printable keys as single-character strings, equal to the printable character. There is no 'kebab-case named' equivalent, you just have to write the character literally in the attribute. In many cases that isn't possible as the character isn't syntactically valid. I'm not aware of any workaround for this, aside from not using the modifier.

I've also changed the existing example. The `delete` key has special internal handling, so I don't think it's the most suitable choice for an example. `page-down` illustrates the use of kebab-case. The `q` example illustrates how the conversion to kebab-case results in letters being matched case-insensitively.