### PR TITLE
Avoid redirects by including .html on links

### DIFF
--- a/src/guide/conditional.md
+++ b/src/guide/conditional.md
@@ -93,4 +93,4 @@ Generally speaking, `v-if` has higher toggle costs while `v-show` has higher ini
 Using `v-if` and `v-for` together is **not recommended**. See the [style guide](../style-guide/#avoid-v-if-with-v-for-essential) for further information.
 :::
 
-When `v-if` and `v-for` are both used on the same element, `v-if` will be evaluated first. See the [list rendering guide](list#v-for-with-v-if) for details.
+When `v-if` and `v-for` are both used on the same element, `v-if` will be evaluated first. See the [list rendering guide](list.html#v-for-with-v-if) for details.

--- a/src/guide/transitions-list.md
+++ b/src/guide/transitions-list.md
@@ -8,7 +8,7 @@ So far, we've managed transitions for:
 So what about for when we have a whole list of items we want to render simultaneously, for example with `v-for`? In this case, we'll use the `<transition-group>` component. Before we dive into an example though, there are a few things that are important to know about this component:
 
 - By default, it doesn't render a wrapper element, but you can specify an element to be rendered with the `tag` attribute.
-- [Transition modes](/guide/transitions-enterleave#transition-modes) are not available, because we are no longer alternating between mutually exclusive elements.
+- [Transition modes](/guide/transitions-enterleave.html#transition-modes) are not available, because we are no longer alternating between mutually exclusive elements.
 - Elements inside are **always required** to have a unique `key` attribute.
 - CSS transition classes will be applied to inner elements and not to the group/container itself.
 


### PR DESCRIPTION
Links without a `.html` extension cause redirects, which strips off the `#` portion of the URL and prevents the page from scrolling to the correct section.

I've only updated the two links that have a `#` portion.