### PR TITLE
fix: broken redirect url

### DIFF
--- a/src/guide/mobile.md
+++ b/src/guide/mobile.md
@@ -20,4 +20,4 @@ While Vue.js does not natively support mobile app development, there are a numbe
 
 **Resources**
 
-- [NativeScript + Vue.js Guide](https://nativescript.org/vue/)
+- [NativeScript + Vue.js Guide](https://nativescript-vue.org/)


### PR DESCRIPTION
## Description of Problem
link native-vue in mobile.md page is redirect to broken link "https://nativescript.org/vue/"
## Proposed Solutionf
fix redirect link to "https://nativescript-vue.org/"
## Additional Information
https://v3.vuejs.org/guide/mobile.html#hybrid-app-development
