### PR TITLE
chore: update migration installation instructions for Vite

### DIFF
--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -29,7 +29,7 @@ If you want to quickly try out Vue 3 in a new project:
 - Scaffold via [Vite](https://github.com/vitejs/vite):
 
   ```bash
-  npm init @vitejs/app hello-vue3 # OR yarn create @vitejs/app hello-vue3
+  npm init vite hello-vue3 -- --template vue # OR yarn create vite hello-vue3 --template vue
   ```
 
 - Scaffold via [vue-cli](https://cli.vuejs.org/):


### PR DESCRIPTION
`@vitejs/app` is now [deprecated](https://github.com/vitejs/vite/pull/4179). We should instruct users to use the new `create-vite` package instead.