### PR TITLE
Update reactivity-computed-watchers.md

### DIFF
--- a/src/guide/reactivity-computed-watchers.md
+++ b/src/guide/reactivity-computed-watchers.md
@@ -125,7 +125,7 @@ An async function implicitly returns a Promise, but the cleanup function needs t
 
 ### Effect Flush Timing
 
-Vue's reactivity system buffers invalidated effects and flushes them asynchronously to avoid unnecessary duplicate invocation when there are many state mutations happening in the same "tick". Internally, a component's `update` function is also a watched effect. When a user effect is queued, it is by default invoked **before** all component `update` effects:
+Vue's reactivity system buffers all effects and flushes them asynchronously to avoid unnecessary duplicate invocation when there are many state mutations happening in the same "tick". Internally, a component's `update` function is also a watched effect. When a user effect is queued, it is by default invoked **before** all component `update` effects:
 
 ```vue
 <template>


### PR DESCRIPTION
## Description of Problem
Vue's reactivity system buffers  not only invalidated effects but also validated effects.

## Proposed Solution
Change buffers  `invalidated`  effects  to buffers  `all` effects  

## Additional Information
In my opnion ,effects can be called invalidated when
[REF](https://v3.vuejs.org/guide/reactivity-computed-watchers.html#side-effect-invalidation)

> the effect is about to re-run
the watcher is stopped (i.e. when the component is unmounted if watchEffect is used inside setup() or lifecycle hooks)

Before that it's still validated one.

I think it's similar to vue2 [Async Update Queue](https://v3.vuejs.org/guide/change-detection.html#async-update-queue) which decribe by:

>Whenever a data change is observed, it will open a queue and buffer all the data changes that happen in the same event loop.

