### PR TITLE
correct spoken language

### DIFF
--- a/src/about/team/members-partner.json
+++ b/src/about/team/members-partner.json
@@ -335,7 +335,7 @@
     "company": "Fatec Taquaritinga",
     "companyLink": "http://www.fatectq.edu.br/",
     "location": "Taquaritinga, Brazil",
-    "languages": ["Polish", "English"],
+    "languages": ["Portuguese", "English"],
     "projects": [
       {
         "label": "vuejs-br/br.vuejs.org",


### PR DESCRIPTION
## Description of Problem

In docs - about, a partner member who is located in Brazil and working for institutions in Brazil is marked as "Polish" speaker.
Most probably this could be a simple mistake in edit and it should be meant as "Portuguese".

## Proposed Solution

replace Polish -> Portuguese

## Additional Information

I've asked this member directly via email and awaiting for reply.