### PR TITLE
fix: fixed content hiding behind the previous code snippet.

### DIFF
--- a/src/guide/component-props.md
+++ b/src/guide/component-props.md
@@ -206,6 +206,7 @@ app.component('my-component', {
 })
 ```
 
+\
 When prop validation fails, Vue will produce a console warning (if using the development build).
 
 ::: tip Note

--- a/src/guide/list.md
+++ b/src/guide/list.md
@@ -354,4 +354,6 @@ app.component('todo-item', {
 app.mount('#todo-list-example')
 ```
 
+\
+
 <common-codepen-snippet title="v-for with components" slug="abOaWpz" tab="js,result" :preview="false" />


### PR DESCRIPTION
## Description of Problem
Some of the Documentation contents are hiding behind the previous code snippet. I have mentioned two of them and fixed them.

## Proposed Solution
Added additional line breaker in markdown.

## Additional Information
### Screenshots
### Here contents  are hiding behind the code snippet
![Here contents  are hiding behind the code snippet](https://user-images.githubusercontent.com/35401388/129838837-9348c5bc-821f-4abe-81cb-5ecda8afcbac.png)
### Fixed
![Fixed](https://user-images.githubusercontent.com/35401388/129838889-33afbdf5-1e10-49b9-a33b-59392d5f95c0.png)
### Here codepen-snippet  hiding behind the code snippet
![Here codepen-snippet  hiding behind the code snippet](https://user-images.githubusercontent.com/35401388/129839030-fbc17bed-0f4d-4193-8c6b-20563e9f93c0.png)
### Fixed
![Fixed](https://user-images.githubusercontent.com/35401388/129839187-28eab15b-5bc9-455d-a2f4-4ac13facc357.png)


