### PR TITLE
Add the expose option and expose function

### DIFF
--- a/src/api/composition-api.md
+++ b/src/api/composition-api.md
@@ -41,6 +41,7 @@ A component option that is executed **before** the component is created, once th
     attrs: Data
     slots: Slots
     emit: (event: string, ...args: unknown[]) => void
+    expose: (exposed?: Record<string, any>) => void
   }
 
   function setup(props: Data, context: SetupContext): Data
@@ -89,8 +90,33 @@ A component option that is executed **before** the component is created, once th
     setup() {
       const readersNumber = ref(0)
       const book = reactive({ title: 'Vue 3 Guide' })
-      // Please note that we need to explicitly expose ref value here
+      // Please note that we need to explicitly use ref value here
       return () => h('div', [readersNumber.value, book.title])
+    }
+  }
+  ```
+
+  If you return a render function then you can't return any other properties. If you need to expose properties so that they can be accessed externally, e.g. via a `ref` in the parent, you can use `expose`:
+
+  ```js
+  // MyBook.vue
+
+  import { h } from 'vue'
+
+  export default {
+    setup(props, { expose }) {
+      const reset = () => {
+        // Some reset logic
+      }
+
+      // If you need to expose multiple properties they must all
+      // be included in the object passed to expose. expose can
+      // only be called once.
+      expose({
+        reset
+      })
+
+      return () => h('div')
     }
   }
   ```

--- a/src/api/options-composition.md
+++ b/src/api/options-composition.md
@@ -294,7 +294,7 @@ The `setup` function is a new component option. It serves as the entry point for
 
   The `props` object is immutable for userland code during development (will emit warning if user code attempts to mutate it).
 
-  The second argument provides a context object which exposes a selective list of properties that were previously exposed on `this`:
+  The second argument provides a context object which exposes various objects and functions that might be useful in `setup`:
 
   ```js
   const MyComponent = {
@@ -302,9 +302,12 @@ The `setup` function is a new component option. It serves as the entry point for
       context.attrs
       context.slots
       context.emit
+      context.expose
     }
   }
   ```
+
+  `attrs`, `slots`, and `emit` are equivalent to the instance properties [`$attrs`](/api/instance-properties.html#attrs), [`$slots`](/api/instance-properties.html#slots), and [`$emit`](/api/instance-methods.html#emit) respectively.
 
   `attrs` and `slots` are proxies to the corresponding values on the internal component instance. This ensures they always expose the latest values even after updates so that we can destructure them without worrying about accessing a stale reference:
 
@@ -315,6 +318,26 @@ The `setup` function is a new component option. It serves as the entry point for
       function onClick() {
         console.log(attrs.foo) // guaranteed to be the latest reference
       }
+    }
+  }
+  ```
+
+  `expose`, added in Vue 3.2, is a function that allows specific properties to be exposed via the public component instance. By default, the public instance retrieved using refs, `$parent`, or `$root` is equivalent to the internal instance used by the template. Calling `expose` will create a separate public instance with the properties specified:
+
+  ```js
+  const MyComponent = {
+    setup(props, { expose }) {
+      const count = ref(0)
+      const reset = () => count.value = 0
+      const increment = () => count.value++
+
+      // Only reset will be available externally, e.g. via $refs
+      expose({
+        reset
+      })
+
+      // Internally, the template has access to count and increment
+      return { count, increment }
     }
   }
   ```

--- a/src/api/options-data.md
+++ b/src/api/options-data.md
@@ -301,3 +301,39 @@
   :::
 
 * **See also:** [Attribute Inheritance](../guide/component-attrs.html#attribute-inheritance)
+
+## expose <Badge text="3.2+" />
+
+- **Type:** `Array<string>`
+
+- **Details:**
+
+  A list of properties to expose on the public component instance.
+
+  By default, the public instance accessed via [`$refs`](/api/instance-properties.html#refs), [`$parent`](/api/instance-properties.html#parent), or [`$root`](/api/instance-properties.html#root) is the same as the internal component instance that's used by the template. The `expose` option restricts the properties that can be accessed via the public instance.
+
+  Properties defined by Vue itself, such as `$el` and `$parent`, will always be available on the public instance and don't need to be listed.
+
+- **Usage:**
+
+  ```js
+  export default {
+    // increment will be exposed but count
+    // will only be accessible internally
+    expose: ['increment'],
+
+    data() {
+      return {
+        count: 0
+      }
+    },
+
+    methods: {
+      increment() {
+        this.count++
+      }
+    }
+  }
+  ```
+
+- **See also:** [defineExpose](/api/sfc-script-setup.html#defineexpose)

--- a/src/style-guide/README.md
+++ b/src/style-guide/README.md
@@ -1284,6 +1284,7 @@ This is the default order we recommend for component options. They're split into
     - `inheritAttrs`
     - `props`
     - `emits`
+    - `expose`
 
 6. **Composition API** (the entry point for using the Composition API)
     - `setup`


### PR DESCRIPTION
Vue 3.2 introduced `defineExpose`, the `expose` option, and the `expose` function in the `setup` context object. While `defineExpose` is documented, the other two are not. This PR adds some documentation for those two forms of `expose`.

RFC: https://github.com/vuejs/rfcs/blob/master/active-rfcs/0042-expose-api.md

While working on this I noticed that `mount` returns the internal instance, not the exposed instance. This made it trickier to create simple, complete examples. I'd have preferred the API example to use `const vm = Vue.createApp(...).mount(...)` to grab the public instance, but that doesn't work. Instead I've used examples that show how to use `expose` but without explicitly showing how to use the exposed properties. I've opened a PR to change this in `vue-next`: https://github.com/vuejs/vue-next/pull/4606. If that gets merged we could revisit those examples to make them a little clearer.