### PR TITLE
fix: double dashes in command with vite

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -97,7 +97,6 @@ Vue projects can quickly be set up with Vite by running the following commands i
 With npm:
 
 ```bash
-
 # npm 6.x
 $ npm init vite@latest <project-name> --template vue
 

--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -97,7 +97,7 @@ Vue projects can quickly be set up with Vite by running the following commands i
 With npm:
 
 ```bash
-$ npm init vite <project-name> -- --template vue
+$ npm init vite <project-name> --template vue
 $ cd <project-name>
 $ npm install
 $ npm run dev

--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -97,7 +97,13 @@ Vue projects can quickly be set up with Vite by running the following commands i
 With npm:
 
 ```bash
-$ npm init vite <project-name> --template vue
+
+# npm 6.x
+$ npm init vite@latest <project-name> --template vue
+
+# npm 7+, extra double-dash is needed:
+$ npm init vite@latest <project-name> -- --template vue
+
 $ cd <project-name>
 $ npm install
 $ npm run dev


### PR DESCRIPTION
## Description of Problem

Double dashes in the scaffolding command with vite
```sh 
npm init vite <proj-name> -- --template vue
```

## Proposed Solution
```sh 
npm init vite <proj-name> --template vue
```

## Additional Information
