### PR TITLE
Minor fixes to tutorial

### DIFF
--- a/src/tutorial/src/step-8/App/template.html
+++ b/src/tutorial/src/step-8/App/template.html
@@ -1,7 +1,7 @@
 <input v-model="newTodo" @keyup.enter="addTodo" />
 <button @click="addTodo">Add Todo</button>
 <ul>
-  <li v-for="todo in todos" :key="todo.text">
+  <li v-for="todo in todos" :key="todo.id">
     <input type="checkbox" v-model="todo.done" />
     <span :class="{ done: todo.done }">{{ todo.text }}</span>
     <button @click="removeTodo(todo)">X</button>

--- a/src/tutorial/src/step-8/App/template.html
+++ b/src/tutorial/src/step-8/App/template.html
@@ -2,7 +2,7 @@
 <button @click="addTodo">Add Todo</button>
 <ul>
   <li v-for="todo in todos" :key="todo.id">
-    <input type="checkbox" v-model="todo.done" />
+    <input type="checkbox" v-model="todo.done">
     <span :class="{ done: todo.done }">{{ todo.text }}</span>
     <button @click="removeTodo(todo)">X</button>
   </li>

--- a/src/tutorial/src/step-9/description.md
+++ b/src/tutorial/src/step-9/description.md
@@ -95,6 +95,6 @@ createApp({
 </div>
 </div>
 
-This is called a **lifecycle hook** - it allows us to register a callback to be called at certain times of the component's lifecycle. There are other hooks such as <span class="options-api">`created` and `updated`<span><span class="composition-api">`onUpdated` and `onUnmounted`</span>. Check out the <a target="_blank" href="/guide/essentials/lifecycle.html#lifecycle-diagram">Lifecycle Diagram</a> for more details.
+This is called a **lifecycle hook** - it allows us to register a callback to be called at certain times of the component's lifecycle. There are other hooks such as <span class="options-api">`created` and `updated`</span><span class="composition-api">`onUpdated` and `onUnmounted`</span>. Check out the <a target="_blank" href="/guide/essentials/lifecycle.html#lifecycle-diagram">Lifecycle Diagram</a> for more details.
 
 Now, try to add an <span class="options-api">`mounted`</span><span class="composition-api">`onMounted`</span> hook, access the `<p>` via <span class="options-api">`this.$refs.p`</span><span class="composition-api">`p.value`</span>, and perform some direct DOM operations on it (e.g. changing its `textContent`).


### PR DESCRIPTION
There are a few little fixes included in this PR:

- fixed the lifecycle hooks description on Lesson 9 for Composition API (it wasn't rendered due to the closing tag absence)
<img width="560" alt="Screenshot 2022-01-17 at 09 49 53" src="https://user-images.githubusercontent.com/18719025/149737572-9912dd8b-095b-441f-a32f-52fac15c1013.png">

- fixed the `:key` for todo-list (it's `todo.id` in the description but `todo.text` in the code
- fixed the lesson 8 code to work for HTML: for some reason, self-closing `input` tag generated closing `</ul>` so there was an error thrown about `todo.done`:
<img width="776" alt="Screenshot 2022-01-17 at 09 52 48" src="https://user-images.githubusercontent.com/18719025/149738154-b686b9bc-ee28-412b-a879-8d2b256e8032.png">
