### PR TITLE
Update composition-api-setup.md

### DIFF
--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -103,7 +103,7 @@ We'll explain the role of `expose` shortly.
 
 ## Accessing Component Properties
 
-When `setup` is executed, although the component instance has already been created, you will only be able to access the following properties:
+When `setup` is executed, you will only be able to access the following properties:
 
 - `props`
 - `attrs`

--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -103,7 +103,7 @@ We'll explain the role of `expose` shortly.
 
 ## Accessing Component Properties
 
-When `setup` is executed, the component instance has not been created yet. As a result, you will only be able to access the following properties:
+When `setup` is executed, although the component instance has already been created, you will only be able to access the following properties:
 
 - `props`
 - `attrs`


### PR DESCRIPTION
From the source code, when the setup function is called, the component instance is already created using the createComponentInstance function.

## Description of Problem

## Proposed Solution

## Additional Information
