### PR TITLE
style: sticky preference switch panel

### DIFF
--- a/src/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/src/.vitepress/theme/components/PreferenceSwitch.vue
@@ -118,6 +118,10 @@ function useToggleFn(
   border-bottom: 1px solid var(--vt-c-divider-light);
   transition: border-color 0.5s;
   margin-bottom: 20px;
+  position: sticky;
+  top: 0;
+  background-color: var(--vt-c-bg);
+  padding-top: 10px;
 }
 
 .toggle {


### PR DESCRIPTION
## Description of Problem

When scrolling down the left side panel, the preference switch panel would be hidden.

Maybe making it sticky would be more convenient for readers. @yyx990803 


https://user-images.githubusercontent.com/46062972/147519380-440e19cf-5052-4006-a097-6c91aa541619.mov


