### PR TITLE
Update description about .number modifier

### DIFF
--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -272,7 +272,7 @@ If you want user input to be automatically typecast as a number, you can add the
 <input v-model.number="age" type="text" />
 ```
 
-This is often useful when the input type is `text`. if the input type is `number`, Vue can automatically convert the raw string value to a number, and you don't need to add the `.number` modifier. If the value cannot be parsed with `parseFloat()`, then the original value is returned.
+This is often useful when the input type is `text`. If the input type is `number`, Vue can automatically convert the raw string value to a number, and you don't need to add the `.number` modifier to `v-model`. If the value cannot be parsed with `parseFloat()`, then the original value is returned.
 
 ### `.trim`
 

--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -269,10 +269,10 @@ By default, `v-model` syncs the input with the data after each `input` event (wi
 If you want user input to be automatically typecast as a number, you can add the `number` modifier to your `v-model` managed inputs:
 
 ```html
-<input v-model.number="age" type="number" />
+<input v-model.number="age" type="text" />
 ```
 
-This is often useful, because even with `type="number"`, the value of HTML input elements always returns a string. If the value cannot be parsed with `parseFloat()`, then the original value is returned.
+This is often useful when the input type is `text`. if the input type is `number`, Vue can automatically convert the raw string value to a number, and you don't need to add the `.number` modifier. If the value cannot be parsed with `parseFloat()`, then the original value is returned.
 
 ### `.trim`
 


### PR DESCRIPTION
## Description of Problem
It seems Vue 3 can automatically convert a string value to a number from a number input, i.e. `<input type="number"`：

Vue Source Code：
```javascript
const castToNumber = number || (vnode.props && vnode.props.type === 'number');
```

The documentation about `.number` modifier does not reflect this.

## Proposed Solution

I made some changes to the docs, to make it clearer about this situation. 

## Additional Information
No.