### PR TITLE
Script Setup Edits for Clarity

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -133,7 +133,7 @@ import * as Form from './form-components'
 
 ## `defineProps` and `defineEmits`
 
-To declare options like `props` and `emits` with full type inference support, you can use the `defineProps` and `defineEmits` APIs, which are automatically available inside `<script setup>`:
+To declare `props` and `emits` in `<script setup>`, you must use the `defineProps` and `defineEmits` APIs, which provide full type inference support and are automatically available inside `<script setup>`:
 
 ```vue
 <script setup>
@@ -148,7 +148,7 @@ const emit = defineEmits(['change', 'delete'])
 
 - `defineProps` and `defineEmits` are **compiler macros** only usable inside `<script setup>`. They do not need to be imported, and are compiled away when `<script setup>` is processed.
 
-- `defineProps` accepts the same value as the `props` option, while `defineEmits` accepts the same value as the `emits` option.
+- `defineProps` accepts the same value as the [`props` option](https://v3.vuejs.org/api/options-data.html#props), while `defineEmits` accepts the same value as the [`emits` option](https://v3.vuejs.org/api/options-data.html#emits).
 
 - `defineProps` and `defineEmits` provide proper type inference based on the options passed.
 

--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -89,7 +89,7 @@ Think of `MyComponent` as being referenced as a variable. If you have used JSX, 
 
 ### Dynamic Components
 
-Since components are referenced as variables instead of registered under string keys, we should use dynamic `:is` binding when using dynamic components inside `<script setup>`:
+Since components are referenced as variables instead of registered under string keys, you should use dynamic `:is` binding when using dynamic components inside `<script setup>`:
 
 ```vue
 <script setup>
@@ -133,7 +133,7 @@ import * as Form from './form-components'
 
 ## `defineProps` and `defineEmits`
 
-To declare options like `props` and `emits` with full type inference support, we can use the `defineProps` and `defineEmits` APIs, which are automatically available inside `<script setup>`:
+To declare options like `props` and `emits` with full type inference support, you can use the `defineProps` and `defineEmits` APIs, which are automatically available inside `<script setup>`:
 
 ```vue
 <script setup>
@@ -195,7 +195,7 @@ const attrs = useAttrs()
 
 ## Usage alongside normal `<script>`
 
-`<script setup>` can be used alongside normal `<script>`. A normal `<script>` may be needed in cases where we need to:
+`<script setup>` can be used alongside normal `<script>`. A normal `<script>` may be needed in cases where you need to:
 
 - Declare options that cannot be expressed in `<script setup>`, for example `inheritAttrs` or custom options enabled via plugins.
 - Declaring named exports.

--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -148,7 +148,7 @@ const emit = defineEmits(['change', 'delete'])
 
 - `defineProps` and `defineEmits` are **compiler macros** only usable inside `<script setup>`. They do not need to be imported, and are compiled away when `<script setup>` is processed.
 
-- `defineProps` accepts the same value as the [`props` option](https://v3.vuejs.org/api/options-data.html#props), while `defineEmits` accepts the same value as the [`emits` option](https://v3.vuejs.org/api/options-data.html#emits).
+- `defineProps` accepts the same value as the [`props` option](/api/options-data.html#props), while `defineEmits` accepts the same value as the [`emits` option](/api/options-data.html#emits).
 
 - `defineProps` and `defineEmits` provide proper type inference based on the options passed.
 


### PR DESCRIPTION
## Description of Problem
The `<script setup>` documentation sometimes used `we` and sometimes used `you`.
The `<script setup>` documentation was unclear about whether `defineProps` was the _only_ way to define props in `<script setup>`; it referred to the "props option," making it ambiguous about whether that option would still be in use.

## Proposed Solution
Edits for clarity below.
## Additional Information
