### PR TITLE
fix: firefox mobile view fixed (Closes #1217)

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -296,6 +296,7 @@ module.exports = {
     ['link', { rel: 'manifest', href: '/manifest.json' }],
     ['meta', { name: 'theme-color', content: '#3eaf7c' }],
     ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
+    ['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1.0' }],
     [
       'meta',
       { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }


### PR DESCRIPTION
#  Closes #1217
added viewport meta tag in vitepress config

Signed-off-by: Anik Das <anikdas0811@gmail.com>

## Description of Problem
Vue docs in Firefox mobile isn't responsive
## Proposed Solution
```js
['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1.0' }],
```
to the vuepress config under head
