### PR TITLE
[next] feat: add sponsor button to team members settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@vue/repl": "^0.4.3",
-    "@vue/theme": "^0.1.15",
+    "@vue/theme": "^0.1.16",
     "vue": "^3.2.23"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,14 +3,14 @@ lockfileVersion: 5.3
 specifiers:
   '@types/node': ^16.9.1
   '@vue/repl': ^0.4.3
-  '@vue/theme': ^0.1.15
+  '@vue/theme': ^0.1.16
   cheap-watch: ^1.0.3
   vitepress: ^0.20.1
   vue: ^3.2.23
 
 dependencies:
   '@vue/repl': 0.4.3_vue@3.2.23
-  '@vue/theme': 0.1.15_vue@3.2.23
+  '@vue/theme': 0.1.16_vue@3.2.23
   vue: 3.2.23
 
 devDependencies:
@@ -280,8 +280,8 @@ packages:
   /@vue/shared/3.2.23:
     resolution: {integrity: sha512-U+/Jefa0QfXUF2qVy9Dqlrb6HKJSr9/wJcM66wXmWcTOoqg7hOWzF4qruDle51pyF4x3wMn6TSH54UdjKjCKMA==}
 
-  /@vue/theme/0.1.15_vue@3.2.23:
-    resolution: {integrity: sha512-zWDZIGOh+HYTFieI+6miCjePRWYnCEc+EavVhNr5LMV7gFeyxocnAJPhf/p6JLGaKMayfhJIghcIqHv1bbSr2w==}
+  /@vue/theme/0.1.16_vue@3.2.23:
+    resolution: {integrity: sha512-Eyqlb8h9uZvgOtn8392DvHV+n8e1nDH5pLthRbTWfWUWe8+0wZaBk8jPpmfIZoYsrNv9FSnjc8YnemwXoMYJHw==}
     dependencies:
       '@docsearch/css': 3.0.0-alpha.41
       '@docsearch/js': 3.0.0-alpha.41

--- a/src/about/team/Member.ts
+++ b/src/about/team/Member.ts
@@ -9,6 +9,7 @@ export interface Member {
   languages: string[]
   website?: Link
   socials: Socials
+  sponsor?: string
 }
 
 export interface Link {

--- a/src/about/team/TeamMember.vue
+++ b/src/about/team/TeamMember.vue
@@ -5,6 +5,7 @@ import {
   VTIconCodePen,
   VTIconGitHub,
   VTIconGlobe,
+  VTIconHeart,
   VTIconLink,
   VTIconLinkedIn,
   VTIconMapPin,
@@ -24,6 +25,10 @@ const avatarUrl = computed(() => {
 
 <template>
   <article class="TeamMember">
+    <VTLink v-if="member.sponsor" class="sponsor" :href="member.sponsor" no-icon>
+      <VTIconHeart class="sponsor-icon" /> Sponsor
+    </VTLink>
+
     <figure class="avatar">
       <img class="avatar-img" :src="avatarUrl" :alt="`${member.name}'s Profile Picture`">
     </figure>
@@ -142,6 +147,7 @@ const avatarUrl = computed(() => {
 
 <style scoped>
 .TeamMember {
+  position: relative;
   background-color: var(--vt-c-bg-soft);
   transition: background-color 0.5s;
 }
@@ -156,6 +162,33 @@ const avatarUrl = computed(() => {
   .TeamMember {
     border-radius: 8px;
   }
+}
+
+.sponsor {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  align-items: center;
+  border: 1px solid #fd1d7c;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #fd1d7c;
+  transition: color 0.25s, background-color 0.25s;
+}
+
+.sponsor:hover {
+  color: var(--vt-c-white);
+  background-color: #fd1d7c;
+}
+
+.sponsor-icon {
+  margin-right: 6px;
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
 }
 
 .avatar {

--- a/src/about/team/members-core.json
+++ b/src/about/team/members-core.json
@@ -22,7 +22,8 @@
     "socials": {
       "github": "yyx990803",
       "twitter": "youyuxi"
-    }
+    },
+    "sponsor": "https://github.com/sponsors/yyx990803"
   },
   {
     "name": "Ben Hong",
@@ -478,7 +479,8 @@
     "socials": {
       "github": "kiaking",
       "twitter": "KiaKing85"
-    }
+    },
+    "sponsor": "https://github.com/sponsors/kiaking"
   },
   {
     "name": "Anthony Fu",


### PR DESCRIPTION
Add sponsor button to the team members.

Now we may add optional `sponsor` setting to team member JSON.

```json
[
  {
    "name": "Evan You",
    "title": "Creator",
    "company": "Vue.js",
    "sponsor": "https://github.com/sponsors/yyx990803"
    ...
  },
  ...
]
```

<img width="1007" alt="Screen Shot 2021-11-29 at 13 59 48" src="https://user-images.githubusercontent.com/3753672/143811677-32fab29d-e1d3-495d-b4d0-632da94acbda.png">

<img width="1013" alt="Screen Shot 2021-11-29 at 13 59 41" src="https://user-images.githubusercontent.com/3753672/143811683-f127b392-0efd-4e35-bd77-b5934126a292.png">


