### PR TITLE
docs: Add a missing type `symbol` to the `key`

### DIFF
--- a/src/api/special-attributes.md
+++ b/src/api/special-attributes.md
@@ -2,7 +2,7 @@
 
 ## key
 
-- **Expects:** `number | string`
+- **Expects:** `number | string | symbol `
 
   The `key` special attribute is primarily used as a hint for Vue's virtual DOM algorithm to identify VNodes when diffing the new list of nodes against the old list. Without keys, Vue uses an algorithm that minimizes element movement and tries to patch/reuse elements of the same type in-place as much as possible. With keys, it will reorder elements based on the order change of keys, and elements with keys that are no longer present will always be removed/destroyed.
 


### PR DESCRIPTION
## Description of Problem




```js
export type VNodeProps = {
  key?: string | number | symbol
  ref?: VNodeRef

  // vnode hooks
  onVnodeBeforeMount?: VNodeMountHook | VNodeMountHook[]
  onVnodeMounted?: VNodeMountHook | VNodeMountHook[]
  onVnodeBeforeUpdate?: VNodeUpdateHook | VNodeUpdateHook[]
  onVnodeUpdated?: VNodeUpdateHook | VNodeUpdateHook[]
  onVnodeBeforeUnmount?: VNodeMountHook | VNodeMountHook[]
  onVnodeUnmounted?: VNodeMountHook | VNodeMountHook[]
}
```


https://github.com/vuejs/vue-next/blob/v3.2.11/packages/runtime-core/src/vnode.ts#L92
## Proposed Solution

## Additional Information
