### PR TITLE
docs: Add additional statement in synchronously behavior  on initial run 

### DIFF
--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -181,11 +181,11 @@
 
   The default value is `'pre'`, which specifies that the callback should be invoked before rendering. This allows the callback to update other values before the template runs.
 
-  The value `'post'` can be used to defer the callback until after rendering. This should be used if the callback needs access to the updated DOM or child components via `$refs`.
+  The value `'post'` can be used to defer the callback until after rendering. This should be used if the callback needs access to the updated DOM or child components via `$refs`.Except it contain option with `immediate: true` , there will be a result logged before rendering on initial run.
 
   If `flush` is set to `'sync'`, the callback will be called synchronously, as soon as the value changes.
 
-  For both `'pre'` and `'post'`, the callback is buffered using a queue. The callback will only be added to the queue once, even if the watched value changes multiple times. The interim values will be skipped and won't be passed to the callback.
+  For both `'pre'` and `'post'`, the callback is buffered using a queue. The callback will only be added to the queue once, even if the watched value changes multiple times. The interim values will be skipped and won't be passed to the callback.It should be noted that if during the initial run with default `'pre'` option, the callback will not buffered but called synchronously.
 
   Buffering the callback not only improves performance but also helps to ensure data consistency. The watchers won't be triggered until the code performing the data updates has finished.
 


### PR DESCRIPTION
## Description of Problem

The synchronously behavior wiht 'flush'option on initial run is not fully stated.

## Proposed Solution

Add description about synchronously behavior of 'flush' on initial run.

Add the description of what will happen when add `post` & `immediate` both in the same watcher.

## Additional Information

When i learn from the docs ,The `flush` & `immediate` its hard to understand for beginner like me.Therefore i do some test in my computer.Something Strange happen made me confuse more:if i do multiple state mutation in setup function.the initial run will not show asynchronously behavior but synchronously behavior. 

In that case i look into the source code and i find 

> REF:vue-next\packages\runtime-core\src\apiWatch.ts   row 340 => row 387

```js
  let scheduler: EffectScheduler
  if (flush === 'sync') {
    scheduler = job as any // the scheduler function gets called directly
  } else if (flush === 'post') {
    scheduler = () => queuePostRenderEffect(job, instance && instance.suspense)
  } else {
    // default: 'pre'
    scheduler = () => {
      if (!instance || instance.isMounted) {
        queuePreFlushCb(job)
      } else {
        // with 'pre' option, the first call must happen before
        // the component is mounted so it is called synchronously.
        job()
      }
    }
  }
```
Although we can find something description like this in [effect-flush-timing](https://v3.vuejs.org/guide/reactivity-computed-watchers.html#effect-flush-timing)

>Vue's reactivity system buffers invalidated effects and flushes them asynchronously to avoid unnecessary duplicate invocation when there are many state mutations happening in the same "tick". Internally, a component's update function is also a watched effect. When a user effect is queued, it is by default invoked before all component update effects:

```vue
<template>
  <div>{{ count }}</div>
</template>

<script>
export default {
  setup() {
    const count = ref(0)

    watchEffect(() => {
      console.log(count.value)
    })

    return {
      count
    }
  }
}
</script>
```



>In this example:

>- The count will be logged synchronously on initial run.
>- When `count` is mutated, the callback will be called **before** the component has updated.

But I think it's kind of ambigue  that timing of asynchronously flush,and will misleading beginner to think  it's asynchronously flush at any point if without 'sync' option.but option with 'pre' also synchronously flush.

Even if that's an fully stated in [effect-flush-timing](https://v3.vuejs.org/guide/reactivity-computed-watchers.html#effect-flush-timing),I think it's still necessary for this additional statement.
