### PR TITLE
fix: missing comma at example src/guide/essentials/component-basics.md

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -558,7 +558,7 @@ HTML tags and attribute names are case-insensitive, so browsers will interpret a
 // camelCase in JavaScript
 const BlogPost = {
   props: ['postTitle'],
-  emits: ['updatePost']
+  emits: ['updatePost'],
   template: `
     <h3>{{ postTitle }}</h3>
   `


### PR DESCRIPTION
## Description of Problem
While copying example code at section component basic, I found missing comma at example `src/guide/essentials/component-basics.md`.

## Proposed Solution
Add an comma 😁

## Additional Information
