### PR TITLE
update tutorial step-8 hint template.html

### DIFF
--- a/src/tutorial/src/step-8/App/template.html
+++ b/src/tutorial/src/step-8/App/template.html
@@ -1,4 +1,4 @@
-<input v-model="newTodo" @keyup.enter="addTodo" />
+<input v-model="newTodo" @keyup.enter="addTodo">
 <button @click="addTodo">Add Todo</button>
 <ul>
   <li v-for="todo in todos" :key="todo.id">

--- a/src/tutorial/src/step-8/_hint/App/template.html
+++ b/src/tutorial/src/step-8/_hint/App/template.html
@@ -1,8 +1,8 @@
-<input v-model="newTodo" @keyup.enter="addTodo" />
+<input v-model="newTodo" @keyup.enter="addTodo">
 <button @click="addTodo">Add Todo</button>
 <ul>
   <li v-for="todo in filteredTodos" :key="todo.id">
-    <input type="checkbox" v-model="todo.done" />
+    <input type="checkbox" v-model="todo.done">
     <span :class="{ done: todo.done }">{{ todo.text }}</span>
     <button @click="removeTodo(todo)">X</button>
   </li>

--- a/src/tutorial/src/step-8/description.md
+++ b/src/tutorial/src/step-8/description.md
@@ -4,7 +4,7 @@ Let's keep building on top of the todo list from the last step. Here, we've alre
 
 ```vue-html{2}
 <li v-for="todo in todos">
-  <input type="checkbox" v-model="todo.done" />
+  <input type="checkbox" v-model="todo.done">
   ...
 </li>
 ```


### PR DESCRIPTION
Removed "closing" forward slashes in empty html (input) elements.

## Description of Problem
I was working through the new Vue tutorial in the docs and noticed that on example 8, Computed Property, there is an error rendering the preview window, `Cannot read properties of undefined (reading 'done')`, after pressing the 'Show Me' button for a solution. I noticed that in the "app" div element of the index.html in the REPL there is an unnecessary closing `</input>` tag after the first `<input>` tag, and an early closing `</ul>` tag after the next `<input>` that is in the `<li>`. The early closing `</ul>` tag appears to be causing the error in the preview. Manually deleting the closing </ul> tag in the REPL fixes the error in the preview.

![Screenshot 2022-03-11 21 33 21](https://user-images.githubusercontent.com/23512329/158006573-39b6b0a4-25fa-4963-b9df-4f666fc59790.png)


## Proposed Solution
Removing the closing forward slashes in the template.html file for both `<input>` tags in the example fixes the error. I cloned the docs repo, ran the development server, and tested the page with the modified template file. My test clone has the html in the "app" div element rendered correctly. If I understand the source code correctly, it appears to me that the when the template code is run through the `toKebabTags` function in the `docs/src/examples/utils.ts file` before being rendered in the REPL that the `toKebabTags` function is seeing the closing forward slashes / at the end of the `<input />` tags in the current template and thinking it needs to add closing tags after those elements and then invalidating the html and causing the error.

## Additional Information
To also let maintainers know, when I cloned the repo and first tried to run the development server, I encountered another error. Because I'm unsure if the issue was due to something wrong in my local installation, I'm not sure if it should be reported as a formal bug or not. The error told me that there was a `SytaxError: Unexpected token '.'` in `/docs/.vitepress/config.ts:52 const headers = md.__data?.headers;`. Changing `const headers = (md as MarkdownRenderer).__data?.headers` to  `const headers = (md as MarkdownRenderer).__data.headers` ( removing the ? after data and before the . ) in `headerMdPlugin.ts` fixed the error for me and allowed me to run the development server on my local machine.

![Screenshot 2022-03-11 22 01 14](https://user-images.githubusercontent.com/23512329/158006604-96906981-c5ea-4e93-8ef8-8f652953f9f6.png)

![Screenshot 2022-03-11 22 15 39](https://user-images.githubusercontent.com/23512329/158006610-4ddaaaa2-41a4-40b5-9335-a1adfc9fb294.png)
