### PR TITLE
Add missing notes about using SFC syntax

### DIFF
--- a/src/guide/composition-api-lifecycle-hooks.md
+++ b/src/guide/composition-api-lifecycle-hooks.md
@@ -1,5 +1,7 @@
 # Lifecycle Hooks
 
+> This section uses [single-file component](single-file-component.html) syntax for code examples
+
 > This guide assumes that you have already read the [Composition API Introduction](composition-api-introduction.html) and [Reactivity Fundamentals](reactivity-fundamentals.html). Read that first if you are new to Composition API.
 
 <VideoLesson href="https://www.vuemastery.com/courses/vue-3-essentials/lifecycle-hooks" title="Learn about how Lifecycle Hooks work with Vue Mastery">Watch a free video about Lifecycle Hooks on Vue Mastery</VideoLesson>

--- a/src/guide/composition-api-provide-inject.md
+++ b/src/guide/composition-api-provide-inject.md
@@ -1,5 +1,7 @@
 # Provide / Inject
 
+> This section uses [single-file component](single-file-component.html) syntax for code examples
+
 > This guide assumes that you have already read [Provide / Inject](component-provide-inject.html), [Composition API Introduction](composition-api-introduction.html), and [Reactivity Fundamentals](reactivity-fundamentals.html).
 
 We can use [provide / inject](component-provide-inject.html) with the Composition API as well. Both can only be called during [`setup()`](composition-api-setup.html) with a current active instance.

--- a/src/guide/reactivity-fundamentals.md
+++ b/src/guide/reactivity-fundamentals.md
@@ -1,5 +1,7 @@
 # Reactivity Fundamentals
 
+> This section uses [single-file component](single-file-component.html) syntax for code examples
+
 ## Declaring Reactive State
 
 To create a reactive state from a JavaScript object, we can use a `reactive` method:


### PR DESCRIPTION
The antagonist of #1281.

## Description of Problem
Not all pages that use SFC syntax mention this, which can cause confusion.

## Proposed Solution
Copy the info note on the [Composition API - Setup](https://v3.vuejs.org/guide/composition-api-setup.html) page to all pages that use SFC syntax without mentioning it.