### PR TITLE
fix: missing comma in web-components.md

### DIFF
--- a/src/guide/web-components.md
+++ b/src/guide/web-components.md
@@ -44,7 +44,7 @@ module.exports = {
       .rule('vue')
       .use('vue-loader')
       .tap(options => ({
-        ...options
+        ...options,
         compilerOptions: {
           // treat any tag that starts with ion- as custom elements
           isCustomElement: tag => tag.startsWith('ion-')


### PR DESCRIPTION
Using the Example Vue CLI Config throws an error because a comma is missing. This PR will fix it.