### PR TITLE
Builds named 'runtime' don't include the compiler

### DIFF
--- a/src/api/options-rendering.md
+++ b/src/api/options-rendering.md
@@ -14,7 +14,7 @@ A string template for the component.
 
 - **Details**
 
-  A template provided via the `template` option will be compiled on-the-fly at runtime. It is only supported when using a full build of Vue that includes the template compiler. The builds that include the template compiler have the word `runtime` in their names, e.g. `vue.runtime.esm-bundler.js`. Consult the [dist file guide](https://github.com/vuejs/core/tree/main/packages/vue#which-dist-file-to-use) for more details about the different builds.
+  A template provided via the `template` option will be compiled on-the-fly at runtime. It is only supported when using a build of Vue that includes the template compiler. The template compiler is **NOT** included in Vue builds that have the word `runtime` in their names, e.g. `vue.runtime.esm-bundler.js`. Consult the [dist file guide](https://github.com/vuejs/core/tree/main/packages/vue#which-dist-file-to-use) for more details about the different builds.
 
   If the string starts with `#` it will be used as a `querySelector` and use the selected element's `innerHTML` as the template string. This allows the source template to be authored using native `<template>` elements.
 


### PR DESCRIPTION
In #1570 I updated the API entry for the `template` option. I now realise that I got the part about which files include the compiler back-to-front. The word `runtime` signifies 'runtime only', rather than 'runtime compiler'.