### PR TITLE
fix: remove `})` in example comment

### DIFF
--- a/src/examples/utils.ts
+++ b/src/examples/utils.ts
@@ -132,7 +132,7 @@ export function resolveNoBuildExample(
   const files: Record<string, string> = {}
 
   const desc = raw['description.txt']
-  let html = desc ? `<!--\n${desc})}\n-->\n\n` : ``
+  let html = desc ? `<!--\n${desc}\n-->\n\n` : ``
   let css = ''
 
   // set it first for ordering


### PR DESCRIPTION
## Description of Problem

![image](https://user-images.githubusercontent.com/2922851/147161747-fc92f345-d440-4b80-8e7d-6fe5d081fa4f.png)

