### PR TITLE
Add HotKey "Ctrl + Space" for switching between Options and Compostion API (issue: #1409)

### DIFF
--- a/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/.vitepress/theme/components/PreferenceSwitch.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { VTSwitch, VTIconChevronDown } from '@vue/theme'
 import { useRoute } from 'vitepress'
-import { ref, computed, inject, Ref } from 'vue'
+import { ref, computed, onMounted, onUnmounted, inject, Ref } from 'vue'
 import {
   preferCompositionKey,
   preferComposition,
@@ -18,6 +18,26 @@ const isOpen = ref(
   typeof localStorage !== 'undefined' &&
     !localStorage.getItem(preferCompositionKey)
 )
+
+onMounted(() => {
+  window.addEventListener('keydown', handleToggleCompositionHotKey)
+  onUnmounted(removeToggleHotKey)
+})
+
+const handleToggleCompositionHotKey = (e: KeyboardEvent) => {
+  if (e.key === ' ' && (e.ctrlKey || e.metaKey)) {
+    e.preventDefault()
+    if (preferComposition.value) {
+      toggleCompositionAPI(false)
+    } else {
+      toggleCompositionAPI(true)
+    }
+  }
+}
+
+const removeToggleHotKey = () => {
+  window.removeEventListener('keydown', handleToggleCompositionHotKey)
+}
 
 const toggleOpen = () => {
   isOpen.value = !isOpen.value


### PR DESCRIPTION
## Description of Problem
Allow users to quickly toggle between APIs  
Enhancement on user experience when reading docs.  
Relates to this issue #1409 

## Proposed Solution
Add an event listener on window when mounting component. Implemented a handler to verify if `ctrl + space` or `⌘ + space` were pressed. And then run `toggleCompositionAPI()`

## Additional Information
Needs improvement to show users that this hotKey is available, but I'm open to help with that