### PR TITLE
Dark-mode styling for select and option elements

### DIFF
--- a/.vitepress/theme/styles/inline-demo.css
+++ b/.vitepress/theme/styles/inline-demo.css
@@ -55,6 +55,15 @@
   padding: 0.2em 0.6em;
   margin-top: 10px;
   background: transparent;
+  transition: background-color 0.5s;
+}
+
+.dark .demo select {
+  background: var(--vt-c-bg-soft);
+}
+
+.dark .demo select option {
+  background: transparent;
 }
 
 .demo input:not([type]):focus,


### PR DESCRIPTION
This is similar to what was attempted in #1453, but without the impact on other elements.

In some browser/OS combinations, the `<select>` example [here](https://vuejs.org/guide/essentials/forms.html#select) looks like this:

![Dark-mode select](https://user-images.githubusercontent.com/65301168/155926638-4af9ee55-84e5-4fef-bafe-9d5252e78a28.png)

This PR attempts to introduce a darker background:

![Dark-mode select](https://user-images.githubusercontent.com/65301168/155926813-6a01fcbc-21fe-43ed-9215-dbe6aaa9a0c4.png)

