### PR TITLE
use kebab-case for event emission

### DIFF
--- a/src/guide/component-basics.md
+++ b/src/guide/component-basics.md
@@ -220,7 +220,7 @@ When we click on the button, we need to communicate to the parent that it should
 Then the child component can emit an event on itself by calling the built-in [**`$emit`** method](../api/instance-methods.html#emit), passing the name of the event:
 
 ```html
-<button @click="$emit('enlargeText')">
+<button @click="$emit('enlarge-text')">
   Enlarge text
 </button>
 ```
@@ -234,7 +234,7 @@ We can list emitted events in the component's `emits` option:
 ```js
 app.component('blog-post', {
   props: ['title'],
-  emits: ['enlargeText']
+  emits: ['enlarge-text']
 })
 ```
 
@@ -245,7 +245,7 @@ This will allow you to check all the events that a component emits and optionall
 It's sometimes useful to emit a specific value with an event. For example, we may want the `<blog-post>` component to be in charge of how much to enlarge the text by. In those cases, we can pass a second parameter to `$emit` to provide this value:
 
 ```html
-<button @click="$emit('enlargeText', 0.1)">
+<button @click="$emit('enlarge-text', 0.1)">
   Enlarge text
 </button>
 ```


### PR DESCRIPTION
## Description of Problem

So I am following through with the documentation, and I encountered the custom event emission section and realized that one part of the documentation uses camelCase and the other part use kebab-case. So I did some google search and [this](https://stackoverflow.com/questions/42441952/vue-js-custom-event-naming/50423976) SO article showed up.

Based on the information, the official recommendation ([link](https://vuejs.org/v2/guide/components-custom-events.html#Event-Names)) is to use kebab-case for the event name.

As a newcomer, this is quite mind-boggling since I think it's natural to expect the same variable name for both hands.

It's surprising that it still works for both camelCase and kebab-case when I tried it in the CODEPEN editor example in [this](https://v3.vuejs.org/guide/component-basics.html#base-example) article. But it would be a smoother learning experience for me if the events were indeed using the exact same name.

## Proposed Solution

camelCase to kebab-case

## Additional Information

I am new to Vue, so I don't know much about it yet.