### PR TITLE
add clarification about type exports in SFCs

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -223,7 +223,7 @@ const attrs = useAttrs()
 `<script setup>` can be used alongside normal `<script>`. A normal `<script>` may be needed in cases where you need to:
 
 - Declare options that cannot be expressed in `<script setup>`, for example `inheritAttrs` or custom options enabled via plugins.
-- Declaring named exports (including TypeScript types)
+- Declaring named exports (including TypeScript types).
 - Run side effects or create objects that should only execute once.
 
 ```vue

--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -223,7 +223,7 @@ const attrs = useAttrs()
 `<script setup>` can be used alongside normal `<script>`. A normal `<script>` may be needed in cases where you need to:
 
 - Declare options that cannot be expressed in `<script setup>`, for example `inheritAttrs` or custom options enabled via plugins.
-- Declaring named exports.
+- Declaring named exports (including TypeScript types)
 - Run side effects or create objects that should only execute once.
 
 ```vue
@@ -264,6 +264,23 @@ In addition, the awaited expression will be automatically compiled in a format t
 :::
 
 ## TypeScript-only Features
+
+### Additional type exports
+
+As noted above, in order to export additional types from an SFC, they must be moved to an additional `<script>` block alongside the `<script setup>` block.
+
+For example
+```vue
+<script lang="ts">
+export type SizeOptions = 'small' | 'medium' | 'large';
+</script>
+
+<script lang="ts" setup>
+defineProps({
+  size: { type: String as PropType<SizeOptions> },
+})
+</script>
+```
 
 ### Type-only props/emit declarations
 


### PR DESCRIPTION
## Description of Problem

Latest vue / volar / vue-tsc complains when exporting additional types from SFCs (even though it worked previously). It seems this may be the intended behaviour (please confirm!) but was a bit unclear in these docs.

## Proposed Solution
This change specifically calls out exporting types and provides a short example.

## Additional Information
