### PR TITLE
Add info about v-bind in CSS under CSSProperties

### DIFF
--- a/src/api/utility-types.md
+++ b/src/api/utility-types.md
@@ -128,3 +128,9 @@ Used to augment allowed values in style property bindings.
  :::tip
   Augmentations must be placed in a module `.ts` or `.d.ts` file. See [Type Augmentation Placement](/guide/typescript/options-api.html#augmenting-global-properties) for more details.
   :::
+  
+  :::info See also
+SFC `<style>` tags support linking CSS values to dynamic component state using the `v-bind CSS` function. This allows for custom properties without type augmentation. 
+
+- [v-bind() in CSS](/api/sfc-css-features.html#v-bind-in-css)
+  :::


### PR DESCRIPTION
When using SFC it's often not necessary to do type augmentation if v-bind in CSS is used.

## Description of Problem
Adding custom properties in a template causes a type error because custom properties are not accounted for in `CSSProperties`. Searching how to fix that error frequently leads to the docs on [CSSProperties](https://vuejs.org/api/utility-types.html#cssproperties) and how to augment the type.
 
## Proposed Solution
Using `v-bind` in CSS is often the better solution or is at least relevant so linking to that documentation will help convey another solution to fixing the type error. 
