### PR TITLE
Update reactivity-fundamentals.md

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -224,7 +224,7 @@ To wait for the DOM update to complete after a state change, you can use the [ne
 import { nextTick } from 'vue'
 
 function increment() {
-  count.value++
+  state.count++
   nextTick(() => {
     // access updated DOM
   })


### PR DESCRIPTION
In the DOM Update Timing section's example, it seems we should use state.count++(which has been shown above) instead of count.value++(which comes later).

## Description of Problem

## Proposed Solution

## Additional Information
