### PR TITLE
docs: fix typo

### DIFF
--- a/src/api/sfc-css-features.md
+++ b/src/api/sfc-css-features.md
@@ -120,7 +120,7 @@ A `<style module>` tag is compiled as [CSS Modules](https://github.com/css-modul
 
 The resulting classes are hashed to avoid collision, achieving the same effect of scoping the CSS to the current component only.
 
-Refer to the [CSS Modules spec](https://github.com/css-modules/css-modules) for mode details such as [global exceptions](https://github.com/css-modules/css-modules#exceptions) and [composition](https://github.com/css-modules/css-modules#composition).
+Refer to the [CSS Modules spec](https://github.com/css-modules/css-modules) for more details such as [global exceptions](https://github.com/css-modules/css-modules#exceptions) and [composition](https://github.com/css-modules/css-modules#composition).
 
 ### Custom Inject Name
 


### PR DESCRIPTION
## Description of Problem

Typo in the phrase "for mode details" (mode => more)

## Proposed Solution

Change "mode" to "more"

## Additional Information
