### PR TITLE
fix: typo on "ATTR_ENUMERATED_COERCION"

### DIFF
--- a/src/guide/migration/migration-build.md
+++ b/src/guide/migration/migration-build.md
@@ -314,7 +314,7 @@ Features that start with `COMPILER_` are compiler-specific: if you are using the
 | V_ON_KEYCODE_MODIFIER        | ✔    | `v-on` no longer supports keyCode modifiers                           | [link](/guide/migration/keycode-modifiers.html)                                            |
 | CUSTOM_DIR                   | ✔    | Custom directive hook names changed                                   | [link](/guide/migration/custom-directives.html)                                            |
 | ATTR_FALSE_VALUE             | ✔    | No longer removes attribute if binding value is boolean `false`       | [link](/guide/migration/attribute-coercion.html)                                           |
-| ATTR_ENUMERATED_COERSION     | ✔    | No longer special case enumerated attributes                          | [link](/guide/migration/attribute-coercion.html)                                           |
+| ATTR_ENUMERATED_COERCION     | ✔    | No longer special case enumerated attributes                          | [link](/guide/migration/attribute-coercion.html)                                           |
 | TRANSITION_GROUP_ROOT        | ✔    | `<transition-group>` no longer renders a root element by default      | [link](/guide/migration/transition-group.html)                                             |
 | COMPONENT_ASYNC              | ✔    | Async component API changed (now requires `defineAsyncComponent`)     | [link](/guide/migration/async-components.html)                                             |
 | COMPONENT_FUNCTIONAL         | ✔    | Functional component API changed (now must be plain functions)        | [link](/guide/migration/functional-components.html)                                        |


### PR DESCRIPTION
## Description of Problem

Config name in docs is wrong

```
[Vue warn]: Invalid deprecation config "ATTR_ENUMERATED_COERSION".
```

## Proposed Solution

Correct typo

## Additional Information

https://github.com/vuejs/vue-next/blob/03e26845e2c220b1350a35179acf3435e2711282/packages/runtime-core/src/compat/compatConfig.ts#L54

