### PR TITLE
Tweak wording, correct typos and adjust grammar

### DIFF
--- a/src/guide/best-practices/performance.md
+++ b/src/guide/best-practices/performance.md
@@ -51,15 +51,15 @@ One of the most effective ways to improve page load performance is shipping smal
 
 - Be cautious of size when introducing new dependencies! In real world applications, bloated bundles are most often a result of introducing heavy dependencies without realizing it.
 
-  - If using a build step, prefer dependencies that offer ES module formats and are tree-shaking-friendly. For example, prefer `lodash-es` over `lodash`.
+  - If using a build step, prefer dependencies that offer ES module formats and are tree-shaking friendly. For example, prefer `lodash-es` over `lodash`.
 
-  - Check a dependency's size and evaluate whether it is worth the functionality it provides. Note if the dependency is tree-shaking-friendly, the actual size increase will depend on the APIs you actually import from it. Tools like [bundle.js.org](https://bundle.js.org/) can be used for quick checks, but measuring with your actual build setup will always be the most accurate.
+  - Check a dependency's size and evaluate whether it is worth the functionality it provides. Note if the dependency is tree-shaking friendly, the actual size increase will depend on the APIs you actually import from it. Tools like [bundle.js.org](https://bundle.js.org/) can be used for quick checks, but measuring with your actual build setup will always be the most accurate.
 
 - If you are using Vue primarily for progressive enhancement and prefer to avoid a build step, consider using [petite-vue](https://github.com/vuejs/petite-vue) (only **6kb**) instead.
 
 ### Code Splitting
 
-Code splitting stands for the build tool splitting the application bundle into multiple smaller chunks which can then be loaded on demand or in parallel. With proper code splitting, features required at page load can be downloaded immediately, with additional chunks being lazy loaded only when needed, thus improving performance.
+Code splitting is where a build tool splits the application bundle into multiple smaller chunks, which can then be loaded on demand or in parallel. With proper code splitting, features required at page load can be downloaded immediately, with additional chunks being lazy loaded only when needed, thus improving performance.
 
 Bundlers like Rollup (which Vite is based upon) or webpack can automatically create split chunks by detecting the ESM dynamic import syntax:
 
@@ -116,11 +116,11 @@ Now, for most components the `active` prop will remain the same when `activeId` 
 
 ### `v-once`
 
-`v-once` is a built-in directive that can be used to render content that relies on runtime data but never needs to update. The entire sub tree it is used on will be skipped for all future updates. Consult its [API reference](/api/built-in-directives.html#v-once) for more details.
+`v-once` is a built-in directive that can be used to render content that relies on runtime data but never needs to update. The entire sub-tree it is used on will be skipped for all future updates. Consult its [API reference](/api/built-in-directives.html#v-once) for more details.
 
 ### `v-memo`
 
-`v-memo` is a built-in directive that can be used to conditionally skip the update of large sub trees or `v-for` lists. Consult its [API reference](/api/built-in-directives.html#v-memo) for more details.
+`v-memo` is a built-in directive that can be used to conditionally skip the update of large sub-trees or `v-for` lists. Consult its [API reference](/api/built-in-directives.html#v-memo) for more details.
 
 ## General Optimizations
 
@@ -128,7 +128,7 @@ Now, for most components the `active` prop will remain the same when `activeId` 
 
 ### Virtualize Large Lists
 
-One of the most common performance issues in all frontend applications is rendering large lists. No matter how performant a framework is, rendering a list with thousands of items **will** be slow due to the sheer amount of DOM nodes that the browser needs to handle.
+One of the most common performance issues in all frontend applications is rendering large lists. No matter how performant a framework is, rendering a list with thousands of items **will** be slow due to the sheer number of DOM nodes that the browser needs to handle.
 
 However, we don't necessarily have to render all these nodes upfront. In most cases, the user's screen size can display only a small subset of our large list. We can greatly improve the performance with **list virtualization**, the technique of only rendering the items that are currently in or close to the viewport in a large list.
 
@@ -139,7 +139,7 @@ Implementing list virtualization isn't easy, luckily there are existing communit
 
 ### Reduce Reactivity Overhead for Large Immutable Structures
 
-Vue's reactivity system is deep by default. While this makes state management intuitive, it does create a certain level of overhead when the data size is large, because every property access triggers proxy traps that performs dependency tracking. This typically becomes noticeable when dealing with large arrays of deeply nested objects, where a single render needs to access 100,000+ properties, so it should only affect very specific use cases.
+Vue's reactivity system is deep by default. While this makes state management intuitive, it does create a certain level of overhead when the data size is large, because every property access triggers proxy traps that perform dependency tracking. This typically becomes noticeable when dealing with large arrays of deeply nested objects, where a single render needs to access 100,000+ properties, so it should only affect very specific use cases.
 
 Vue does provide an escape hatch to opt-out of deep reactivity by using [`shallowRef()`](/api/reactivity-advanced.html#shallowref) and [`shallowReactive()`](/api/reactivity-advanced.html#shallowreactive). Shallow APIs create state that is reactive only at the root level, and exposes all nested objects untouched. This keeps nested property access fast, with the trade-off being that we must now treat all nested objects as immutable, and updates can only be triggered by replacing the root state:
 
@@ -153,7 +153,7 @@ shallowArray.value.push(newObject)
 // this does:
 shallowArray.value = [...shallowArr.value, newObject]
 
-// this won't trigger update...
+// this won't trigger updates...
 shallowArray.value[0].foo = 1
 // this does:
 shallowArray.value = [

--- a/src/guide/built-ins/keep-alive.md
+++ b/src/guide/built-ins/keep-alive.md
@@ -71,7 +71,7 @@ By default, `<KeepAlive>` will cache any component instance inside. We can custo
 </KeepAlive>
 ```
 
-The match is checked against the component's [`name`](/api/options-misc.html#name) option, so components that need to be conditionally cached by `KeepAlive` must explicitly delcare a `name` option.
+The match is checked against the component's [`name`](/api/options-misc.html#name) option, so components that need to be conditionally cached by `KeepAlive` must explicitly declare a `name` option.
 
 ## Max Cached Instances
 
@@ -85,7 +85,7 @@ We can limit the maximum number of component instances that can be cached via th
 
 ## Lifecycle of Cached Instance
 
-When a component instance is removed from the DOM but is part of a component tree cached by `<KeepAlive>`, it goes into **deactivated** state instead of unmounted. When a component instance is inserted into the DOM as part of a cached tree, it is **activated**.
+When a component instance is removed from the DOM but is part of a component tree cached by `<KeepAlive>`, it goes into a **deactivated** state instead of being unmounted. When a component instance is inserted into the DOM as part of a cached tree, it is **activated**.
 
 <div class="composition-api">
 
@@ -110,7 +110,7 @@ onDeactivated(() => {
 </div>
 <div class="options-api">
 
-A kept-alive component can register lifecycle hooks for these two states using [`activated`](/api/options-lifecycle.html#activated) and [`deactovated`](/api/options-lifecycle.html#deactivated) hooks:
+A kept-alive component can register lifecycle hooks for these two states using [`activated`](/api/options-lifecycle.html#activated) and [`deactivated`](/api/options-lifecycle.html#deactivated) hooks:
 
 ```js
 export default {

--- a/src/guide/built-ins/suspense.md
+++ b/src/guide/built-ins/suspense.md
@@ -30,7 +30,7 @@ The `<Suspense>` component gives us the ability to display top-level loading / e
 
 There are two types of async dependencies that `<Suspense>` can wait on:
 
-1. Components with an async `setup()` hook. This includes components with `<script setup>` that contains top-level `await` expressions.
+1. Components with an async `setup()` hook. This includes components using `<script setup>` with top-level `await` expressions.
 
 2. [Async Components](/guide/components/async.html).
 
@@ -85,17 +85,17 @@ The `<Suspense>` component has two slots: `#default` and `#fallback`. Both slots
 </Suspense>
 ```
 
-On initial render, `<Suspense>` will render its default slot content in memory. If any async dependencies are encountered during the process, it will enter **pending** state. During pending state, the fallback content will be displayed. When all encountered async dependencies have been resolved, `<Suspense>` enters **resolved** state and the resolved default slot content is displayed.
+On initial render, `<Suspense>` will render its default slot content in memory. If any async dependencies are encountered during the process, it will enter a **pending** state. During the pending state, the fallback content will be displayed. When all encountered async dependencies have been resolved, `<Suspense>` enters a **resolved** state and the resolved default slot content is displayed.
 
-If no async dependencies were encountered during the initial render, `<Suspense>` will directly go into resolved state.
+If no async dependencies were encountered during the initial render, `<Suspense>` will directly go into a resolved state.
 
-Once in resolved state, `<Suspense>` will only revert to pending state if the root node of the `#default` slot is replaced. New async dependencies nested deeper in the tree will **not** cause the `<Suspense>` to revert into pending state.
+Once in a resolved state, `<Suspense>` will only revert to a pending state if the root node of the `#default` slot is replaced. New async dependencies nested deeper in the tree will **not** cause the `<Suspense>` to revert to a pending state.
 
 When a revert happens, fallback content will not be immediately displayed. Instead, `<Suspense>` will display the previous `#default` content while waiting for the new content and its async dependencies to be resolved. This behavior can be configured with the `timeout` prop: `<Suspense>` will switch to fallback content if it takes longer than `timeout` to render the new default content. A `timeout` value of `0` will cause the fallback content to be displayed immediately when default content is replaced.
 
 ## Events
 
-In addition to the `pending` event, the `<suspense>` component also has `resolve` and `fallback` events. The `resolve` event is emitted when new content has finished resolving in the `default` slot. The `fallback` event is fired when the contents of the `fallback` slot are shown.
+The `<Suspense>` component emits 3 events: `pending`, `resolve` and `fallback`. The `pending` event occurs when entering a pending state. The `resolve` event is emitted when new content has finished resolving in the `default` slot. The `fallback` event is fired when the contents of the `fallback` slot are shown.
 
 The events could be used, for example, to show a loading indicator in front of the old DOM while new components are loading.
 

--- a/src/guide/built-ins/teleport.md
+++ b/src/guide/built-ins/teleport.md
@@ -111,7 +111,7 @@ When using this component inside the initial HTML structure, there are a number 
 
 The `to` target of `<Teleport>` expects a CSS selector string or an actual DOM node. Here, we are essentially telling Vue to "**teleport** this template fragment **to** the **`body`** tag".
 
-You can click the button below and inspect the `<body>` tag via browser devtools:
+You can click the button below and inspect the `<body>` tag via your browser's devtools:
 
 <script setup>
 let open = $ref(false)
@@ -170,7 +170,7 @@ Where the `isMobile` state can be dynamically updated by detecting media query c
 
 ## Multiple Teleports on the Same Target
 
-A common use case scenario would be a reusable `<Modal>` component of which there might be multiple instances active at the same time. For this kind of scenario, multiple `<Teleport>` components can mount their content to the same target element. The order will be a simple append - later mounts will be located after earlier ones within the target element.
+A common use case would be a reusable `<Modal>` component, with the potential for multiple instances to be active at the same time. For this kind of scenario, multiple `<Teleport>` components can mount their content to the same target element. The order will be a simple append - later mounts will be located after earlier ones within the target element.
 
 Given the following usage:
 

--- a/src/guide/built-ins/transition-group.md
+++ b/src/guide/built-ins/transition-group.md
@@ -8,7 +8,7 @@ import ListStagger from './transition-demos/ListStagger.vue'
 
 `<TransitionGroup>` is a built-in component designed for animating the insertion, removal, and order change of elements or components that are rendered in a list.
 
-## Difference from `<Transition>`
+## Differences from `<Transition>`
 
 `<TransitionGroup>` supports the same props, CSS transition classes, and JavaScript hook listeners as `<Transition>`, with the following differences:
 
@@ -52,7 +52,7 @@ Here is an example of applying enter / leave transitions to a `v-for` list using
 
 ## Move Transitions
 
-The above demo has some obvious flaws: when an item is inserted or removed, its sorrounding items instantly "jumps" into place instead of moving smoothly. We can fix this by adding a few additional CSS rules:
+The above demo has some obvious flaws: when an item is inserted or removed, its surrounding items instantly "jump" into place instead of moving smoothly. We can fix this by adding a few additional CSS rules:
 
 ```css{1,13-17}
 .list-move, /* apply transition to moving elements */
@@ -74,7 +74,7 @@ The above demo has some obvious flaws: when an item is inserted or removed, its 
 }
 ```
 
-Now it looks much better - even animates smoothly when the whole list is shuffled:
+Now it looks much better - even animating smoothly when the whole list is shuffled:
 
 <ListMove />
 

--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -14,7 +14,7 @@ Vue offers two built-in components that can help work with transitions and anima
 
 - `<Transition>` for applying animations when an element or component is entering and leaving the DOM. This is covered on this page.
 
-- `<TransitionGroup>` for applying animations when an element or component is inserted into, removed from, or moved within a `v-for` list. This is covered in the next chapter.
+- `<TransitionGroup>` for applying animations when an element or component is inserted into, removed from, or moved within a `v-for` list. This is covered in [the next chapter](/guide/built-ins/transition-group.html).
 
 Aside from these two components, we can also apply animations in Vue using other techniques such as toggling CSS classes or state-driven animations via style bindings. These additional techniques are covered in the [Animation Techniques](/guide/extras/animation.html) chapter.
 
@@ -125,7 +125,7 @@ For a named transition, its transition classes will be prefixed with its name in
 
 `<Transition>` is most commonly used in combination with [native CSS transitions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions), as seen in the basic example above. The `transition` CSS property is a shorthand that allows us to specify multiple aspects of a transition, including properties that should be animated, duration of the transition, and [easing curves](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function).
 
-Here is a more advanced example transitioning more than one properties, with different duration and easing curves for enter and leave:
+Here is a more advanced example that transitions multiple properties, with different durations and easing curves for enter and leave:
 
 ```vue-html
 <Transition name="slide-fade">
@@ -319,9 +319,9 @@ You may notice that the animations shown above are mostly using properties like 
 
 1. They do not affect the document layout during the animation, so they do not trigger expensive CSS layout calculation on every animation frame.
 
-2. Most modern browsers can leverage GPU hardware accelaration when animating `transform`.
+2. Most modern browsers can leverage GPU hardware acceleration when animating `transform`.
 
-In comparision, properties like `height` or `margin` will trigger CSS layout, so they are much more expensive to animate, and should be used with caution. We can check resources like [CSS-Triggers](https://csstriggers.com/) to see which properties will trigger layout if we animate them.
+In comparison, properties like `height` or `margin` will trigger CSS layout, so they are much more expensive to animate, and should be used with caution. We can check resources like [CSS-Triggers](https://csstriggers.com/) to see which properties will trigger layout if we animate them.
 
 ## JavaScript Hooks
 
@@ -362,7 +362,7 @@ function onAfterEnter(el) {}
 function onEnterCancelled(el) {}
 
 // called before the leave hook.
-// Most of the time, you shoud just use the leave hook
+// Most of the time, you should just use the leave hook
 function onBeforeLeave(el) {}
 
 // called when the leave transition starts.
@@ -463,13 +463,13 @@ Here's a demo using the [GreenSock library](https://greensock.com/) to perform t
 Transitions can be reused through Vue's component system. To create a reusable transition, we can create a component that wraps the `<Transition>` component and passes down the slot content:
 
 ```vue{5}
-<!-- MyTransitio.vue -->
+<!-- MyTransition.vue -->
 <script>
 // JavaScript hooks logic...
 </script>
 
 <template>
-  <!-- wrap the built in Transition component -->
+  <!-- wrap the built-in Transition component -->
   <Transition
     name="my-transition"
     @enter="onEnter"
@@ -523,7 +523,7 @@ In addition to toggling an element with `v-if` / `v-show`, we can also transitio
 
 ## Transition Modes
 
-In the previous example, the entering and leaving elements are animated at the same time, and we had to work make them `position: absolute` to avoid the layout issue when both elements are present in the DOM.
+In the previous example, the entering and leaving elements are animated at the same time, and we had to make them `position: absolute` to avoid the layout issue when both elements are present in the DOM.
 
 However, in some cases this isn't an option, or simply isn't the desired behavior. We may want the leaving element to be animated out first, and for the entering element to only be inserted **after** the leaving animation has finished. Orchestrating such animations manually would be very complicated - luckily, we can enable this behavior by passing `<Transition>` a `mode` prop:
 
@@ -574,7 +574,7 @@ Here's the previous demo with `mode="out-in"`:
 
 This can be useful when you've defined CSS transitions / animations using Vue's transition class conventions and want to switch between them.
 
-You can also apply different behavior in JavaScript transition hooks based on current state of your component. Finally, the ultimate way of creating dynamic transitions is through [reusable transition components](#reusable-transitions) that accept props to change the nature of the transition(s) to be used. It may sound cheesy, but the only limit really is your imagination.
+You can also apply different behavior in JavaScript transition hooks based on the current state of your component. Finally, the ultimate way of creating dynamic transitions is through [reusable transition components](#reusable-transitions) that accept props to change the nature of the transition(s) to be used. It may sound cheesy, but the only limit really is your imagination.
 
 ---
 

--- a/src/guide/extras/composition-api-faq.md
+++ b/src/guide/extras/composition-api-faq.md
@@ -53,7 +53,7 @@ If you are interested in learning how to use Vue with Composition API, you can s
 
 The primary advantage of Composition API is that it enables clean, efficient logic reuse in the form of [Composable functions](/guide/reusability/composables.html). It solves [all the drawbacks of mixins](/guide/reusability/composables.html#vs-mixins), the primary logic reuse mechanism for Options API.
 
-Composition API's logic reuse capability has given rise to impressive community projects such as [VueUse](https://vueuse.org/), an ever-growing collection of composable utilities. It also serves as a clean mechanism for easily integrating stateful 3rd party libraries into Vue's reactivity system, for example [RxJS](https://vueuse.org/rxjs/readme.html#vueuse-rxjs).
+Composition API's logic reuse capability has given rise to impressive community projects such as [VueUse](https://vueuse.org/), an ever-growing collection of composable utilities. It also serves as a clean mechanism for easily integrating stateful third-party libraries into Vue's reactivity system, for example [RxJS](https://vueuse.org/rxjs/readme.html#vueuse-rxjs).
 
 ### More Flexible Code Organization
 
@@ -78,11 +78,11 @@ Here's the same component, before and after the [refactor into Composition API](
 
 ![folder component after](./images/composition-api-after.png)
 
-Notice how the code related to the same logical concern can now be grouped together: we no longer need to jump between different options blocks while working on a specific logical concern. Moreover, we can now move a group of code into an external file with minimal effort, since we no longer need to shuffle the code around in order to extract them. This reduced friction for refactor is key to the long term maintainability in large codebases.
+Notice how the code related to the same logical concern can now be grouped together: we no longer need to jump between different options blocks while working on a specific logical concern. Moreover, we can now move a group of code into an external file with minimal effort, since we no longer need to shuffle the code around in order to extract them. This reduced friction for refactoring is key to the long-term maintainability in large codebases.
 
 ### Better Type Inference
 
-In recent years, more and more frontend developers are adopting [TypeScript](https://www.typescriptlang.org/) as it helps us write more robust code, make changes with more confidence, and provides a great development experience with IDE support. However, the Options API, originally perceived in 2013, was designed without type inference in mind. We had to implement some [absurdly complex type gymnastics](https://github.com/vuejs/core/blob/44b95276f5c086e1d88fa3c686a5f39eb5bb7821/packages/runtime-core/src/componentPublicInstance.ts#L132-L165) to make type inference work with the Options API. Even with all this effort, type inference for Options API can still break down for mixins and dependency injection.
+In recent years, more and more frontend developers are adopting [TypeScript](https://www.typescriptlang.org/) as it helps us write more robust code, make changes with more confidence, and provides a great development experience with IDE support. However, the Options API, originally conceived in 2013, was designed without type inference in mind. We had to implement some [absurdly complex type gymnastics](https://github.com/vuejs/core/blob/44b95276f5c086e1d88fa3c686a5f39eb5bb7821/packages/runtime-core/src/componentPublicInstance.ts#L132-L165) to make type inference work with the Options API. Even with all this effort, type inference for Options API can still break down for mixins and dependency injection.
 
 This had led many developers who wanted to use Vue with TS to lean towards Class API powered by `vue-class-component`. However, a class-based API heavily relies on ES decorators, a language feature that was only a stage 2 proposal when Vue 3 was being developed in 2019. We felt it was too risky to base an official API on an unstable proposal. Since then, the decorators proposal has gone through yet another complete overhaul, and has yet to reach stage 3 as of this writing. In addition, class-based API suffers from logic reuse and organization limitations similar to Options API.
 
@@ -90,7 +90,7 @@ In comparison, Composition API utilizes mostly plain variables and functions, wh
 
 ### Smaller Production Bundle and Less Overhead
 
-Code written in Composition API and `<script setup>` is also more efficient and minification-friendly than Options API equivalent. This is because the template in a `<script setup>` component is compiled as a function inlined in the same scope of the `<script setup>` code. Unlike property access from `this`, the compiled template code can directly access variables declared inside `<script setup>` without an instance proxy in between. This also leads to better minification because all the variable names can be safely shortened.
+Code written in Composition API and `<script setup>` is also more efficient and minification-friendly than Options API equivalent. This is because the template in a `<script setup>` component is compiled as a function inlined in the same scope of the `<script setup>` code. Unlike property access from `this`, the compiled template code can directly access variables declared inside `<script setup>`, without an instance proxy in between. This also leads to better minification because all the variable names can be safely shortened.
 
 ## Relationship with Options API
 
@@ -108,7 +108,7 @@ However, we only recommend doing so if you have an existing Options API codebase
 
 ### Will Options API be deprecated?
 
-No, we do not have any plan to do so. Options API is an integral part of Vue and the reason many developers love it. We also realize that many of the benefits of Composition API only manifest in larger scale projects, and Options API remains a solid choice for many low-to-medium-complexity scenarios.
+No, we do not have any plan to do so. Options API is an integral part of Vue and the reason many developers love it. We also realize that many of the benefits of Composition API only manifest in larger-scale projects, and Options API remains a solid choice for many low-to-medium-complexity scenarios.
 
 ## Relationship with Class API
 
@@ -124,9 +124,9 @@ React Hooks are invoked repeatedly every time a component updates. This creates 
 
 - Variables declared in a React component can be captured by a hook closure and become "stale" if the developer fails to pass in the correct dependencies array. This leads to React developers relying on ESLint rules to ensure correct dependencies are passed. However, the rule is often not smart enough and over-compensates for correctness, which leads to unnecessary invalidation and headaches when edge cases are encountered.
 
-- Expensive computations require the use of `useMemo`, which again requires manually passing in correct dependencies array.
+- Expensive computations require the use of `useMemo`, which again requires manually passing in the correct dependencies array.
 
-- Event handlers passed to child components cause unnecessary children updates by default, and requires explicit `useCallback` as an optimization. This is almost always needed, and again requires correct dependencies array. Neglecting this leads to over-rendering apps by default and can cause performance issues without realizing it.
+- Event handlers passed to child components cause unnecessary child updates by default, and require explicit `useCallback` as an optimization. This is almost always needed, and again requires a correct dependencies array. Neglecting this leads to over-rendering apps by default and can cause performance issues without realizing it.
 
 - The stale closure problem, combined with Concurrent features, makes it difficult to reason about when a piece of hooks code is run, and makes working with mutable state that should persist across renders (via `useRef`) cumbersome.
 
@@ -136,6 +136,6 @@ In comparison, Vue Composition API:
 
 - Vue's runtime reactivity system automatically collects reactive dependencies used in computed properties and watchers, so there's no need to manually declare dependencies.
 
-- No need to manually cache callback functions to avoid unnecessary children updates. In general, Vue's fine grained reactivity system ensures child components only update when they need to. Manual child update optimizations are rarely a concern for Vue developers.
+- No need to manually cache callback functions to avoid unnecessary child updates. In general, Vue's fine-grained reactivity system ensures child components only update when they need to. Manual child-update optimizations are rarely a concern for Vue developers.
 
 We acknowledge the creativity of React Hooks, and it is a major source of inspiration for Composition API. However, the issues mentioned above do exist in its design and we noticed Vue's reactivity model happens to provide a way around them.

--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -65,9 +65,9 @@ This `whenDepsChange()` function has the following tasks:
 
 ## How Reactivity Works in Vue
 
-We can't really track read and write of local variables like in the example. There's just no mechanism for doing that in vanilla JavaScript. What we **can** do though, is intercepting the read and write of **object properties**.
+We can't really track the reading and writing of local variables like in the example. There's just no mechanism for doing that in vanilla JavaScript. What we **can** do though, is intercept the reading and writing of **object properties**.
 
-There are two ways of intercepting property access in JavaScript: [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get)/[setters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set) and [Proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy). Vue 2 used getter/setters exclusively due to browser support limitations. In Vue 3, Proxies are used for reactive objects and getter/setters are used for refs. Here's the pseudo code that illustrates how they work:
+There are two ways of intercepting property access in JavaScript: [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get)/[setters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/set) and [Proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy). Vue 2 used getter/setters exclusively due to browser support limitations. In Vue 3, Proxies are used for reactive objects and getter/setters are used for refs. Here's some pseudo-code that illustrates how they work:
 
 ```js{4,8,17,21}
 function reactive(obj) {
@@ -108,7 +108,7 @@ This explains a few things that we have discussed in the fundamentals section:
 
 - The returned proxy from `reactive()`, although behaving just like the original, has a different identity if we compare it to the original using the `===` operator.
 
-Inside `track()`, we check whether there is a currently running effect. If there is one, we lookup the subscriber effects (stored in a Set) to the property being tracked, and adds the effect to the Set:
+Inside `track()`, we check whether there is a currently running effect. If there is one, we lookup the subscriber effects (stored in a Set) for the property being tracked, and add the effect to the Set:
 
 ```js
 // This will be set right before an effect is about
@@ -147,11 +147,11 @@ function whenDepsChange(update) {
 }
 ```
 
-It wraps the raw `update` function into an effect that sets itself as the current active effect before running the actual update. This enables `track()` calls during the update to locate the current active effect.
+It wraps the raw `update` function in an effect that sets itself as the current active effect before running the actual update. This enables `track()` calls during the update to locate the current active effect.
 
 At this point, we have created an effect that automatically tracks its dependencies, and re-runs whenever a dependency changes. We call this a **Reactive Effect**.
 
-Vue provides an API that allows you to create reactive effects: [`watchEffect()`](/api/reactivity-core.html#watcheffect). In fact, you probably have noticed that it works pretty similar to the magical `whenDepsChange()` in the example. We can now rework the original example using actual Vue APIs:
+Vue provides an API that allows you to create reactive effects: [`watchEffect()`](/api/reactivity-core.html#watcheffect). In fact, you may have noticed that it works pretty similarly to the magical `whenDepsChange()` in the example. We can now rework the original example using actual Vue APIs:
 
 ```js
 import { ref, watchEffect } from 'vue'
@@ -169,7 +169,7 @@ watchEffect(() => {
 A0.value = 2
 ```
 
-Using a reactive effect to mutating a ref isn't the most interesting use case - in fact, using a computed property makes it more declarative:
+Using a reactive effect to mutate a ref isn't the most interesting use case - in fact, using a computed property makes it more declarative:
 
 ```js
 import { ref, computed } from 'vue'
@@ -202,7 +202,7 @@ In fact, this is pretty close to how a Vue component keeps the state and the DOM
 
 <div class="options-api">
 
-The `ref()`, `computed()` and `watchEffect()` APIs are all part of the Composition API. If you have only been using Options API with Vue so far, you'll notice that Composition API is closer to how Vue's reactivity system works under the hood. In fact, in Vue 3 the Options API is implemented on top of the Composition API. All property access on the component instance (`this`) trigger getter/setters for reactivity tracking, and options like `watch` and `computed` invoke their Composition API equivalents internally.
+The `ref()`, `computed()` and `watchEffect()` APIs are all part of the Composition API. If you have only been using Options API with Vue so far, you'll notice that Composition API is closer to how Vue's reactivity system works under the hood. In fact, in Vue 3 the Options API is implemented on top of the Composition API. All property access on the component instance (`this`) triggers getter/setters for reactivity tracking, and options like `watch` and `computed` invoke their Composition API equivalents internally.
 
 </div>
 
@@ -210,7 +210,7 @@ The `ref()`, `computed()` and `watchEffect()` APIs are all part of the Compositi
 
 Vue's reactivity system is primarily runtime-based: the tracking and triggering are all performed while the code is running directly in the browser. The pros of runtime reactivity is that it can work without a build step, and there are fewer edge cases. On the other hand, this makes it constrained by the syntax limitations of JavaScript.
 
-We have already encountered a limitation in the previous example: JavaScript does not provide a way for us to intercept read and write of local variables, so we have to always access reactive state as object properties, using either reactive objects or refs.
+We have already encountered a limitation in the previous example: JavaScript does not provide a way for us to intercept the reading and writing of local variables, so we have to always access reactive state as object properties, using either reactive objects or refs.
 
 We have been experimenting with the [Reactivity Transform](/guide/extras/reactivity-transform.html) feature to reduce the code verbosity:
 
@@ -225,7 +225,7 @@ const A2 = $computed(() => A0 + A1)
 A0 = 2
 ```
 
-This snippet compiles into exactly what we'd have written without the transform, by automatically appending `.value` after references of the variables. With Reactivity Transform, Vue's reactivity system becomes a hybrid one.
+This snippet compiles into exactly what we'd have written without the transform, by automatically appending `.value` after references to the variables. With Reactivity Transform, Vue's reactivity system becomes a hybrid one.
 
 ## Reactivity Debugging
 
@@ -387,7 +387,7 @@ export function useImmer(baseState) {
 
 ### State Machines
 
-[State Machine](https://en.wikipedia.org/wiki/Finite-state_machine) is a model for describing all the possible states an application can be in, and all the possible ways it can transition from one state to another. While it may be an overkill for simple components, it can help make complex state flows more robust and manageable.
+[State Machine](https://en.wikipedia.org/wiki/Finite-state_machine) is a model for describing all the possible states an application can be in, and all the possible ways it can transition from one state to another. While it may be overkill for simple components, it can help make complex state flows more robust and manageable.
 
 One of the most popular state machine implementations in JavaScript is [XState](https://xstate.js.org/). Here's a composable that integrates with it:
 

--- a/src/guide/extras/reactivity-transform.md
+++ b/src/guide/extras/reactivity-transform.md
@@ -87,7 +87,7 @@ const __temp = useMouse(),
 console.log(x.value, y.value)
 ```
 
-Note that if `x` is already a ref, `toRef(__temp, 'x')` will simply return it as-is and no additional ref will be created. If a destructured value is not a ref (e.g. a function), it will still work - the value will be wrapped into a ref so the rest of the code work as expected.
+Note that if `x` is already a ref, `toRef(__temp, 'x')` will simply return it as-is and no additional ref will be created. If a destructured value is not a ref (e.g. a function), it will still work - the value will be wrapped in a ref so the rest of the code works as expected.
 
 `$()` destructure works on both reactive objects **and** plain objects containing refs.
 
@@ -111,7 +111,7 @@ There are two pain points with the current `defineProps()` usage in `<script set
 
 2. When using the [type-only props declaration](/api/sfc-script-setup.html#typescript-only-features), there is no easy way to declare default values for the props. We introduced the `withDefaults()` API for this exact purpose, but it's still clunky to use.
 
-We can address these issues by applying the same logic for reactive variables destructure to `defineProps`:
+We can address these issues by applying a compile-time transform when `defineProps` is used with destructuring, similar to what we saw earlier with `$()`:
 
 ```html
 <script setup lang="ts">
@@ -137,7 +137,7 @@ We can address these issues by applying the same logic for reactive variables de
 </script>
 ```
 
-the above will be compiled into the following runtime declaration equivalent:
+The above will be compiled into the following runtime declaration equivalent:
 
 ```js
 export default {
@@ -160,7 +160,7 @@ While reactive variables relieve us from having to use `.value` everywhere, it c
 
 ### Passing into function as argument
 
-Given a function that expects a ref object as argument, e.g.:
+Given a function that expects a ref as an argument, e.g.:
 
 ```ts
 function trackChange(x: Ref<number>) {
@@ -180,7 +180,7 @@ let count = ref(0)
 trackChange(count.value)
 ```
 
-Here `count.value` is passed as a number where `trackChange` expects an actual ref. This can be fixed by wrapping `count` with `$$()` before passing it:
+Here `count.value` is passed as a number, whereas `trackChange` expects an actual ref. This can be fixed by wrapping `count` with `$$()` before passing it:
 
 ```diff
 let count = $ref(0)
@@ -229,7 +229,7 @@ return {
 
 In order to retain reactivity, we should be returning the actual refs, not the current value at return time.
 
-Again, we can use `$$()` to fix this. In this case, `$$()` can be used directly on the returned object - any reference to reactive variables inside the `$$()` call will be retained as reference to their underlying refs:
+Again, we can use `$$()` to fix this. In this case, `$$()` can be used directly on the returned object - any reference to reactive variables inside the `$$()` call will retain the reference to their underlying refs:
 
 ```ts
 function useMouse() {
@@ -246,7 +246,7 @@ function useMouse() {
 }
 ```
 
-### `$$()` Usage on destructured props
+### Using `$$()` on destructured props
 
 `$$()` works on destructured props since they are reactive variables as well. The compiler will convert it with `toRef` for efficiency:
 
@@ -267,7 +267,7 @@ setup(props) {
 
 ## TypeScript Integration <sup class="vt-badge ts" />
 
-Vue provides typings for these macros (available globally) and all types will work as expected. There are no incompatibilities with standard TypeScript semantics so the syntax would work with all existing tooling.
+Vue provides typings for these macros (available globally) and all types will work as expected. There are no incompatibilities with standard TypeScript semantics, so the syntax will work with all existing tooling.
 
 This also means the macros can work in any files where valid JS / TS are allowed - not just inside Vue SFCs.
 
@@ -287,7 +287,7 @@ Reactivity Transform is currently disabled by default and requires explicit opt-
 
 - Requires `@vitejs/plugin-vue@^2.0.0`
 - Applies to SFCs and js(x)/ts(x) files. A fast usage check is performed on files before applying the transform so there should be no performance cost for files not using the macros.
-- Note `refTransform` is now a plugin root-level option instead of nested as `script.refSugar`, since it affects not just SFCs.
+- Note `reactivityTransform` is now a plugin root-level option instead of nested as `script.refSugar`, since it affects not just SFCs.
 
 ```js
 // vite.config.js
@@ -303,7 +303,7 @@ export default {
 ### `vue-cli`
 
 - Currently only affects SFCs
-- requires `vue-loader@^17.0.0`
+- Requires `vue-loader@^17.0.0`
 
 ```js
 // vue.config.js
@@ -325,7 +325,7 @@ module.exports = {
 ### Plain `webpack` + `vue-loader`
 
 - Currently only affects SFCs
-- requires `vue-loader@^17.0.0`
+- Requires `vue-loader@^17.0.0`
 
 ```js
 // webpack.config.js

--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -40,7 +40,7 @@ h('div', { id: 'foo' })
 h('div', { class: 'bar', innerHTML: 'hello' })
 
 // class and style have the same object / array
-// value support like in templates
+// value support that they have in templates
 h('div', { class: [foo, { bar }], style: { color: 'red' } })
 
 // event listeners should be passed as onXxx
@@ -72,7 +72,7 @@ vnode.key // null
 The full `VNode` interface contains many other internal properties, but it is strongly recommended to avoid relying on any properties other than the ones listed here. This avoids unintended breakage in case the internal properties are changed.
 :::
 
-### Declaring Render Function
+### Declaring Render Functions
 
 <div class="composition-api">
 
@@ -114,7 +114,7 @@ export default {
     // use an array to return multiple root nodes
     return () => [
       h('div'),
-      h('div')
+      h('div'),
       h('div')
     ]
   }
@@ -145,7 +145,7 @@ export default {
 }
 ```
 
-The `render()` function has access to the same `this` component instance.
+The `render()` function has access to the component instance via `this`.
 
 In addition to returning a single vnode, you can also return strings or arrays:
 
@@ -165,7 +165,7 @@ export default {
     // use an array to return multiple root nodes
     return [
       h('div'),
-      h('div')
+      h('div'),
       h('div')
     ]
   }
@@ -182,7 +182,7 @@ function Hello() {
 }
 ```
 
-That's right, this is is a valid Vue component! See [Functional Components](#functional-components) for more details on this syntax.
+That's right, this is a valid Vue component! See [Functional Components](#functional-components) for more details on this syntax.
 
 ### Vnodes Must Be Unique
 
@@ -228,16 +228,16 @@ const vnode = <div id={dynamicId}>hello, {userName}</div>
 
 `create-vue` and Vue CLI both have options for scaffolding projects with pre-configured JSX support. If you are configuring JSX manually, please refer to the documentation of [`@vue/babel-plugin-jsx`](https://github.com/vuejs/jsx-next) for details.
 
-Although first introduced by React, JSX actually has no defined runtime semantics and can be compiled into various different output. If you have worked with JSX before, do note that **Vue JSX transform is different from React's JSX transform**, so you can't use React's JSX transform in Vue applications. Some notable differences from React JSX include:
+Although first introduced by React, JSX actually has no defined runtime semantics and can be compiled into various different outputs. If you have worked with JSX before, do note that **Vue JSX transform is different from React's JSX transform**, so you can't use React's JSX transform in Vue applications. Some notable differences from React JSX include:
 
 - You can use HTML attributes such as `class` and `for` as props - no need to use `className` or `htmlFor`.
-- Passing children to components (i.e. slots) [work differently](#passing-slots).
+- Passing children to components (i.e. slots) [works differently](#passing-slots).
 
 Vue's type definition also provides type inference for TSX usage. When using TSX, make sure to specify `"jsx": "preserve"` in `tsconfig.json` so that TypeScript leaves the JSX syntax intact for Vue JSX transform to process.
 
 ## Render Function Recipes
 
-Below we will provide some common recipes for implementating template feature equivalents in render function / JSX.
+Below we will provide some common recipes for implementing template features as their equivalent render functions / JSX.
 
 ### `v-if`
 
@@ -332,7 +332,7 @@ h(
 
 ### `v-on`
 
-Props with names that start with `on` followed by uppercase letter are treated as event listeners. For example, `onClick` is the equivalent of `@click` in templates.
+Props with names that start with `on` followed by an uppercase letter are treated as event listeners. For example, `onClick` is the equivalent of `@click` in templates.
 
 ```js
 h(
@@ -358,7 +358,7 @@ h(
 
 #### Event Modifiers
 
-For the `.passive`, `.capture`, and `.once` event modifiers, they can be concatenated after the event name using camel case.
+For the `.passive`, `.capture`, and `.once` event modifiers, they can be concatenated after the event name using camelCase.
 
 For example:
 
@@ -424,7 +424,7 @@ function render() {
 
 As we can see, `h` can work with components imported from any file format as long as it's a valid Vue component.
 
-Dynamic components are strightforward with render functions:
+Dynamic components are straightforward with render functions:
 
 ```js
 import Foo from './Foo.vue'
@@ -456,7 +456,7 @@ export default {
     return () => [
       // default slot:
       // <div><slot /></div>
-      h('div', slots.default())
+      h('div', slots.default()),
 
       // named slot:
       // <div><slot name="footer" :text="message" /></div>
@@ -492,7 +492,7 @@ export default {
   render() {
     return [
       // <div><slot /></div>
-      h('div', this.$slots.default())
+      h('div', this.$slots.default()),
 
       // <div><slot name="footer" :text="message" /></div>
       h(
@@ -528,7 +528,7 @@ h(MyComponent, () => 'hello')
 
 // named slots
 // notice the `null` is required to avoid
-// slots object being treated as props
+// the slots object being treated as props
 h(MyComponent, null, {
   default: () => 'default slot',
   foo: () => h('div', 'foo'),
@@ -550,7 +550,7 @@ JSX equivalent:
 }}</MyComponent>
 ```
 
-Passing slots as functions allows them to be invoked lazily by the child component. This makes a slot's dependncies to be tracked by the child instead of the parent, which results in more accurate and efficient updates.
+Passing slots as functions allows them to be invoked lazily by the child component. This leads to the slot's dependencies being tracked by the child instead of the parent, which results in more accurate and efficient updates.
 
 ### Built-in Components
 
@@ -559,7 +559,7 @@ Passing slots as functions allows them to be invoked lazily by the child compone
 <div class="composition-api">
 
 ```js
-import { h, KeepAlive, Teleport, Transition, TransitionGroup } from Vue
+import { h, KeepAlive, Teleport, Transition, TransitionGroup } from 'vue'
 
 export default {
   setup () {
@@ -572,7 +572,7 @@ export default {
 <div class="options-api">
 
 ```js
-import { h, KeepAlive, Teleport, Transition, TransitionGroup } from Vue
+import { h, KeepAlive, Teleport, Transition, TransitionGroup } from 'vue'
 
 export default {
   render () {
@@ -596,7 +596,7 @@ export default {
   setup(props, { emit }) {
     return () =>
       h(SomeComponent, {
-        modelValue: modelValue,
+        modelValue: props.modelValue,
         'onUpdate:modelValue': (value) => emit('update:modelValue', value)
       })
   }
@@ -626,7 +626,7 @@ export default {
 Custom directives can be applied to a vnode using [`withDirectives`](/api/render-function.html#withdirectives):
 
 ```js
-import { h, withDirectives } from Vue
+import { h, withDirectives } from 'vue'
 
 // a custom directive
 const pin = {

--- a/src/guide/extras/rendering-mechanism.md
+++ b/src/guide/extras/rendering-mechanism.md
@@ -10,7 +10,7 @@ How does Vue take a template and turn it into actual DOM nodes? How does Vue upd
 
 You have probably heard about the term virtual DOM, which Vue's rendering system is based upon.
 
-The virtual DOM (VDOM) is a programming concept where an ideal, or “virtual”, representation of a UI is kept in memory and synced with the “real” DOM. The concept is pioneered by [React](https://reactjs.org/), and has been adapted in many other frameworks with different implementations, including Vue.
+The virtual DOM (VDOM) is a programming concept where an ideal, or “virtual”, representation of a UI is kept in memory and synced with the “real” DOM. The concept was pioneered by [React](https://reactjs.org/), and has been adapted in many other frameworks with different implementations, including Vue.
 
 Virtual DOM is more of a pattern than a specific technology, so there is no one canonical implementation. We can illustrate the idea using a simple example:
 
@@ -26,39 +26,39 @@ const vnode = {
 }
 ```
 
-Here `vnode` is plain JavaScript object (a "virtual node") representing a `<div>` element. It contains all the information that we need to create the actual element. It also contains more children vnodes, which makes it the root of a virtual DOM tree.
+Here, `vnode` is a plain JavaScript object (a "virtual node") representing a `<div>` element. It contains all the information that we need to create the actual element. It also contains more children vnodes, which makes it the root of a virtual DOM tree.
 
 A runtime renderer can walk a virtual DOM tree and construct a real DOM tree from it. This process is called **mount**.
 
 If we have two copies of virtual DOM trees, the renderer can also walk and compare the two trees, figuring out the differences, and apply those changes to the actual DOM. This process is called **patch**, also known as "diffing" or "reconciliation".
 
-The main benefits of virtual DOM is that it gives the developer the ability to programmatically create, inspect and compose desired UI structures in a declarative way, while leaving the direct DOM manipulation to the renderer.
+The main benefit of virtual DOM is that it gives the developer the ability to programmatically create, inspect and compose desired UI structures in a declarative way, while leaving the direct DOM manipulation to the renderer.
 
 ## Render Pipeline
 
 At the high level, this is what happens when a Vue component is mounted:
 
-1. **Compile**: Vue templates are compiled into **render functions**: functions that return vritual DOM trees. This step can be done either ahead-of-time via a build step, or on-the-fly by using the runtime compiler.
+1. **Compile**: Vue templates are compiled into **render functions**: functions that return virtual DOM trees. This step can be done either ahead-of-time via a build step, or on-the-fly by using the runtime compiler.
 
-2. **Mount**: The runtime renderer invokes the render functions, walks the returned virtual DOM tree, and create actual DOM nodes based on it. This step is performed as a [reactive effect](./reactivity-in-depth) so it keeps track of all reactive dependencies that were used.
+2. **Mount**: The runtime renderer invokes the render functions, walks the returned virtual DOM tree, and creates actual DOM nodes based on it. This step is performed as a [reactive effect](./reactivity-in-depth), so it keeps track of all reactive dependencies that were used.
 
-3. **Patch**: When a dependency used during mount changes, the effect re-runs. This time, a new, updated Virtual DOM tree is created. The runtime renderer walks the new tree, compares it with the old one, and apply necessary updates to the actual DOM. This process is also known as "diffing" or "reconciliation".
+3. **Patch**: When a dependency used during mount changes, the effect re-runs. This time, a new, updated Virtual DOM tree is created. The runtime renderer walks the new tree, compares it with the old one, and applies necessary updates to the actual DOM. This process is also known as "diffing" or "reconciliation".
 
 ![render pipeline](./images/render-pipeline.png)
 
 <!-- https://www.figma.com/file/elViLsnxGJ9lsQVsuhwqxM/Rendering-Mechanism -->
 
-## Template vs. Render Functions
+## Templates vs. Render Functions
 
-Vue templates are compiled into virtual DOM render functions. Vue also provides APIs that allow us to skip the template compilation step and directly author render functions. Render functions are more flexible compared to templates when dealing with highly dynamic logic, because you can work with vnodes using the full power of JavaScript.
+Vue templates are compiled into virtual DOM render functions. Vue also provides APIs that allow us to skip the template compilation step and directly author render functions. Render functions are more flexible than templates when dealing with highly dynamic logic, because you can work with vnodes using the full power of JavaScript.
 
 So why does Vue recommend templates by default? There are a number of reasons:
 
 1. Templates are closer to actual HTML. This makes it easier to reuse existing HTML snippets, apply a11y best practices, style with CSS, and for designers to understand and modify.
 
-2. Templates are easier to statically analyze due to its more deterministic syntax. This allows Vue's template compiler to apply many compile-time optimizations to improve the performance of virtual DOM (which we will discuss below).
+2. Templates are easier to statically analyze due to their more deterministic syntax. This allows Vue's template compiler to apply many compile-time optimizations to improve the performance of the virtual DOM (which we will discuss below).
 
-In practice, templates are sufficient for most use cases in applications. Render functions are typically only used in reusable components that need to deal with highly dynamic rendering logic. Render function usage is discussed in more details in [Render Function & JSX](./render-function).
+In practice, templates are sufficient for most use cases in applications. Render functions are typically only used in reusable components that need to deal with highly dynamic rendering logic. Render function usage is discussed in more detail in [Render Functions & JSX](./render-function).
 
 ## Compiler-Informed Virtual DOM
 
@@ -66,7 +66,7 @@ The virtual DOM implementation in React and most other virtual-DOM implementatio
 
 But it doesn't have to be that way. In Vue, the framework controls both the compiler and the runtime. This allows us to implement many compile-time optimizations that only a tightly-coupled renderer can take advantage of. The compiler can statically analyze the template and leave hints in the generated code so that the runtime can take shortcuts whenever possible. At the same time, we still preserve the capability for the user to drop down to the render function layer for more direct control in edge cases. We call this hybrid approach **Compiler-Informed Virtual DOM**.
 
-Below, we will discuss a few major optimizations done by the Vue template compiler to improve virtual DOM's runtime performance.
+Below, we will discuss a few major optimizations done by the Vue template compiler to improve the virtual DOM's runtime performance.
 
 ### Static Hoisting
 
@@ -82,7 +82,7 @@ Quite often there will be parts in a template that do not contain any dynamic bi
 
 [Inspect in Template Explorer](https://vue-next-template-explorer.netlify.app/#eyJzcmMiOiI8ZGl2PlxuICA8ZGl2PmZvbzwvZGl2PlxuICA8ZGl2PmJhcjwvZGl2PlxuICA8ZGl2Pnt7IGR5bmFtaWMgfX08L2Rpdj5cbjwvZGl2PiIsInNzciI6ZmFsc2UsIm9wdGlvbnMiOnsiaG9pc3RTdGF0aWMiOnRydWV9fQ==)
 
-The `foo` and `bar` divs are static - re-creating vnodes and diffing them on each re-render is unnecessary. The Vue compiler automatically hoists their vnode creation calls out of the render function, and reuse the same vnodes on every render. The renderer is also able to completely skips diffing them when it notices the old vnode and the new vnode are the same one.
+The `foo` and `bar` divs are static - re-creating vnodes and diffing them on each re-render is unnecessary. The Vue compiler automatically hoists their vnode creation calls out of the render function, and reuses the same vnodes on every render. The renderer is also able to completely skip diffing them when it notices the old vnode and the new vnode are the same one.
 
 In addition, when there are enough consecutive static elements, they will be condensed into a single "static vnode" that contains the plain HTML string for all these nodes ([Example](https://vue-next-template-explorer.netlify.app/#eyJzcmMiOiI8ZGl2PlxuICA8ZGl2IGNsYXNzPVwiZm9vXCI+Zm9vPC9kaXY+XG4gIDxkaXYgY2xhc3M9XCJmb29cIj5mb288L2Rpdj5cbiAgPGRpdiBjbGFzcz1cImZvb1wiPmZvbzwvZGl2PlxuICA8ZGl2IGNsYXNzPVwiZm9vXCI+Zm9vPC9kaXY+XG4gIDxkaXYgY2xhc3M9XCJmb29cIj5mb288L2Rpdj5cbiAgPGRpdj57eyBkeW5hbWljIH19PC9kaXY+XG48L2Rpdj4iLCJzc3IiOmZhbHNlLCJvcHRpb25zIjp7ImhvaXN0U3RhdGljIjp0cnVlfX0=)). These static vnodes are mounted by directly setting `innerHTML`. They also cache their corresponding DOM nodes on initial mount - if the same piece of content is reused elsewhere in the app, new DOM nodes are created using native `cloneNode()`, which is extremely efficient.
 
@@ -111,7 +111,7 @@ createElementVNode("div", {
 }, null, 2 /* CLASS */)
 ```
 
-The last argument `2` is a [patch flag](https://github.com/vuejs/core/blob/main/packages/shared/src/patchFlags.ts). An element can have multiple patch flags, which will be merged into a single number. The runtime renderer can then check against the flags using [bitwise operations](https://en.wikipedia.org/wiki/Bitwise_operation) to determine whether it needs to do certain work:
+The last argument, `2`, is a [patch flag](https://github.com/vuejs/core/blob/main/packages/shared/src/patchFlags.ts). An element can have multiple patch flags, which will be merged into a single number. The runtime renderer can then check against the flags using [bitwise operations](https://en.wikipedia.org/wiki/Bitwise_operation) to determine whether it needs to do certain work:
 
 ```js
 if (vnode.patchFlag & PatchFlags.CLASS /* 2 */) {
@@ -131,7 +131,7 @@ export function render() {
 }
 ```
 
-The runtime can thus completely skip children order reconciliation for the root fragment.
+The runtime can thus completely skip child-order reconciliation for the root fragment.
 
 ### Tree Flattening
 
@@ -147,7 +147,7 @@ export function render() {
 
 Conceptually, a "block" is a part of the template that has stable inner structure. In this case, the entire template has a single block because it does not contain any structural directives like `v-if` and `v-for`.
 
-Each block tracks its descendent nodes (not just direct children) that has patch flags. For example:
+Each block tracks any descendent nodes (not just direct children) that have patch flags. For example:
 
 ```vue-html{3,5}
 <div> <!-- root block -->
@@ -167,7 +167,7 @@ div (block root)
 - div with {{ bar }} binding
 ```
 
-When this component needs to re-render, it only needs to traverse the flattened tree instead of the full tree. This is called **Tree Flattening**, and it greatly reduces the amount of nodes that need to be traversed during virtual DOM reconciliation. Any static parts of the template are effectively skipped.
+When this component needs to re-render, it only needs to traverse the flattened tree instead of the full tree. This is called **Tree Flattening**, and it greatly reduces the number of nodes that need to be traversed during virtual DOM reconciliation. Any static parts of the template are effectively skipped.
 
 `v-if` and `v-for` directives will create new block nodes:
 
@@ -181,12 +181,12 @@ When this component needs to re-render, it only needs to traverse the flattened 
 </div>
 ```
 
-A child block is tracked inside the parent block's dynamic children array. This retains a stable structure for their parent block.
+A child block is tracked inside the parent block's array of dynamic descendents. This retains a stable structure for the parent block.
 
 ### Impact on SSR Hydration
 
 Both patch flags and tree flattening also greatly improve Vue's [SSR Hydration](/guide/scaling-up/ssr.html#client-hydration) performance:
 
-- Single element hydration can take fast paths based on corresponding vnode's patch flag.
+- Single element hydration can take fast paths based on the corresponding vnode's patch flag.
 
-- Only block nodes and their dynamic children need to be traversed during hydration, effectively achieving partial hydration at the template level.
+- Only block nodes and their dynamic descendents need to be traversed during hydration, effectively achieving partial hydration at the template level.

--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -42,13 +42,13 @@ Before using SSR for your app, the first question you should ask is whether you 
 
 SSG retains the same performance characteristics of SSR apps: it provides great time-to-content performance. At the same time, it is cheaper and easier to deploy than SSR apps because the output is static HTML and assets. The keyword here is **static**: SSG can only be applied to pages consuming static data, i.e. data that is known at build time and does not change between deploys. Every time the data changes, a new deployment is needed.
 
-If you're only investigating SSR to improve the SEO of a handful of marketing pages (e.g. `/`, `/about`, `/contact`, etc), then you probably want SSG instead of SSR. SSG is also great for content-based websites such as documentation sites or blogs. In fact, this website you are reading right now is statically generated using [VitePress](https://vitepress.vuejs.org/), a Vue-powered static site generator.
+If you're only investigating SSR to improve the SEO of a handful of marketing pages (e.g. `/`, `/about`, `/contact`, etc.), then you probably want SSG instead of SSR. SSG is also great for content-based websites such as documentation sites or blogs. In fact, this website you are reading right now is statically generated using [VitePress](https://vitepress.vuejs.org/), a Vue-powered static site generator.
 
 ## Basic Tutorial
 
 ### Rendering an App
 
-Let's take a look at the most bare-bone example of Vue SSR in action.
+Let's take a look at the most bare-bones example of Vue SSR in action.
 
 1. Create a new directory and `cd` into it
 2. Run `npm init -y`
@@ -84,7 +84,7 @@ It should print the following to the command line:
 <button>1</button>
 ```
 
-[`renderToString()`](/api/ssr.html#rendertostring) takes a Vue app instance and returns a Promise that resolves to the rendered HTML of the app. It is also possible to perform streaming render using [Node.js Stream API](https://nodejs.org/api/stream.html) or [Web Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API). Check out the [SSR API Reference](/api/ssr.html) for full details.
+[`renderToString()`](/api/ssr.html#rendertostring) takes a Vue app instance and returns a Promise that resolves to the rendered HTML of the app. It is also possible to stream rendering using the [Node.js Stream API](https://nodejs.org/api/stream.html) or [Web Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API). Check out the [SSR API Reference](/api/ssr.html) for full details.
 
 We can then move the Vue SSR code into a server request handler, which wraps the application markup with the full page HTML. We will be using [`express`](https://expressjs.com/) for the next steps:
 
@@ -205,7 +205,7 @@ In addition, in order to load the client files in the browser, we also need to:
 
 Moving from the example to a production-ready SSR app involves a lot more. We will need to:
 
-- Support Vue SFCs and other build step requirements. In fact, we will need to coordinate two builds for the same app: once for the client, and once for the server.
+- Support Vue SFCs and other build step requirements. In fact, we will need to coordinate two builds for the same app: one for the client, and one for the server.
 
   :::tip
   Vue components are compiled differently when used for SSR - templates are compiled into string concatenations instead of Virtual DOM render functions for more efficient rendering performance.
@@ -249,11 +249,11 @@ You should avoid code that produces side effects that need cleanup in <span clas
 
 Universal code cannot assume access to platform-specific APIs, so if your code directly uses browser-only globals like `window` or `document`, they will throw errors when executed in Node.js, and vice-versa.
 
-For tasks shared between server and client but use different platform APIs, it's recommended to wrap the platform-specific implementations inside a universal API, or use libraries that do this for you. For example, you can use [`node-fetch`](https://github.com/node-fetch/node-fetch) to use the same fetch API on both server and client.
+For tasks that are shared between server and client but with different platform APIs, it's recommended to wrap the platform-specific implementations inside a universal API, or use libraries that do this for you. For example, you can use [`node-fetch`](https://github.com/node-fetch/node-fetch) to use the same fetch API on both server and client.
 
 For browser-only APIs, the common approach is to lazily access them inside client-only lifecycle hooks such as <span class="options-api">`mounted`</span><span class="composition-api">`onMounted`</span>.
 
-Note that if a 3rd party library is not written with universal usage in mind, it could be tricky to integrate it into an server-rendered app. You _might_ be able to get it working by mocking some of the globals, but it would be hacky and may interfere with the environment detection code of other libraries.
+Note that if a third-party library is not written with universal usage in mind, it could be tricky to integrate it into an server-rendered app. You _might_ be able to get it working by mocking some of the globals, but it would be hacky and may interfere with the environment detection code of other libraries.
 
 ### Cross-Request State Pollution
 
@@ -265,7 +265,7 @@ However, in an SSR context, the application modules are typically initialized on
 
 We can technically re-initialize all the JavaScript modules on each request, just like we do in browsers. However, initializing JavaScript modules can be costly, so this would significantly affect server performance.
 
-The recommended solution is to create a new instance of the entire application - including the router and global stores - on each request. The, instead of directly importing it in our components, we provide the shared state using [app-level provide](/guide/components/provide-inject.html#app-level-provide) and inject it in components that need it:
+The recommended solution is to create a new instance of the entire application - including the router and global stores - on each request. Then, instead of directly importing it in our components, we provide the shared state using [app-level provide](/guide/components/provide-inject.html#app-level-provide) and inject it in components that need it:
 
 ```js
 // app.js (shared between server and client)
@@ -287,7 +287,7 @@ State Management libraries like Pinia are designed with this in mind. Consult [P
 
 ### Hydration Mismatch
 
-If the DOM structure of the pre-rendered HTML does not match the expected output of the client-side app, there will be a hydration mismatch error. In most cases, this is caused by browser's native HTML parsing behavior trying to correct invalid structures in the HTML string. For example, a common gotcha is that [`<div>` cannot be placed inside `<p>`](https://stackoverflow.com/questions/8397852/why-cant-the-p-tag-contain-a-div-tag-inside-it):
+If the DOM structure of the pre-rendered HTML does not match the expected output of the client-side app, there will be a hydration mismatch error. In most cases, this is caused by the browser's native HTML parsing behavior trying to correct invalid structures in the HTML string. For example, a common gotcha is that [`<div>` cannot be placed inside `<p>`](https://stackoverflow.com/questions/8397852/why-cant-the-p-tag-contain-a-div-tag-inside-it):
 
 ```html
 <p><div>hi</div></p>
@@ -301,7 +301,7 @@ If we produce this in our server-rendered HTML, the browser will terminate the f
 <p></p>
 ```
 
-When Vue encounters a hydration mismatch, it will attempt to automatically recover and adjust the pre-rendered DOM to match the client side state. This will lead to some rendering performance loss due to incorrect nodes being discarded and new nodes being mounted, but in most cases, the app should continue to work as expected. That said, it is still best to eliminate hydration mismatches during development.
+When Vue encounters a hydration mismatch, it will attempt to automatically recover and adjust the pre-rendered DOM to match the client-side state. This will lead to some rendering performance loss due to incorrect nodes being discarded and new nodes being mounted, but in most cases, the app should continue to work as expected. That said, it is still best to eliminate hydration mismatches during development.
 
 ### Custom Directives
 
@@ -313,7 +313,7 @@ const myDirective = {
     el.id = 'foo'
   },
   getSSRProps(binding, vnode) {
-    // the hook the directive binding and the element vnode as arguments.
+    // the hook is passed the directive binding and the element vnode.
     // return props to be added to the vnode.
     return {
       id: 'foo'

--- a/src/guide/scaling-up/state-management.md
+++ b/src/guide/scaling-up/state-management.md
@@ -163,7 +163,7 @@ However, this also means any component importing `store` can mutate it however t
 </template>
 ```
 
-While this works in simple cases, global state that can be arbitrarily mutated by any component is not going to be very maintainable for the long run. To ensure the state-mutating logic is centralized like the state itself, it is recommended to define methods on the store with names that express the intention of the actions:
+While this works in simple cases, global state that can be arbitrarily mutated by any component is not going to be very maintainable in the long run. To ensure the state-mutating logic is centralized like the state itself, it is recommended to define methods on the store with names that express the intention of the actions:
 
 ```js{6-8}
 // store.js
@@ -238,6 +238,6 @@ While our hand-rolled state management solution will suffice in simple scenarios
 
 Existing users may be familiar with [Vuex](https://vuex.vuejs.org/), the previous official state management library for Vue. With Pinia serving the same role in the ecosystem, Vuex is now in maintenance mode. It still works, but will no longer receive new features. It is recommended to use Pinia for new applications.
 
-Pinia in fact started as an exploration for how the next iteration of Vuex would look like, incorporating many ideas from core team discussions for Vuex 5. Eventually, we realized that Pinia already implements most of what we wanted in Vuex 5, and decided to make it the new recommendation instead.
+Pinia started out as an exploration of what the next iteration of Vuex could look like, incorporating many ideas from core team discussions for Vuex 5. Eventually, we realized that Pinia already implements most of what we wanted in Vuex 5, and decided to make it the new recommendation instead.
 
 Compared to Vuex, Pinia provides a simpler API with less ceremony, offers Composition-API-style APIs, and most importantly, has solid type inference support when used with TypeScript.

--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -10,9 +10,9 @@ In a Vue application, there are different types of concerns that can be covered 
 
 - **Visual**: given certain input props / state, verify that an isolated component or component tree is rendering the correct visual output.
 
-- **Interaction**: given a simulate user behavior such as click or input, verify that an isolated component or component tree renders correct, updated output.
+- **Interaction**: simulate user behavior, such as a click or input, and verify that an isolated component or component tree renders correct, updated output.
 
-- **User Flow**: given a sequence of user interactions that are necessary to complete an actual user task, whether the application as a whole is working as expected.
+- **User Flow**: given a sequence of user interactions that are necessary to complete an actual user task, check whether the application as a whole is working as expected.
 
 For different testing concerns, we need to use different testing techniques:
 
@@ -62,13 +62,13 @@ Component tests should focus on the component's public interfaces rather than in
 
   Assert the private state of a component instance or test the private methods of a component. Testing implementation details makes the tests brittle, as they are more likely to break and require updates when the implementation changes.
 
-  The component's ultimate job is rendering the correct DOM output, so the tests focusing on the DOM output provides the same level of correctness assurance (if not more) while being more robust and resistant to change.
+  The component's ultimate job is rendering the correct DOM output, so tests focusing on the DOM output provide the same level of correctness assurance (if not more) while being more robust and resilient to change.
 
   If a method needs to be tested, extract it into a standalone utility function and write a dedicated unit test for it. If it cannot be extracted cleanly, it should be tested as a part of an interaction test that invokes it.
 
 ### Recommendation
 
-- [Vitest](https://vitest.dev/) or other unit test frameworks mentioned above can be used for component testing by simulating the DOM in Node.js. See [Adding Vitest to a Project](#adding-vitest-to-a-project) for more details.
+- [Vitest](https://vitest.dev/) or the other unit testing frameworks mentioned above can be used for component testing by simulating the DOM in Node.js. See [Adding Vitest to a Project](#adding-vitest-to-a-project) for more details.
 
 ### Libraries
 
@@ -84,7 +84,7 @@ We recommend using `@testing-library/vue` for testing components in applications
 
 - [Cypress](https://www.cypress.io/) is an E2E test solution, but it also supports [Component Testing](https://docs.cypress.io/guides/component-testing/introduction) which can test components in real browsers with a GUI that shows the actual DOM state during tests.
 
-- [Nightwatch](https://v2.nightwatchjs.org/) is another E2E test runner with Vue Component Testing support. ([Exmaple Project](https://github.com/nightwatchjs-community/todo-vue) in Nightwatch v2)
+- [Nightwatch](https://v2.nightwatchjs.org/) is another E2E test runner with Vue Component Testing support. ([Example Project](https://github.com/nightwatchjs-community/todo-vue) in Nightwatch v2)
 
 ## E2E Testing
 
@@ -104,13 +104,13 @@ One of the primary benefits that end-to-end (E2E) testing is known for is its ab
 
 One of the primary problems with end-to-end (E2E) tests and development is that running the entire suite takes a long time. Typically, this is only done in continuous integration and deployment (CI/CD) pipelines. Modern E2E testing frameworks have helped to solve this by adding features like parallelization, which allows for CI/CD pipelines to often run magnitudes faster than before. In addition, when developing locally, the ability to selectively run a single test for the page you are working on while also providing hot reloading of tests can help to boost a developer's workflow and productivity.
 
-#### First class debugging experience
+#### First-class debugging experience
 
 While developers have traditionally relied on scanning logs in a terminal window to help determine what went wrong in a test, modern end-to-end (E2E) test frameworks allow developers to leverage tools that they are already familiar with, e.g. browser developer tools.
 
 #### Visibility in headless mode
 
-When end-to-end (E2E) tests are run in continuous integration / deployment pipelines, they are often run in headless browsers (i.e., no visible browser is opened for the user to watch). As a result, when errors occur, a critical feature that modern E2E testing frameworks provide 1st class support for is the ability to see snapshots and/or videos of your applications during various testing stages in order to provide insight into why errors are happening. Historically, it was tedious to maintain these integrations.
+When end-to-end (E2E) tests are run in continuous integration / deployment pipelines, they are often run in headless browsers (i.e., no visible browser is opened for the user to watch). A critical feature of modern E2E testing frameworks is the ability to see snapshots and/or videos of the application during testing, providing some insight into why errors are happening. Historically, it was tedious to maintain these integrations.
 
 ### Recommendation
 

--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -31,7 +31,7 @@ const props = defineProps<{
 </script>
 ```
 
-This is called "type-based declaration". The compiler will try to do its best to infer the equivalent runtime options based on the type argument. In this case, our second example compiles into the exact same runtime options from the first one.
+This is called "type-based declaration". The compiler will try to do its best to infer the equivalent runtime options based on the type argument. In this case, our second example compiles into the exact same runtime options as the first example.
 
 You can use either type-based declaration OR runtime declaration, but you cannot use both at the same time.
 
@@ -200,7 +200,7 @@ It's not recommended to use the generic argument of `reactive()` because the ret
 ```ts
 import { ref, computed } from 'vue'
 
-let count = ref(0)
+const count = ref(0)
 
 // inferred type: ComputedRef<number>
 const double = computed(() => count.value * 2)
@@ -209,7 +209,7 @@ const double = computed(() => count.value * 2)
 const result = double.value.split('')
 ```
 
-You can also specify an explicit type via generic argument:
+You can also specify an explicit type via a generic argument:
 
 ```ts
 const double = computed<number>(() => {
@@ -244,8 +244,7 @@ function handleChange(event: Event) {
 
 ## Typing Provide / Inject
 
-Provide and inject are usually performed in separate components. To properly type injected values,
-Vue provides an `InjectionKey` interface which is a generic type that extends `Symbol`. It can be used to sync the type of the injected value between the provider and the consumer:
+Provide and inject are usually performed in separate components. To properly type injected values, Vue provides an `InjectionKey` interface, which is a generic type that extends `Symbol`. It can be used to sync the type of the injected value between the provider and the consumer:
 
 ```ts
 import { provide, inject, InjectionKey } from 'vue'
@@ -285,7 +284,7 @@ Template refs should be created with an explicit generic type argument and an in
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 
 const el = ref<HTMLInputElement | null>(null)
 

--- a/src/guide/typescript/options-api.md
+++ b/src/guide/typescript/options-api.md
@@ -76,7 +76,7 @@ interface Book {
   year?: number
 }
 
-const Component = defineComponent({
+export default defineComponent({
   props: {
     bookA: {
       type: Object as PropType<Book>,
@@ -142,19 +142,19 @@ export default defineComponent({
 })
 ```
 
-In some cases, you may want to explicit annotate the type of a computed property to ensure its implementation is correct:
+In some cases, you may want to explicitly annotate the type of a computed property to ensure its implementation is correct:
 
 ```ts
 import { defineComponent } from 'vue'
 
-const Component = defineComponent({
+export default defineComponent({
   data() {
     return {
       message: 'Hello!'
     }
   },
   computed: {
-    // explicit annotate return type
+    // explicitly annotate return type
     greeting(): string {
       return this.message + '!'
     },
@@ -180,14 +180,16 @@ When dealing with native DOM events, it might be useful to type the argument we 
 
 ```vue
 <script lang="ts">
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   methods: {
     handleChange(event) {
       // `event` implicitly has `any` type
       console.log(event.target.value)
     }
   }
-}
+})
 </script>
 
 <template>
@@ -198,13 +200,15 @@ export default {
 Without type annotation, the `event` argument will implicitly have a type of `any`. This will also result in a TS error if `"strict": true` or `"noImplicitAny": true` are used in `tsconfig.json`. It is therefore recommended to explicitly annotate the argument of event handlers. In addition, you may need to explicitly cast properties on `event`:
 
 ```ts
-export default {
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   methods: {
     handleChange(event: Event) {
       console.log((event.target as HTMLInputElement).value)
     }
   }
-}
+})
 ```
 
 ## Augmenting Global Properties
@@ -234,7 +238,7 @@ In order to take advantage of module augmentation, you will need to ensure the a
 
 ## Augmenting Custom Options
 
-Some plugins, for example `vue-router`, provides support for custom component options such as `beforeRouteEnter`:
+Some plugins, for example `vue-router`, provide support for custom component options such as `beforeRouteEnter`:
 
 ```ts
 import { defineComponent } from 'vue'
@@ -253,12 +257,12 @@ import { Route } from 'vue-router'
 
 declare module 'vue' {
   interface ComponentCustomOptions {
-    beforeRouteEnter?(to: any, from: any, next: () => void): void
+    beforeRouteEnter?(to: Route, from: Route, next: () => void): void
   }
 }
 ```
 
-Now the `beforeRouterEnter` option will be properly typed. Note this is just an example - well-typed libraries like `vue-router` should automatically perform these augmentations in their own type definitions.
+Now the `beforeRouteEnter` option will be properly typed. Note this is just an example - well-typed libraries like `vue-router` should automatically perform these augmentations in their own type definitions.
 
 The placement of this augmentation is subject the [same restrictions](#type-augmentation-placement) as global property augmentations.
 

--- a/src/guide/typescript/overview.md
+++ b/src/guide/typescript/overview.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Using Vue with TypeScript
 
-A type system like TypeScript can detect many common errors via static analysis at build time. This reduces the chance of runtime errors in production, and also allows us to more confidently refactor code in large scale applications. TypeScript also improves developer ergonomics via type-based auto-completion in IDEs.
+A type system like TypeScript can detect many common errors via static analysis at build time. This reduces the chance of runtime errors in production, and also allows us to more confidently refactor code in large-scale applications. TypeScript also improves developer ergonomics via type-based auto-completion in IDEs.
 
 Vue is written in TypeScript itself and provides first-class TypeScript support. All official Vue packages come with bundled type declarations that should work out-of-the-box.
 
@@ -46,9 +46,9 @@ When configuring `tsconfig.json` manually, some notable options include:
 
 - [`compilerOptions.isolatedModules`](https://www.typescriptlang.org/tsconfig#isolatedModules) is set to `true` because Vite uses [esbuild](https://esbuild.github.io/) for transpiling TypeScript and is subject to single-file transpile limitations.
 
-- If using Options API, it is required to set [`compilerOptions.strict`](https://www.typescriptlang.org/tsconfig#strict) to `true` (or at least enable [`compilerOptions.noImplicitThis`](https://www.typescriptlang.org/tsconfig#noImplicitThis) which is a part of the `strict` flag) to leverage type checking of `this` in component options. Otherwise `this` will be treated as `any`.
+- If you're using Options API, you need to set [`compilerOptions.strict`](https://www.typescriptlang.org/tsconfig#strict) to `true` (or at least enable [`compilerOptions.noImplicitThis`](https://www.typescriptlang.org/tsconfig#noImplicitThis), which is a part of the `strict` flag) to leverage type checking of `this` in component options. Otherwise `this` will be treated as `any`.
 
-- If you have configured resolver alias in your build tool, for example the `@/*` alias configured by default in a `create-vue` project, you need to also configure it for TypeScript via [`compilerOptions.paths`](https://www.typescriptlang.org/tsconfig#paths).
+- If you have configured resolver aliases in your build tool, for example the `@/*` alias configured by default in a `create-vue` project, you need to also configure it for TypeScript via [`compilerOptions.paths`](https://www.typescriptlang.org/tsconfig#paths).
 
 See also:
 
@@ -65,7 +65,7 @@ Volar provides a feature called "Takeover Mode" to improve performance. In takeo
 
 To enable Takeover Mode, you need to disable VSCode's built-in TS language service in **your project's workspace only** by following these steps:
 
-1. In your project workspace, bring up the command pallette with `Ctrl + Shift + P` (macOS: `Cmd + Shift + P`).
+1. In your project workspace, bring up the command palette with `Ctrl + Shift + P` (macOS: `Cmd + Shift + P`).
 2. Type `built` and select "Extensions: Show Built-in Extensions".
 3. Type `typescript` in the extension search box (do not remove `@builtin` prefix).
 4. Click the little gear icon of "TypeScript and JavaScript Language Features", and select "Disable (Workspace)".
@@ -77,7 +77,7 @@ To enable Takeover Mode, you need to disable VSCode's built-in TS language servi
 
 In webpack-based setups such as Vue CLI, it is common to perform type checking as part of the module transform pipeline, for example with `ts-loader`. This, however, isn't a clean solution because the type system needs knowledge of the entire module graph to perform type checks. Individual module's transform step simply is not the right place for the task. It leads to the following problems:
 
-- `ts-loader` can only type check post-transform code. This doesn't align with the errors we see in IDEs or from `vue-tsc`, which maps directly back to the source code.
+- `ts-loader` can only type check post-transform code. This doesn't align with the errors we see in IDEs or from `vue-tsc`, which map directly back to the source code.
 
 - Type checking can be slow. When it is performed in the same thread / process with code transformations, it significantly affects the build speed of the entire application.
 
@@ -89,7 +89,7 @@ If you are currently using Vue 3 + TypeScript via Vue CLI, we strongly recommend
 
 ### `defineComponent()`
 
-To let TypeScript properly infer types inside component options, we need to define components with [`defineComponent()`](/api/general.html#definecomponent) global API:
+To let TypeScript properly infer types inside component options, we need to define components with [`defineComponent()`](/api/general.html#definecomponent):
 
 ```ts
 import { defineComponent } from 'vue'
@@ -204,7 +204,7 @@ let x: string | number = 1
 ```
 
 :::tip
-If using Vue CLI or webpack-based setup, TypeScript in template expressions requires `vue-loader@^16.8.0`.
+If using Vue CLI or a webpack-based setup, TypeScript in template expressions requires `vue-loader@^16.8.0`.
 :::
 
 ## API-Specific Recipes


### PR DESCRIPTION
Following on from #1366 and #1432, I've now finished going through the guides and these are relatively minor tweaks to the remaining pages.

Some are more subjective than others. Even if the original wording was technically correct, I tried to reword anything that caused me to stumble on first reading.

Let me know if anything is unclear or contentious.