### PR TITLE
update Ref type import

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -162,7 +162,7 @@ year.value = '2020'
 Sometimes we may need to specify complex types for a ref's inner value. We can do that by using the `Ref` type:
 
 ```ts
-import { ref, Ref } from 'vue'
+import { ref, type Ref } from 'vue'
 
 const year: Ref<string | number> = ref('2020')
 


### PR DESCRIPTION
In TypeScript 4.5+, This practice appears  error message(`TS1444: 'Ref' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.`). We should change Type import mode.

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/19850462/158018683-bf901ba6-bc0d-4bf1-b193-c321751a62dd.png">

Reference linking: https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta