### PR TITLE
Add a MDN link for landmark

### DIFF
--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -92,7 +92,7 @@ Users can navigate an application through headings. Having descriptive headings 
 
 ### Landmarks
 
-Landmarks provide programmatic access to sections within an application. Users who rely on assistive technology can navigate to each section of the application and skip over content. You can use [ARIA roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) to help you achieve this.
+[Landmarks](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role) provide programmatic access to sections within an application. Users who rely on assistive technology can navigate to each section of the application and skip over content. You can use [ARIA roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) to help you achieve this.
 
 | HTML            | ARIA Role            | Landmark Purpose                                                                                                 |
 | --------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Description of Problem

People might not know what landmark is in the accessibility doc. So I added a MDN link for it.

## Proposed Solution

Added the MDN link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role

## Additional Information

No