### PR TITLE
Add missing closing parenthesis to the Vue ESM builds' descriptions

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -138,7 +138,7 @@ Global builds are not [UMD](https://github.com/umdjs/umd) builds. They are built
 
 #### `vue(.runtime).esm-browser(.prod).js`:
 
-- For usage via native ES modules imports (in browser via `<script type="module">`.
+- For usage via native ES modules imports (in browser via `<script type="module">`).
 - Shares the same runtime compilation, dependency inlining and hard-coded prod/dev behavior with the global build.
 
 ### With a Bundler


### PR DESCRIPTION
## Description of Problem

Missing closing parenthesis in the description of Vue ESM builds.

## Proposed Solution

Add the closing parenthesis in the proper place.

## Additional Information

N/A.