### PR TITLE
use camelCase

### DIFF
--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -4,7 +4,7 @@
 
 ## Event Names
 
-Like components and props, event names provide an automatic case transformation. If you emit an event from the child component in camel case, you will be able to add a kebab-cased listener in the parent:
+Like components and props, event names provide an automatic case transformation. If you emit an event from the child component in camelCase, you will be able to add a kebab-cased listener in the parent:
 
 ```js
 this.$emit('myEvent')

--- a/src/guide/migration/vnode-lifecycle-events.md
+++ b/src/guide/migration/vnode-lifecycle-events.md
@@ -31,7 +31,7 @@ In Vue 3, the event name is prefixed with `vnode-`:
 </template>
 ```
 
-Or just `vnode` if you're using camel case:
+Or just `vnode` if you're using camelCase:
 
 ```html
 <template>

--- a/src/guide/render-function.md
+++ b/src/guide/render-function.md
@@ -350,7 +350,7 @@ render() {
 
 #### Event Modifiers
 
-For the `.passive`, `.capture`, and `.once` event modifiers, they can be concatenated after the event name using camel case.
+For the `.passive`, `.capture`, and `.once` event modifiers, they can be concatenated after the event name using camelCase.
 
 For example:
 


### PR DESCRIPTION
## Description of Problem

`camelCase` should be better, and used lot more in other places of the document.