### PR TITLE
fix(compat): add a note about Nuxt Bridge for Nuxt.js users

### DIFF
--- a/src/guide/migration/migration-build.md
+++ b/src/guide/migration/migration-build.md
@@ -20,7 +20,7 @@ While we've tried hard to make the migration build mimic Vue 2 behavior as much 
 
 - Internet Explorer 11 support: [Vue 3 has officially dropped the plan for IE11 support](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0038-vue3-ie11-support.md). If you still need to support IE11 or below, you will have to stay on Vue 2.
 
-- Server-side rendering: the migration build can be used for SSR, but migrating a custom SSR setup is much more involved. The general idea is replacing `vue-server-renderer` with [`@vue/server-renderer`](https://github.com/vuejs/vue-next/tree/master/packages/server-renderer). Vue 3 no longer provides a bundle renderer and it is recommended to use Vue 3 SSR with [Vite](https://vitejs.dev/guide/ssr.html). If you are using [Nuxt.js](https://nuxtjs.org/), it is probably better to wait for Nuxt 3.
+- Server-side rendering: the migration build can be used for SSR, but migrating a custom SSR setup is much more involved. The general idea is replacing `vue-server-renderer` with [`@vue/server-renderer`](https://github.com/vuejs/vue-next/tree/master/packages/server-renderer). Vue 3 no longer provides a bundle renderer and it is recommended to use Vue 3 SSR with [Vite](https://vitejs.dev/guide/ssr.html). If you are using [Nuxt.js](https://nuxtjs.org/), you can try [Nuxt Bridge, a Nuxt.js 2 to 3 compatibility layer](https://v3.nuxtjs.org/getting-started/bridge/). For complex, production projects, it is probably best to wait for [Nuxt 3 (currently in beta)](https://v3.nuxtjs.org/getting-started/introduction).
 
 ### Expectations
 


### PR DESCRIPTION
## Description of Problem
The current piece of advice for Nuxt.js users (https://v3.vuejs.org/guide/migration/migration-build.html#intended-use-cases) is currently: 
> Server-side rendering: [...] If you are using Nuxt.js, it is probably better to wait for Nuxt 3.

Nevertheless, Nuxt Bridge can be a great alternative, and a nice way to see how much of a codebase will have to be updated to run Nuxt 3.

There's also no link to Nuxt 3, and the fact that it is now in beta phase is not mentioned. I think it would be helpful to give more information about it right the docs.

## Proposed Solution

- Add information + link to Nuxt Bridge "Getting Started" guide  
- Add link to Nuxt.js 3 "Getting Started" guide + a note to inform readers that it is currently in beta.

## Additional Information
I guess someone should add a reminder to update the docs again when Nuxt.js 3 gets a first stable release - it seems overkill to get the version during Vue docs build. I'll try to remember doing this!