### PR TITLE
Document the removal of binding.expression for directives

### DIFF
--- a/src/guide/migration/custom-directives.md
+++ b/src/guide/migration/custom-directives.md
@@ -9,6 +9,8 @@ badges:
 
 The hook functions for directives have been renamed to better align with the component lifecycle.
 
+Additionally, the `expression` string is no longer passed as part of the `binding` object.
+
 ## 2.x Syntax
 
 In Vue 2, custom directives were created by using the hooks listed below to target an element’s lifecycle, all of which are optional:

--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -100,7 +100,7 @@ The following consists a list of breaking changes from 2.x:
 - The `destroyed` lifecycle option has been renamed to `unmounted`
 - The `beforeDestroy` lifecycle option has been renamed to `beforeUnmount`
 - [Props `default` factory function no longer has access to `this` context](/guide/migration/props-default-this.html)
-- [Custom directive API changed to align with component lifecycle](/guide/migration/custom-directives.html)
+- [Custom directive API changed to align with component lifecycle and `binding.expression` removed](/guide/migration/custom-directives.html)
 - [The `data` option should always be declared as a function](/guide/migration/data-option.html)
 - [The `data` option from mixins is now merged shallowly](/guide/migration/data-option.html#mixin-merge-behavior-change)
 - [Attributes coercion strategy changed](/guide/migration/attribute-coercion.html)


### PR DESCRIPTION
Closes #758.

Related issues from `vue-next`:

* https://github.com/vuejs/vue-next/issues/3107
* https://github.com/vuejs/vue-next/issues/4029

#1005 attempted to document the same change but the author didn't respond to my feedback, so I'm opening this PR to replace it.

I've only documented the removal. I haven't provided a migration path or rationale for the change because I don't have that information.