### PR TITLE
typo clarity

### DIFF
--- a/src/guide/component-basics.md
+++ b/src/guide/component-basics.md
@@ -97,7 +97,7 @@ app.component('blog-post', {
 app.mount('#blog-post-demo')
 ```
 
-When a value is passed to a prop attribute, it becomes a property on that component instance. The value of that property is accessible within the template, just like any other component property.
+When a value is passed to a prop option, it becomes a property on that component instance. The value of that property is accessible within the template, just like any other component property.
 
 A component can have as many props as you like and, by default, any value can be passed to any prop.
 


### PR DESCRIPTION
## Description of Problem
I was bit confused with the wording `prop attribute` as i thought it means a custom html attribute on the custom component. Later i realised that it literally is a `prop` key on the _options api_. 

## Proposed Solution
Improved the typo by replacing `attribute` with the word `key`. Hope that would clarify ?!

## Additional Information
Btw let me know if it is otherwise :)