### PR TITLE
Modify the documentation description of the custom directive

### DIFF
--- a/src/guide/custom-directive.md
+++ b/src/guide/custom-directive.md
@@ -49,7 +49,7 @@ A directive definition object can provide several hook functions (all optional):
 
 - `beforeMount`: called when the directive is first bound to the element and before parent component is mounted.
 
-- `mounted`: called when the bound element's parent component is mounted.
+- `mounted`: called before the bound element's parent component is mounted.
 
 - `beforeUpdate`: called before the containing component's VNode is updated
 


### PR DESCRIPTION
## Description of Problem
the mounted of the custom directive is earlier than the onMounted of the component,but `called when the bound element's parent component is mounted`  in docs

## Proposed Solution
Modify the documentation description of the custom directive
eg:`called before the bound element's parent component is mounted`

## Additional Information
[The issue of pull request](https://github.com/vuejs/docs/issues/1428) 