### PR TITLE
Fixed Grammatical Errors in Community Theme Descriptions

### DIFF
--- a/src/.vuepress/components/community/themes/theme-data.js
+++ b/src/.vuepress/components/community/themes/theme-data.js
@@ -218,7 +218,7 @@ export default [
   },
   {
     name: 'Flatlogic',
-    description: `Check the admin dashboard templates built by our partners from [Flatlogic](https://flatlogic.com/templates?ref=x-fdkuTAVW). With these themes you can see how real applications are built. Additionally, these templates will help you to start a new application and save you time and money.`,
+    description: `Check out the admin dashboard templates built by our partners from [Flatlogic](https://flatlogic.com/templates?ref=x-fdkuTAVW). With these themes you can see how real applications are built. Additionally, these templates will help you to start a new application and save you time and money.`,
     seeMoreUrl: 'https://flatlogic.com/templates?ref=x-fdkuTAVW',
     products: [
       {

--- a/src/.vuepress/components/community/themes/theme-data.js
+++ b/src/.vuepress/components/community/themes/theme-data.js
@@ -127,7 +127,7 @@ export default [
   },
   {
     name: 'PrimeVue',
-    description: `The open-source UI component library [PrimeVue](https://www.primefaces.org/primevue/#/?af_id=4218) offers over 80 flexible components to build your apps with! They have a ton of different component themes and Vue-CLI application templates available to get the look&feel that suits you best.`,
+    description: `The open-source UI component library [PrimeVue](https://www.primefaces.org/primevue/#/?af_id=4218) offers over 80 flexible components to build your apps with! They have a ton of different component themes and Vue-CLI application templates available to get the look & feel that suits you best.`,
     seeMoreUrl: 'https://www.primefaces.org/primevue/#/?af_id=4218',
     products: [
       {
@@ -218,7 +218,7 @@ export default [
   },
   {
     name: 'Flatlogic',
-    description: `Check the admin dashboards templates built by our partners from [Flatlogic](https://flatlogic.com/templates?ref=x-fdkuTAVW). With these themes you can see how real applications is built. Additionally these templates will help you to start a new application and save you time and money.`,
+    description: `Check the admin dashboard templates built by our partners from [Flatlogic](https://flatlogic.com/templates?ref=x-fdkuTAVW). With these themes you can see how real applications are built. Additionally, these templates will help you to start a new application and save you time and money.`,
     seeMoreUrl: 'https://flatlogic.com/templates?ref=x-fdkuTAVW',
     products: [
       {


### PR DESCRIPTION
## Description of Problem
The descriptions of the community theme providers contained a few grammatical errors, namely:

**PrimeVue**
1. "look&feel" is incorrect since there should be spaces between the ampersand and the words.

**Flatlogic**
1. "Check the admin dashboards templates" does not use the conventional expression "check out". It also unnecessarily pluralises the word "dashboard."
2. "how real applications is built" has an inconsistency in that the noun "applications" is plural but the verb "is" is singular.
3. "Additionally these" should have a comma after the preposition "Additionally."

## Proposed Solution
**PrimeVue**
1. "look & feel"

**Flatlogic**
1. "Check out the admin dashboard templates"
2. "how real applications are built"
3. "Additionally, these"

## Additional Information
