### PR TITLE
Docs: Update to useDebouncedRef code

### DIFF
--- a/src/api/reactivity-advanced.md
+++ b/src/api/reactivity-advanced.md
@@ -94,7 +94,9 @@ Creates a customized ref with explicit control over its dependency tracking and 
   Creating a debounced ref that only updates the value after a certain timeout after the latest set call:
 
   ```js
-  function useDebouncedRef(value, delay = 200) {
+  import { customRef } from 'vue'
+  
+  export function useDebouncedRef(value, delay = 200) {
     let timeout
     return customRef((track, trigger) => {
       return {


### PR DESCRIPTION
Fixes issue with `useDebouncedRef` function so it can be readily imported to a project.

## Description of Problem
The current docs do not indicate the complete code needed to implement the `useDebouncedRef`. 

## Proposed Solution
Update the docs to include the import statement and default function export.

## Additional Information
