### PR TITLE
Remove Vue School's Black Friday banner

### DIFF
--- a/src/.vuepress/theme/layouts/Layout.vue
+++ b/src/.vuepress/theme/layouts/Layout.vue
@@ -5,8 +5,6 @@
     @touchstart="onTouchStart"
     @touchend="onTouchEnd"
   >
-    <BannerTop v-if="showTopBanner" @close="closeBannerTop" />
-
     <Navbar v-if="shouldShowNavbar" @toggle-sidebar="toggleSidebar" />
 
     <div class="sidebar-mask" @click="toggleSidebar(false)" />
@@ -52,7 +50,6 @@ import Page from '@theme/components/Page.vue'
 import Sidebar from '@theme/components/Sidebar.vue'
 import BuySellAds from '@theme/components/BuySellAds.vue'
 import CarbonAds from '@theme/components/CarbonAds.vue'
-import BannerTop from '@theme/components/BannerTop.vue'
 import { resolveSidebarItems } from '../util'
 
 export default {
@@ -63,14 +60,12 @@ export default {
     Page,
     Sidebar,
     Navbar,
-    BannerTop,
     BuySellAds,
     CarbonAds
   },
 
   data() {
     return {
-      showTopBanner: false,
       isSidebarOpen: false
     }
   },
@@ -131,16 +126,9 @@ export default {
     this.$router.afterEach(() => {
       this.isSidebarOpen = false
     })
-
-    this.showTopBanner = !localStorage.getItem('VS_BF21_BANNER_CLOSED')
   },
 
   methods: {
-    closeBannerTop () {
-      this.showTopBanner = false
-      localStorage.setItem('VS_BF21_BANNER_CLOSED', 1)
-    },
-
     toggleSidebar(to) {
       this.isSidebarOpen = typeof to === 'boolean' ? to : !this.isSidebarOpen
       this.$emit('toggle-sidebar', this.isSidebarOpen)


### PR DESCRIPTION
This PR removes the Vue School Black Friday banner from the top of v3.vuejs.org.

Please merge this PR after **Dec 3th 21 PM (Central European Time)**

The landing page will keep working after the promo ends, so the link (https://vueschool.io/sales/blackfriday?friend=vuejs) will still be valid.

Related to [PR 1330](https://github.com/vuejs/docs/pull/1330)