### PR TITLE
re-positioning icon try_it_in_playground

### DIFF
--- a/.vitepress/theme/styles/inline-demo.css
+++ b/.vitepress/theme/styles/inline-demo.css
@@ -1,5 +1,6 @@
-.vt-doc a[href^="https://sfc.vuejs.org"]:before {
-  content: "▶";
+.vt-doc a[href^="https://sfc.vuejs.org"]:before
+{
+  content: '▶';
   width: 20px;
   height: 20px;
   display: inline-block;
@@ -11,8 +12,8 @@
   border: 2px solid var(--vt-c-green);
   margin-right: 8px;
   margin-left: 4px;
-  line-height: 16px;
-  padding-left: 4px;
+  line-height: 15px;
+  padding-left: 4.5px;
   font-size: 11px;
 }
 


### PR DESCRIPTION
## Description of Problem
The aligntment of "Play Icon" besides the "Try it in playground section" is not centered.
## Proposed Solution
Change CSS to make it properly centered.
## Additional Information
Before:
![image](https://user-images.githubusercontent.com/71051032/153702185-47d96166-bc0a-447d-9791-e215bb95ca8f.png)

After:
![image](https://user-images.githubusercontent.com/71051032/153702197-3ec0acad-d8f7-453c-a76a-8fc5ebad18be.png)
