### PR TITLE
update global-api.md

### DIFF
--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -193,7 +193,7 @@ createApp({
 })
 ```
 
-For advanced usage, `defineAsyncComponent` can accept an object:
+For advanced usage, `defineAsyncComponent` can accept an object of the following format:
 
 ```js
 import { defineAsyncComponent } from 'vue'

--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -195,8 +195,6 @@ createApp({
 
 For advanced usage, `defineAsyncComponent` can accept an object:
 
-The `defineAsyncComponent` method can also return an object of the following format:
-
 ```js
 import { defineAsyncComponent } from 'vue'
 


### PR DESCRIPTION
## Description of Problem

This 2 sentences looks duplicated. And the second one feels not correct: the example is not "returning an object of the following format", but accepting it as param instead. So I think delete the second one maybe better.