### PR TITLE
fix: typo 'kept-alive'

### DIFF
--- a/src/api/options-lifecycle-hooks.md
+++ b/src/api/options-lifecycle-hooks.md
@@ -102,7 +102,7 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
 - **Details:**
 
-  Called when a kept-alive component is activated.
+  Called when a keep-alive component is activated.
 
   **This hook is not called during server-side rendering.**
 
@@ -115,7 +115,7 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
 - **Details:**
 
-  Called when a kept-alive component is deactivated.
+  Called when a keep-alive component is deactivated.
 
   **This hook is not called during server-side rendering.**
 


### PR DESCRIPTION
## Description of Problem

From JP translation team.

This means the [keep-alive](https://v3.vuejs.org/api/built-in-components.html#keep-alive) component.
But, it seems to be spelled incorrectly.

## Proposed Solution

## Additional Information
