### PR TITLE
fix: expose configureCompat types

### DIFF
--- a/src/guide/migration/migration-build.md
+++ b/src/guide/migration/migration-build.md
@@ -163,6 +163,8 @@ The following workflow walks through the steps of migrating an actual Vue 2 app 
      const Vue: CompatVue
      export default Vue
      export * from '@vue/runtime-dom'
+     const { configureCompat } = Vue
+     export { configureCompat }
    }
    ```
 


### PR DESCRIPTION
## Description of Problem

With the proposed d.ts file it's not possible to use `configureCompat`

## Proposed Solution

Add `configureCompat` to the d.ts exports.

## Additional Information

Related file:
https://github.com/vuejs/core/blob/293b41ba3be095452f9648b0b35dfd9022a3621e/packages/vue-compat/src/esm-index.ts

Also see:
https://github.com/vuejs/core/issues/4330#issuecomment-914590969