### PR TITLE
Use counter variable, not undefined state

### DIFF
--- a/src/tutorial/src/step-2/description.md
+++ b/src/tutorial/src/step-2/description.md
@@ -63,7 +63,7 @@ Properties in the returned object will be made available in the template. This i
 
 ```vue-html
 <h1>{{ message }}</h1>
-<p>count is: {{ state.count }}</p>
+<p>count is: {{ counter.count }}</p>
 ```
 
 Notice how we did not need to use `.value` when accessing the `message` ref in templates: it is automatically unwrapped for more succinct usage.


### PR DESCRIPTION
## Description of Problem
The variable `state` is not defined in the context. On top you can find the `counter` variable though.
It's kind of irritating.

## Proposed Solution
Change variable.

## Additional Information
