### PR TITLE
Use createSSRApp instead of createApp

### DIFF
--- a/src/guide/ssr/routing.md
+++ b/src/guide/ssr/routing.md
@@ -25,14 +25,14 @@ And update our client and server entries:
 
 ```js
 // entry-client.js
-import { createApp } from 'vue'
+import { createSSRApp } from 'vue'
 import { createWebHistory } from 'vue-router'
 import createRouter from './router.js'
 import App from './App.vue'
 
 // ...
 
-const app = createApp(App)
+const app = createSSRApp(App)
 
 const router = createRouter(createWebHistory())
 
@@ -50,7 +50,7 @@ import createRouter from './router.js'
 import App from './App.vue'
 
 export default function () {
-  const app = createSSRApp(Vue)
+  const app = createSSRApp(App)
   const router = createRouter(createMemoryHistory())
 
   app.use(router)
@@ -79,16 +79,16 @@ const routes = [
 ]
 ```
 
-On both client and server we need to wait for the router to resolve async route components ahead of time in order to properly invoke in-component hooks. For this we will be using [router.isReady](https://next.router.vuejs.org/api/#isready) method Let's update our client entry:
+On both client and server we need to wait for the router to resolve async route components ahead of time in order to properly invoke in-component hooks. For this we will be using the [router.isReady](https://next.router.vuejs.org/api/#isready) method. Let's update our client entry:
 
 ```js
 // entry-client.js
-import { createApp } from 'vue'
+import { createSSRApp } from 'vue'
 import { createWebHistory } from 'vue-router'
 import createRouter from './router.js'
 import App from './App.vue'
 
-const app = createApp(App)
+const app = createSSRApp(App)
 
 const router = createRouter(createWebHistory())
 


### PR DESCRIPTION
I believe `entry-client.js` should be using `createSSRApp` instead of `createApp`. Both will work, but `createApp` will create an entirely new DOM in the browser, whereas `createSSRApp` will hydrate the existing DOM.

I've also made a few other minor corrections. I think they're self-explanatory but let me know if not.