### PR TITLE
Fix API links for headings with badges

### DIFF
--- a/src/api/ApiIndex.vue
+++ b/src/api/ApiIndex.vue
@@ -6,11 +6,11 @@ import { data as apiIndex, APIGroup } from './api.data'
 import { ref, computed } from 'vue'
 
 const query = ref('')
-const nomralize = (s: string) => s.toLowerCase().replace(/-/g, ' ')
+const normalize = (s: string) => s.toLowerCase().replace(/-/g, ' ')
 
 const filtered = computed(() => {
-  const q = nomralize(query.value)
-  const matches = (text: string) => nomralize(text).includes(q)
+  const q = normalize(query.value)
+  const matches = (text: string) => normalize(text).includes(q)
 
   return apiIndex
     .map((section) => {
@@ -31,7 +31,7 @@ const filtered = computed(() => {
             return item
           }
           // filter headers
-          const matchedHeaders = item.headers.filter(matches)
+          const matchedHeaders = item.headers.filter(({ shortText }) => matches(shortText))
           return matchedHeaders.length
             ? { text: item.text, link: item.link, headers: matchedHeaders }
             : null
@@ -76,8 +76,8 @@ function slugify(text: string): string {
         <div v-for="item of section.items" :key="item.text" class="api-group">
           <h3>{{ item.text }}</h3>
           <ul>
-            <li v-for="h of item.headers" :key="h">
-              <a :href="item.link + '.html#' + slugify(h)">{{ h }}</a>
+            <li v-for="{ shortText, fullText } of item.headers" :key="fullText">
+              <a :href="item.link + '.html#' + slugify(fullText)">{{ shortText }}</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Some API entries have badges in their headings, such as `<Suspense> [experimental]`. VitePress includes the badge text in the hash, so we need to do the same.

Currently several links on this page are broken:

https://staging.vuejs.org/api/

They are auto-generated based on the page headings, but currently they ignore the badges.

My fix generates two sets of text for each heading , `shortText` and `fullText`. The former is suitable for displaying to the user in the index (without the badge), whereas the former includes the badge so we can generate the correct link.

Badges probably shouldn't be included in the hash. I don't know how feasible it is to change that in VitePress.