### PR TITLE
Computed property returns a number, not an object

### DIFF
--- a/src/guide/composition-api-introduction.md
+++ b/src/guide/composition-api-introduction.md
@@ -357,7 +357,7 @@ const twiceTheCounter = computed(() => counter.value * 2)
 
 counter.value++
 console.log(counter.value) // 1
-console.log(twiceTheCounter.value) // 2
+console.log(twiceTheCounter) // 2
 ```
 
 Here, the `computed` function returns a _read-only_ **Reactive Reference** to the output of the getter-like callback passed as the first argument to `computed`. In order to access the **value** of the newly-created computed variable, we need to use the `.value` property just like with `ref`.


### PR DESCRIPTION
## Description of Problem
When defining the `twiceTheCounter` computed property, the associated function returns a number instead of an object.

## Proposed Solution
Adjusted the logging function to expect a number, not an object.

## Additional Information
