### PR TITLE
Update template-syntax.md

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -207,7 +207,7 @@ It is also possible to use a JavaScript expression in a directive argument by wr
 ```vue-html
 <!--
 Note that there are some constraints to the argument expression,
-as explained in the "Dynamic Argument Expression Constraints" section below.
+as explained in the "Dynamic Argument Value Constraints" section below.
 -->
 <a v-bind:[attributeName]="url"> ... </a>
 

--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -207,7 +207,7 @@ It is also possible to use a JavaScript expression in a directive argument by wr
 ```vue-html
 <!--
 Note that there are some constraints to the argument expression,
-as explained in the "Dynamic Argument Value Constraints" section below.
+as explained in the "Dynamic Argument Value Constraints" and "Dynamic Argument Syntax Constraints" sections below.
 -->
 <a v-bind:[attributeName]="url"> ... </a>
 


### PR DESCRIPTION
## Description of Problem

Section name mismatch. There are three variations:

1. "Dynamic Argument Expression Constraints" section
2. "Dynamic Argument Value Constraints"
3. "Dynamic Argument Syntax Constraints"

The titles 2 and 3 are existing within the file.
The title 1 does not exist. It should be pointing to 2 and 3.

## Proposed Solution

Update 1 to cover both 2 and 3.
1. "Dynamic Argument Value Constraints" and "Dynamic Argument Syntax Constraints" sections

## Additional Information

If it is too long, we can insert a level-3 header "### Dynamic Argument Expression Constraints" right above 2.