### PR TITLE
More detailed example in special-attributes.md

### DIFF
--- a/src/api/special-attributes.md
+++ b/src/api/special-attributes.md
@@ -12,7 +12,7 @@
 
   ```html
   <ul>
-    <li v-for="item in items" :key="item.id">...</li>
+    <li v-for="(item , index) in items" :key="index">item</li>
   </ul>
   ```
 


### PR DESCRIPTION
The item.id is not defined in the code so I think the index in the v-for is better. Also `...` in the li isn't very detailed 
