### PR TITLE
Fix API links for headings with badges

### DIFF
--- a/.vitepress/theme/styles/badges.css
+++ b/.vitepress/theme/styles/badges.css
@@ -22,3 +22,7 @@
 .vt-badge.experimental:before {
   content: 'Experimental';
 }
+
+.vt-badge[data-text]:before {
+  content: attr(data-text);
+}

--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -463,7 +463,7 @@ Render the element and component once only, and skip future updates.
   - [Data Binding Syntax - interpolations](/guide/essentials/template-syntax.html#text)
   - [v-memo](#v-memo)
 
-## v-memo <sup class="vt-badge">3.2+</sup>
+## v-memo <sup class="vt-badge" data-text="3.2+" />
 
 - **Expects:** `any[]`
 

--- a/src/api/composition-api-lifecycle.md
+++ b/src/api/composition-api-lifecycle.md
@@ -297,7 +297,7 @@ Registers a callback to be called after the component instance is removed from t
 
 - **See also:** [Guide - Lifecycle of Cached Instance](/guide/built-ins/keep-alive.html#lifecycle-of-cached-instance)
 
-## onServerPrefetch() <sup class="vt-badge">SSR only</sup>
+## onServerPrefetch() <sup class="vt-badge" data-text="SSR only" />
 
 Registers a async function to be resolved before the component instance is to be rendered on the server.
 

--- a/src/api/options-lifecycle.md
+++ b/src/api/options-lifecycle.md
@@ -286,7 +286,7 @@ Called after the component instance is removed from the DOM as part of a tree ca
 
 - **See also:** [Guide - Lifecycle of Cached Instance](/guide/built-ins/keep-alive.html#lifecycle-of-cached-instance)
 
-## serverPrefetch <sup class="vt-badge">SSR only</sup>
+## serverPrefetch <sup class="vt-badge" data-text="SSR only" />
 
 Async function to be resolved before the component instance is to be rendered on the server.
 


### PR DESCRIPTION
Following on from e6512dc7d52c1d00adca715e371c123f0ef0b46a, this PR moves the text for 3 badges into CSS `content` .

Currently the links from https://staging.vuejs.org/api/ are broken for `v-memo`, `onServerPrefetch()` and `serverPrefetch` due to the badges being included in the hash.