### PR TITLE
Add v-bind:key in todo list

### DIFF
--- a/src/guide/introduction.md
+++ b/src/guide/introduction.md
@@ -189,7 +189,8 @@ There are quite a few other directives, each with its own special functionality.
 ```html
 <div id="list-rendering">
   <ol>
-    <li v-for="todo in todos">
+    <li v-for="todo in todos"
+        v-bind:key="todo.id">
       {{ todo.text }}
     </li>
   </ol>
@@ -201,9 +202,9 @@ const ListRendering = {
   data() {
     return {
       todos: [
-        { text: 'Learn JavaScript' },
-        { text: 'Learn Vue' },
-        { text: 'Build something awesome' }
+        { id: 0, text: 'Learn JavaScript' },
+        { id: 1, text: 'Learn Vue' },
+        { id: 2, text: 'Build something awesome' }
       ]
     }
   }


### PR DESCRIPTION
Add v-bind:key in todo list to avoid error  "Custom elements in iteration require 'v-bind:key' directives"

## Description of Problem
Miss key in list will report  "error  Custom elements in iteration require 'v-bind:key' directives"
It is petty annoy for beginner that their code same as tutorial, but can not run.

## Proposed Solution
Added the v-bind:key in todo list.

## Additional Information
