### PR TITLE
fix example for consistency

### DIFF
--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -163,7 +163,7 @@ import { createSSRApp } from 'vue'
 export function createApp() {
   return createSSRApp({
     data: () => ({ count: 1 }),
-    template: `<div @click="count++">{{ count }}</div>`
+    template: `<button @click="count++">{{ count }}</button>`
   })
 }
 ```


### PR DESCRIPTION
The `<button>` element is already used in the example above. This commit updates the next example, where a `<div>` is used instead.

## Description of Problem

## Proposed Solution

## Additional Information
