### PR TITLE
[next] fix keep-alive examples

### DIFF
--- a/src/guide/built-ins/keep-alive-demos/SwitchComponent.vue
+++ b/src/guide/built-ins/keep-alive-demos/SwitchComponent.vue
@@ -4,7 +4,7 @@ import CompB from './CompB.vue'
 
 let current = $shallowRef(CompA)
 
-const { useKeepAlive } = defineProps(['useKeepAlive'])
+const { useKeepAlive } = defineProps({ useKeepAlive: Boolean })
 </script>
 
 <template>
@@ -12,12 +12,12 @@ const { useKeepAlive } = defineProps(['useKeepAlive'])
     <label><input type="radio" v-model="current" :value="CompA" /> A</label>
     <label><input type="radio" v-model="current" :value="CompB" /> B</label>
     <template v-if="useKeepAlive">
-      <component :is="current"></component>
-    </template>
-    <template v-else>
       <KeepAlive>
         <component :is="current"></component>
       </KeepAlive>
+    </template>
+    <template v-else>
+      <component :is="current"></component>
     </template>
   </div>
 </template>


### PR DESCRIPTION
The first example on the page about `KeepAlive` is supposed to show what happens without using `KeepAlive`. However, it is currently using `KeepAlive`, so the state doesn't get reset. The `v-if`/`v-else` logic in the template of `SwitchComponent` is back-to-front.

Flipping the logic fixes the first example but breaks the second example.

The first example uses:

```html
<SwitchComponent />
```

The second example is similar, but with `KeepAlive` enabled:

```html
<SwitchComponent use-KeepAlive />
```

For this to work, it needs the `useKeepAlive` prop to be defined as a `Boolean`, otherwise it ends up with a value of `""`. Currently this is not the case.