### PR TITLE
Fixed typo on page 1 of tutorial

### DIFF
--- a/src/tutorial/src/step-1/description.md
+++ b/src/tutorial/src/step-1/description.md
@@ -6,7 +6,7 @@ The goal of this tutorial is to quickly give you an experience of what it feels 
 
 ## Prerequisites
 
-The tutorial assumes basic familiarity with HTML, CSS and JavaScript. If you are totally new to front development, it might not be the best idea to jump right into a framework as your first step - grasp the basics then come back! Prior experience with other frameworks helps, but is not required.
+The tutorial assumes basic familiarity with HTML, CSS and JavaScript. If you are totally new to front-end development, it might not be the best idea to jump right into a framework as your first step - grasp the basics then come back! Prior experience with other frameworks helps, but is not required.
 
 ## How to Use This Tutorial
 


### PR DESCRIPTION
## Description of Problem
Simple typo on the first page of the tutorial: https://vuejs.org/tutorial/#step-1
![typo-vue](https://user-images.githubusercontent.com/24629970/154204696-eadbeafb-f9e4-4c7c-8d8c-41616cecca86.png)

## Proposed Solution
Change "front development" to "front-end development"
