### PR TITLE
Link to the style guide entry for keyed v-for

### DIFF
--- a/src/guide/list.md
+++ b/src/guide/list.md
@@ -127,7 +127,7 @@ To give Vue a hint so that it can track each node's identity, and thus reuse and
 </div>
 ```
 
-It is recommended to provide a `key` attribute with `v-for` whenever possible, unless the iterated DOM content is simple, or you are intentionally relying on the default behavior for performance gains.
+[It is recommended](/style-guide/#keyed-v-for-essential) to provide a `key` attribute with `v-for` whenever possible, unless the iterated DOM content is simple, or you are intentionally relying on the default behavior for performance gains.
 
 Since it's a generic mechanism for Vue to identify nodes, the `key` also has other uses that are not specifically tied to `v-for`, as we will see later in the guide.
 


### PR DESCRIPTION
Inspired by #1161, this PR adds a link from the guide discussing using `key` with `v-for` to the relevant style guide entry.