### PR TITLE
Fix a grammatical error in the docs

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -303,7 +303,7 @@ That's all you need to know about props for now, but once you've finished readin
 
 ## Listening to Events
 
-As we develop our `<BlogPost>` component, some features may require communicating back up to the parent. For example, we may decide to include an accessibility feature to enlarge the text of blog posts, while leaving the rest of the page its default size.
+As we develop our `<BlogPost>` component, some features may require communicating back up to the parent. For example, we may decide to include an accessibility feature to enlarge the text of blog posts, while leaving the rest of the page at its default size.
 
 In the parent, we can support this feature by adding a `postFontSize` <span class="options-api">data property</span><span class="composition-api">ref</span>:
 


### PR DESCRIPTION
## Description of Problem
There's a minor grammatical error in a sentence.
## Proposed Solution
Add the word "at".