### PR TITLE
Fix mismatched quotes in import

### DIFF
--- a/src/guide/components/registration.md
+++ b/src/guide/components/registration.md
@@ -26,7 +26,7 @@ app.component(
 If using SFCs, you will be registering the imported `.vue` files:
 
 ```js
-import MyComponent from './App.vue`
+import MyComponent from './App.vue'
 
 app.component('MyComponent', MyComponent)
 ```


### PR DESCRIPTION
This PR just changes the closing quote to match the opening quote. The current code is invalid.

This was originally included in #1461, but that PR combined a number of disparate changes that have made it tricky to merge. This PR splits off this one change so we can get it merged.