### PR TITLE
Create a new SSR router history for each router instance

### DIFF
--- a/src/guide/ssr/routing.md
+++ b/src/guide/ssr/routing.md
@@ -13,12 +13,15 @@ import MyUser from './components/MyUser.vue'
 
 const isServer = typeof window === 'undefined'
 
-const history = isServer ? createMemoryHistory() : createWebHistory()
+const createHistory = isServer ? createMemoryHistory : createWebHistory
 
 const routes = [{ path: '/user', component: MyUser }]
 
 export default function() {
-  return createRouter({ routes, history })
+  return createRouter({
+    history: createHistory(),
+    routes
+  })
 }
 ```
 


### PR DESCRIPTION
Closes #1219.

A memory history is stateful, so the server should create a new instance every time.

For reference, this is how the Vite SSR example is implemented:

https://github.com/vitejs/vite/blob/46ecda4df229e4cf3e9e364cb6271198f9fdfc40/packages/playground/ssr-vue/src/router.js