### PR TITLE
fix the `v-for` attribute value

### DIFF
--- a/src/examples/src/cells/App/template.html
+++ b/src/examples/src/cells/App/template.html
@@ -8,7 +8,7 @@
   <tbody>
     <tr v-for="i in cells[0].length">
       <th>{{ i - 1 }}</th>
-      <td v-for="c, j in cols">
+      <td v-for="(c, j) in cols">
         <Cell :r="i - 1" :c="j"></Cell>
       </td>
     </tr>


### PR DESCRIPTION
## Description of Problem
the `v-for` attribute value is wrong at src/examples/src/cells/App/template.html
```html
<td v-for="c, j in cols">
```
## Proposed Solution
replaced with
```html
<td v-for="(c, j) in cols">
```
