### PR TITLE
chore: update installation instructions for Vite

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -97,7 +97,7 @@ Vue projects can quickly be set up with Vite by running the following commands i
 With npm:
 
 ```bash
-$ npm init @vitejs/app <project-name>
+$ npm init vite <project-name> -- --template vue
 $ cd <project-name>
 $ npm install
 $ npm run dev
@@ -106,7 +106,7 @@ $ npm run dev
 Or with Yarn:
 
 ```bash
-$ yarn create @vitejs/app <project-name>
+$ yarn create vite <project-name> --template vue
 $ cd <project-name>
 $ yarn
 $ yarn dev

--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -112,12 +112,6 @@ $ yarn
 $ yarn dev
 ```
 
-It might occur, that when your username has a space in it like 'Mike Baker', Vite cannot succeed. Have a try with
-
-```bash
-$ create-vite-app <project-name>
-```
-
 ## Explanation of Different Builds
 
 In the [`dist/` directory of the npm package](https://cdn.jsdelivr.net/npm/vue@3.0.2/dist/) you will find many different builds of Vue.js. Here is an overview of which `dist` file should be used depending on the use-case.


### PR DESCRIPTION
`@vitejs/app` is now [deprecated](https://github.com/vitejs/vite/pull/4179). We should instruct users to use the new `create-vite` package instead.

Also, I got rid of the mention of `create-vite-app` since that package is deprecated and says to use `create-vite` instead.