### PR TITLE
add important clarification to <template>

### DIFF
--- a/src/api/sfc-spec.md
+++ b/src/api/sfc-spec.md
@@ -34,7 +34,7 @@ export default {
 
 ### `<template>`
 
-- Each `*.vue` file can contain at most one `<template>` block at a time.
+- Each `*.vue` file can contain at most one top-level `<template>` block at a time.
 
 - Contents will be extracted and passed on to `@vue/compiler-dom`, pre-compiled into JavaScript render functions, and attached to the exported component as its `render` option.
 


### PR DESCRIPTION
## Description of Problem
`<template>` is used as a wrapper for [conditional rendering](https://v3.vuejs.org/guide/conditional.html#conditional-groups-with-v-if-on-template) of multiple elements, and as such **is** allowed to exist multiple times within a component, even a single-file one, but the top-level `<template>` tag must be only one.

## Proposed Solution
By specifying that the constraint applies only to top-level instances of `<template>`, the ambiguity or possible confusion with the other use of the tag is avoided. Better alternatives to "top-level" could exist, but it's the most unambiguous term I could think of.