### PR TITLE
Update Introduction example to use `components` instead of `.component()`

### DIFF
--- a/src/guide/introduction.md
+++ b/src/guide/introduction.md
@@ -223,7 +223,6 @@ The component system is another important concept in Vue, because it's an abstra
 In Vue, a component is essentially an instance with pre-defined options. Registering a component in Vue is straightforward: we create a component object as we did with `App` objects and we define it in parent's `components` option:
 
 ```js
-// Import the child component
 const TodoItem = {
   template: `<li>This is a todo</li>`
 }


### PR DESCRIPTION
Fixes for #1274.