### PR TITLE
Update PreferenceSwitch.vue

### DIFF
--- a/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/.vitepress/theme/components/PreferenceSwitch.vue
@@ -234,6 +234,10 @@ function useToggleFn(
   transform: translateX(18px);
 }
 
+.vt-switch-check {
+  background-color: var(--vt-c-green);
+}
+
 .composition-label,
 .sfc-label,
 .prefer-composition .options-label,


### PR DESCRIPTION
To make the preference switch between Option API and Composition API looks more align with the theme.

## Description of Problem
The small problem is that the style of preference switcher is in gray color and that's not clearly reflects wether the Option or Composition API is in active state.
## Proposed Solution
Add css style to make the background of the API preference switch show as a primary theme color (green)
## Additional Information
from:
![image](https://user-images.githubusercontent.com/71051032/153567560-110b2769-6719-4421-8646-3f8f438d5f46.png)
![image](https://user-images.githubusercontent.com/71051032/153567605-c8801a18-8096-473e-aba5-8a0b0cb6913b.png)


to:
![image](https://user-images.githubusercontent.com/71051032/153567362-ab088ba9-11e3-4918-b1f5-d6b2b44411e6.png)
![image](https://user-images.githubusercontent.com/71051032/153567453-b12e1ed9-5cab-42f0-b290-92c02ff55b2c.png)


