### PR TITLE
Change `property` to `attribute`

### DIFF
--- a/src/guide/migration/v-bind.md
+++ b/src/guide/migration/v-bind.md
@@ -12,11 +12,11 @@ badges:
 
 ## Introduction
 
-When dynamically binding attributes on an element, a common scenario involves using both the `v-bind="object"` syntax as well as individual properties in the same element. However, this raises questions as far as the priority of merging.
+When dynamically binding attributes on an element, a common scenario involves using both the `v-bind="object"` syntax as well as individual attributes in the same element. However, this raises questions as far as the priority of merging.
 
 ## 2.x Syntax
 
-In 2.x, if an element has both `v-bind="object"` and an identical individual property defined, the individual property would always overwrite bindings in the `object`.
+In 2.x, if an element has both `v-bind="object"` and an identical individual attribute defined, the individual attribute would always overwrite bindings in the `object`.
 
 ```html
 <!-- template -->
@@ -27,7 +27,7 @@ In 2.x, if an element has both `v-bind="object"` and an identical individual pro
 
 ## 3.x Syntax
 
-In 3x, if an element has both `v-bind="object"` and an identical individual property defined, the order of how the bindings are declared determines how they are merged. In other words, rather than assuming developers want the individual property to always override what is defined in the `object`, developers now have more control over the desired merging behavior.
+In 3x, if an element has both `v-bind="object"` and an identical individual attribute defined, the order of how the bindings are declared determines how they are merged. In other words, rather than assuming developers want the individual attribute to always override what is defined in the `object`, developers now have more control over the desired merging behavior.
 
 ```html
 <!-- template -->
@@ -43,6 +43,6 @@ In 3x, if an element has both `v-bind="object"` and an identical individual prop
 
 ## Migration Strategy
 
-If you are relying on this override functionality for `v-bind`, we currently recommend ensuring that your `v-bind` attribute is defined before individual properties.
+If you are relying on this override functionality for `v-bind`, we currently recommend ensuring that your `v-bind` attribute is defined before individual attributes.
 
 [Migration build flag: `COMPILER_V_BIND_OBJECT_ORDER`](migration-build.html#compat-configuration)


### PR DESCRIPTION
## Description of Problem
It's'  `attribute`  rather than `property` .
## Proposed Solution
Change `property` to `attribute`
## Additional Information
This correction will make the docs more precise and easier to understand

I try attribute with 'foo', the result is just like the expect.