### PR TITLE
Document v-bind.attr shorthand in API section.

### DIFF
--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -319,13 +319,16 @@ Dynamically bind one or more attributes, or a component prop to an expression.
   <svg><a :xlink:special="foo"></a></svg>
   ```
 
-  The `.prop` modifier also has a dedicated shorthand, `.`:
+  The `.prop` and `.attr` modifiers also have a dedicated shorthand, `.` and `^` respectively:
 
   ```vue-html
   <div :someProperty.prop="someObject"></div>
-
   <!-- equivalent to -->
   <div .someProperty="someObject"></div>
+  
+  <div :someProperty.attr="someObject"></div>
+  <!-- equivalent to -->
+  <div ^someProperty="someObject"></div>
   ```
 
   The `.camel` modifier allows camelizing a `v-bind` attribute name when using in-DOM templates, e.g. the SVG `viewBox` attribute:

--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -326,9 +326,9 @@ Dynamically bind one or more attributes, or a component prop to an expression.
   <!-- equivalent to -->
   <div .someProperty="someObject"></div>
   
-  <div :someProperty.attr="someObject"></div>
+  <div :someProperty.attr="someString"></div>
   <!-- equivalent to -->
-  <div ^someProperty="someObject"></div>
+  <div ^someProperty="someString"></div>
   ```
 
   The `.camel` modifier allows camelizing a `v-bind` attribute name when using in-DOM templates, e.g. the SVG `viewBox` attribute:


### PR DESCRIPTION
## Description of Problem

We describe the vbind.prop shorthand, but not the v-bind.attr shorthand

## Proposed Solution

Add missing API documentation

## Additional Information
