### PR TITLE
docs(installation): link to cli.vuejs.org and vitejs.dev

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -68,7 +68,7 @@ In most cases, the preferred way to create a webpack build with minimal configur
 
 ## CLI
 
-Vue provides an [official CLI](https://github.com/vuejs/vue-cli) for quickly scaffolding ambitious Single Page Applications. It provides batteries-included build setups for a modern frontend workflow. It takes only a few minutes to get up and running with hot-reload, lint-on-save, and production-ready builds. See [the Vue CLI docs](https://cli.vuejs.org) for more details.
+Vue provides an [official CLI](https://cli.vuejs.org/) for quickly scaffolding ambitious Single Page Applications. It provides batteries-included build setups for a modern frontend workflow. It takes only a few minutes to get up and running with hot-reload, lint-on-save, and production-ready builds.
 
 ::: tip
 The CLI assumes prior knowledge of Node.js and the associated build tools. If you are new to Vue or front-end build tools, we strongly suggest going through [the guide](./introduction.html) without any build tools before using the CLI.
@@ -90,7 +90,7 @@ vue upgrade --next
 
 ## Vite
 
-[Vite](https://github.com/vitejs/vite) is a web development build tool that allows for lightning fast serving of code due to its native ES Module import approach.
+[Vite](https://vitejs.dev/) is a web development build tool that allows for lightning fast serving of code due to its native ES Module import approach.
 
 Vue projects can quickly be set up with Vite by running the following commands in your terminal.
 


### PR DESCRIPTION
Rationale: newcomers prefer official documentation over GitHub project
