### PR TITLE
fix: Inconsistent word "radius" vs "diameter" in doc

### DIFF
--- a/src/examples/src/circle-drawer/App/template.html
+++ b/src/examples/src/circle-drawer/App/template.html
@@ -22,6 +22,6 @@
 </div>
 
 <div class="dialog" v-if="adjusting" @click.stop>
-  <p>Adjust diameter of circle at ({{ selected.cx }}, {{ selected.cy }})</p>
+  <p>Adjust radius of circle at ({{ selected.cx }}, {{ selected.cy }})</p>
   <input type="range" v-model="selected.r" min="1" max="300" />
 </div>


### PR DESCRIPTION
## Description of Problem

Inconsistent word "radius" vs "diameter" in docs - examples - circle.

## Proposed Solution

Use "radius".
The program source seems to handle the interfacing value as radius.
Diameter seems to be generated within the internal logic and it is not obvious to the user.

## Additional Information
