### PR TITLE
Change git clone git@github.com to git clone https:// in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See the [Vue Docs Writing Guide](https://v3.vuejs.org/guide/writing-guide.html) 
 1. Clone repository
 
 ```bash
-git clone git@github.com:vuejs/docs.git
+git clone https://github.com/vuejs/docs.git
 ```
 
 2. Install dependencies


### PR DESCRIPTION
## Description of Problem
Using `git clone git@github.com...` notation may lead to an error `Permission denied (publickey) fatal: Could not read from remote repository.` if a user doesn't have a public SSH key stored in their github account. Using `git clone https://` is a 100% error-free solution (it doesn't require any SSH keys).

<img width="662" alt="Screenshot 2022-01-04 at 01 08 23" src="https://user-images.githubusercontent.com/439939/147980591-c247e0f1-5b13-46e0-b60e-80e3d0b078b8.png">

## Proposed Solution
`git clone https://github.com/vuejs/docs.git`

## Additional Information
https://stackoverflow.com/questions/21255438/git-permission-denied-publickey-fatal-could-not-read-from-remote-repository
