### PR TITLE
fix: correct Markdown syntax and broken links

### DIFF
--- a/src/api/sfc-spec.md
+++ b/src/api/sfc-spec.md
@@ -105,9 +105,9 @@ p {{ msg }}
 
 Note that integration with various pre-processors may differ by toolchain. Check out the respective documentation for examples:
 
-- [Vite](https://vitejs.dev](features.html#css-pre-processors)
-- [Vue CLI](https://cli.vuejs.org](css.html#pre-processors)
-- [webpack + vue-loader](https://vue-loader.vuejs.org](pre-processors.html#using-pre-processors)
+- [Vite](https://vitejs.dev/guide/features.html#css-pre-processors)
+- [Vue CLI](https://cli.vuejs.org/guide/css.html#pre-processors)
+- [webpack + vue-loader](https://vue-loader.vuejs.org/guide/pre-processors.html#using-pre-processors)
 
 ## Src Imports
 


### PR DESCRIPTION
Fixed this formatting error on [SFC Syntax Specification](https://vuejs.org/api/sfc-spec.html#pre-processors) page:

![Screenshot from 2022-03-12 20-22-37](https://user-images.githubusercontent.com/16514302/158040825-bdc6cfbd-3aa7-474b-9a6f-15f1f9652e07.png)
