### PR TITLE
[A11y Docs] Labels code block `Warning` => `Note`

### DIFF
--- a/src/guide/a11y-semantics.md
+++ b/src/guide/a11y-semantics.md
@@ -40,8 +40,8 @@ If you inspect this element in your chrome developer tools and open the Accessib
 
 ![Chrome Developer Tools showing input accessible name from label](/images/AccessibleLabelChromeDevTools.png)
 
-:::warning Warning:
-Though you might have seen labels wrapping the input fields like this:
+:::tip Note
+You might have seen labels wrapping the input fields like this:
 
 ```html
 <label>


### PR DESCRIPTION
## Description of Problem

There is a warning about enclosing `<input>` in a `<label>`.

https://github.com/vuejs/docs/blob/master/src/guide/a11y-semantics.md?plain=1#L43-L54

However, this is allowed in [HTML Standard](https://html.spec.whatwg.org/multipage/forms.html#the-label-element).
It seems like a **deprecation** to be written as a warning.

It also says "better supported by assistive technology", but it is unclear which assistive technologies it refers to.

Therefore, I thought it would be better to write it as a `Note` rather than a `Warning`.

## Proposed Solution

Fix documentation

## Additional Information

I hope @mlama007 who [wrote the documentation](https://github.com/vuejs/docs/pull/109) to review it too.