### PR TITLE
Remove scrollbars from the spreadsheet cells

### DIFF
--- a/src/guide/extras/demos/SpreadSheet.vue
+++ b/src/guide/extras/demos/SpreadSheet.vue
@@ -40,7 +40,6 @@ tr:first-of-type th:first-of-type {
 
 td {
   border: 1px solid #ccc;
-  overflow: scroll;
   padding: 0;
 }
 </style>


### PR DESCRIPTION
Similar to #1517, but for the other spreadsheet example.

![Cells with scrollbars](https://user-images.githubusercontent.com/65301168/153696454-0f68613f-c499-4512-ac8b-f3b7557f64c2.png)

Fixed preview: https://deploy-preview-1521--vuejs.netlify.app/guide/extras/reactivity-in-depth.html#what-is-reactivity