### PR TITLE
better example for kebab-case vs camelCase

### DIFF
--- a/src/guide/component-props.md
+++ b/src/guide/component-props.md
@@ -254,7 +254,14 @@ to validate that the value of the `author` prop was created with `new Person`.
 HTML attribute names are case-insensitive, so browsers will interpret any uppercase characters as lowercase. That means when you're using in-DOM templates, camelCased prop names need to use their kebab-cased (hyphen-delimited) equivalents:
 
 ```js
-const app = Vue.createApp({})
+const app = Vue.createApp({
+  template: `
+    <div>
+      <h1>Using camelCase</h1>
+      <blog-post postTitle="hello!"></blog-post>
+    </div>
+  `
+})
 
 app.component('blog-post', {
   // camelCase in JavaScript


### PR DESCRIPTION
The whole point of camelCase vs kebab-case when talking about props is when kebab-case is required in DOM templates rather than Vue's instance template property, that's why I think using an example where the attribute is using camelCase is the right thing to do for this explanation.

## Description of Problem

Example about camelCase vs kebab-case props is not good enough.

## Proposed Solution

I provided a better example.

## Additional Information

N/A
