### PR TITLE
fix: Explain usage of custom directives with script-setup

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -131,6 +131,31 @@ import * as Form from './form-components'
 </template>
 ```
 
+## Using Custom Directives
+
+Globally registered custom directives just work as expected, and local ones can be used directly in the template, much like we explained above for components. 
+
+But there's one restriction to be aware of: You must name local custom directives according to the following schema: `vNameOfDirective` in order for them to be directly usable in the template.
+
+```html
+<script setup>
+const vMyDirective = {
+  beforeMount: (el) => {
+    // do someting with the element
+  }
+}
+</script>
+<template>
+  <h1 v-my-directive>This is a Heading</h1>
+</template>
+```
+```html
+<script setup>
+  // imports also work, and can be renamed to fit the requires naming schema
+  import { myDirective as vMyDirective } from './MyDirective.js'
+</script>
+```
+
 ## `defineProps` and `defineEmits`
 
 To declare `props` and `emits` in `<script setup>`, you must use the `defineProps` and `defineEmits` APIs, which provide full type inference support and are automatically available inside `<script setup>`:

--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -151,7 +151,7 @@ const vMyDirective = {
 ```
 ```html
 <script setup>
-  // imports also work, and can be renamed to fit the requires naming schema
+  // imports also work, and can be renamed to fit the required naming schema
   import { myDirective as vMyDirective } from './MyDirective.js'
 </script>
 ```

--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -141,7 +141,7 @@ But there's one restriction to be aware of: You must name local custom directive
 <script setup>
 const vMyDirective = {
   beforeMount: (el) => {
-    // do someting with the element
+    // do something with the element
   }
 }
 </script>


### PR DESCRIPTION
## Description of Problem

In the docs for `<script setup>`, we explain how to use components directly in the template without registering them, but we don't do the same for custom directives.

## Proposed Solution

add a small section to the `<script setup>` docs after the component explanations.

## Additional Information
