### PR TITLE
Fix Black Friday banner close button

### DIFF
--- a/src/.vuepress/theme/components/BannerTop.vue
+++ b/src/.vuepress/theme/components/BannerTop.vue
@@ -17,7 +17,7 @@
         Get Discount
       </div>
     </div>
-    <div id="vs-close" class="vs-close">
+    <div id="vs-close" class="vs-close" @click.stop.prevent="$emit('close')">
       <img src="/images/vueschool/vueschool_close.svg" alt="Close">
     </div>
   </a>


### PR DESCRIPTION
This PR fixes the following issue: [1332](https://github.com/vuejs/docs/issues/1332), introduced in [this commit](https://github.com/vuejs/docs/pull/1330).

Before: when the "X" to close the banner was clicked the banner didn't close.

Now: when the "X" is clicked, the banner closes as expected.


