### PR TITLE
Using a real html tag name instead of unknown `custom1` component in sfc api

### DIFF
--- a/src/api/sfc-spec.md
+++ b/src/api/sfc-spec.md
@@ -25,9 +25,9 @@ export default {
 }
 </style>
 
-<custom1>
+<p class="doc">
   This could be e.g. documentation for the component.
-</custom1>
+</p>
 ```
 
 ## Language Blocks


### PR DESCRIPTION
## Description of Problem
Custom1 is not defined so you should make a one(the example will be so long) or using a real tag name like p
