### PR TITLE
Correct a common misconception regarding argument passing

### DIFF
--- a/src/guide/composition-api-introduction.md
+++ b/src/guide/composition-api-introduction.md
@@ -157,9 +157,7 @@ counter.value++
 console.log(counter.value) // 1
 ```
 
-Wrapping values inside an object might seem unnecessary but is required to keep the behavior unified across different data types in JavaScript. That’s because in JavaScript, primitive types like `Number` or `String` are passed by value, not by reference:
-
-![Pass by reference vs pass by value](https://blog.penjee.com/wp-content/uploads/2015/02/pass-by-reference-vs-pass-by-value-animation.gif)
+Wrapping values inside an object might seem unnecessary but is required to keep the behavior unified across different data types in JavaScript. That’s because in JavaScript, primitive types like `Number` or `String` are accessed differently from reference types like `Object` or `Array`.
 
 Having a wrapper object around any value allows us to safely pass it across our whole app without worrying about losing its reactivity somewhere along the way.
 


### PR DESCRIPTION
JavaScript is always pass-by-value. The difference is that with reference types the *value of the reference* is passed (but never the reference itself). If JavaScript were pass-by-reference, the following JSFiddle would have logged `2` instead of `1`: https://jsfiddle.net/zryav4fx/

For more information:
  - https://stackoverflow.com/a/7744623
  - https://stackoverflow.com/a/5314911
  - https://stackoverflow.com/a/430958