### PR TITLE
Remove WIP notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # vuejs.org
 
-This is the WIP branch of the brand new vuejs.org. **The content is under heavy updates and re-organization so please refrain from submitting PRs to this branch until we have removed this notice.**
-
 ## Contributing
 
 This site is built with [VitePress](https://github.com/vuejs/vitepress) and depends on [@vue/theme](https://github.com/vuejs/vue-theme). Site content is written in Markdown format located in `src`. For simple edits, you can directly edit the file on GitHub and generate a Pull Request.


### PR DESCRIPTION
This PR removes the WIP notice from the top of README.md. I think we're past the stage of asking people not to submit PRs.