### PR TITLE
chore: fixing type errors with core members json

### DIFF
--- a/src/about/team/Member.ts
+++ b/src/about/team/Member.ts
@@ -9,7 +9,8 @@ export interface Member {
   languages: string[]
   website?: Link
   socials: Socials
-  sponsor?: string
+  sponsor?: boolean | string
+  reposPersonal?: string[]
 }
 
 export interface Link {

--- a/src/about/team/members-core.json
+++ b/src/about/team/members-core.json
@@ -179,7 +179,7 @@
     "name": "Rahul Kadyan",
     "title": "Software Engineer",
     "company": "Grammarly",
-    "companyList": "https://grammarly.com/",
+    "companyLink": "https://grammarly.com/",
     "projects": [
       {
         "label": "vuejs/core",


### PR DESCRIPTION
## Description of Problem
There were some type errors in the `<TeamPage>` when mounting the team list. Turns out there was a typo and some type mismatches.

I was investigating https://github.com/vuejs/theme/issues/36 and noticed it.