### PR TITLE
Update href of perfomance.mark

### DIFF
--- a/src/api/application.md
+++ b/src/api/application.md
@@ -387,7 +387,7 @@ Assign a custom handler for runtime warnings from Vue.
 
 ## app.config.performance
 
-Set this to `true` to enable component init, compile, render and patch performance tracing in the browser devtool performance/timeline panel. Only works in development mode and in browsers that support the [performance.mark](/) API.
+Set this to `true` to enable component init, compile, render and patch performance tracing in the browser devtool performance/timeline panel. Only works in development mode and in browsers that support the [performance.mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) API.
 
 - **Type**: `boolean`
 


### PR DESCRIPTION
## Description of Problem
 href to `performance.mark` docs was empty
## Proposed Solution
  Updated to mozilla docs
## Additional Information
