### PR TITLE
fix: special sponsors link on homepage is broken

### DIFF
--- a/.vitepress/theme/components/Home.vue
+++ b/.vitepress/theme/components/Home.vue
@@ -36,7 +36,7 @@ import SponsorsGroup from './SponsorsGroup.vue';
   <!-- TODO make dynamic based on data -->
   <section id="special-sponsor">
     <span>Special Sponsor</span>
-    <a href="#">
+    <a href="https://www.dcloud.io/hbuilderx.html?hmsr=vue-en&hmpl=&hmcu=&hmkw=&hmci=">
       <picture>
         <source type="image/avif" srcset="/images/sponsors/hbuilder.avif" />
         <img


### PR DESCRIPTION
User reported that the Special Sponsors link for hbuilderx is broken. This fixes that.