### PR TITLE
docs: Add some modifier on nextTick

### DIFF
--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -487,7 +487,7 @@ Accepts two arguments: `HostNode` and `HostElement`
 
 ## nextTick
 
-Defer the callback to be executed after the next DOM update cycle. Use it immediately after you’ve changed some data to wait for the DOM update.
+Defer the callback to be executed after the next DOM update cycle begin. Use it immediately after you’ve changed some data to wait for the DOM update.
 
 ```js
 import { createApp, nextTick } from 'vue'


### PR DESCRIPTION
## Description of Problem
The current description about execute timing poing of nextTick is kind of confusing for me.

I dont know whether it's after the next DOM update cycle **begined** or **finished** yet untill i try on my code.

Although it seems can be infer from the context

I think it's still worth to add some modifier to make it more easier to understand.




## Proposed Solution

Add  modifier  `begin`

## Additional Information
