### PR TITLE
Improve clarity of a sentence in the "Lifecycle Hooks" section of the docs

### DIFF
--- a/src/guide/essentials/lifecycle.md
+++ b/src/guide/essentials/lifecycle.md
@@ -51,7 +51,7 @@ setTimeout(() => {
 }, 100)
 ```
 
-Do note this doesn't mean that the call must be placed lexically inside `setup()` or `<script setup>` - `onMounted()` can be called in an external function as long as the call stack is synchronous and originates from within `setup()`.
+Do note this doesn't mean that the call must be placed lexically inside `setup()` or `<script setup>`, `onMounted()` can be called in an external function as long as the call stack is synchronous and originates from within `setup()`.
 
 </div>
 

--- a/src/guide/essentials/lifecycle.md
+++ b/src/guide/essentials/lifecycle.md
@@ -51,7 +51,7 @@ setTimeout(() => {
 }, 100)
 ```
 
-Do note this doesn't mean that the call must be placed lexically inside `setup()` or `<script setup>`, `onMounted()` can be called in an external function as long as the call stack is synchronous and originates from within `setup()`.
+Do note this doesn't mean that the call must be placed lexically inside `setup()` or `<script setup>`. `onMounted()` can be called in an external function as long as the call stack is synchronous and originates from within `setup()`.
 
 </div>
 


### PR DESCRIPTION
## Description of Problem

> Do note this doesn't mean that the call must be placed lexically inside `setup()` or `<script setup>` - `onMounted()` can be called in an external function as long as the call stack is synchronous and originates from within `setup()`.

The dash in this sentence makes it look like it's `<script setup>` - `onMounted()`, when in fact they should be separate.
## Proposed Solution
To improve clarity and flow of the sentence, I suggest using a fullstop instead.