### PR TITLE
Update sfc-script-setup.md

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -243,6 +243,10 @@ export default {
 </script>
 ```
 
+:::warning
+`render` function is not supported in this scenario. Please use one normal `<script>` with `setup` option instead.
+:::
+
 ## Top-level `await`
 
 Top-level `await` can be used inside `<script setup>`. The resulting code will be compiled as `async setup()`:


### PR DESCRIPTION
## Description of Problem

The document has not covered how to use `script setup` with render functions, it ends up with no way to do so (for now).

see https://github.com/vuejs/vue-next/issues/4980

