### PR TITLE
docs: fix typo

### DIFF
--- a/src/guide/essentials/application.md
+++ b/src/guide/essentials/application.md
@@ -43,8 +43,7 @@ We will discuss how to define and compose multiple components together in later 
 
 ## Mounting the App
 
-An application instance won't render anything until its `.mount()` method is called.
-It expects a "container" argument, which can either be an actual DOM element or a selector string:
+An application instance won't render anything until its `.mount()` method is called. It expects a "container" argument, which can either be an actual DOM element or a selector string:
 
 ```html
 <div id="app"></div>


### PR DESCRIPTION
## Description of Problem

When I proofread the Chinese translation document, I found that these two lines could be combined and there was no need to split them into two lines.
You can reference [this](https://github.com/vuejs-translations/docs-zh-cn/pull/17)
