### PR TITLE
Adding Components.studio and WebComponents.dev...

### DIFF
--- a/src/api/sfc-tooling.md
+++ b/src/api/sfc-tooling.md
@@ -10,6 +10,8 @@ You don't need to install anything on your machine to try out Vue SFCs - there a
 - [Vue on Repl.it](https://replit.com/@templates/VueJS-with-Vite)
 - [Vue on Codepen](https://codepen.io/pen/editor/vue)
 - [Vue on StackBlitz](https://stackblitz.com/fork/vue)
+- [Vue on Components.studio](https://components.studio/create/vue3)
+- [Vue on WebComponents.dev](https://webcomponents.dev/create/cevue)
 
 It is also recommended to use these online playgrounds to provide reproductions when reporting bugs.
 


### PR DESCRIPTION
... in list of Online Playgrounds.

## Description of Problem

No problem :) Just adding content.

## Proposed Solution

- [Vue on Components.studio](https://components.studio/create/vue3)
- [Vue on WebComponents.dev](https://webcomponents.dev/create/cevue)

## Additional Information

Components.studio supports standard Vue SFC component 
while WebComponents.dev supports Web Components wrapper via the `.ce.vue` as defined by Vue.
