### PR TITLE
Update API entry for toRef to mention mutating props

### DIFF
--- a/src/api/reactivity-utilities.md
+++ b/src/api/reactivity-utilities.md
@@ -80,12 +80,14 @@ Can be used to create a ref for a property on a source reactive object. The crea
   const fooRef = ref(state.foo)
   ```
 
-  The above ref is **not** synced with `state.foo`, because the `ref()` receives a plain string value.
+  The above ref is **not** synced with `state.foo`, because the `ref()` receives a plain number value.
 
   `toRef()` is useful when you want to pass the ref of a prop to a composable function:
 
   ```vue
   <script setup>
+  import { toRef } from 'vue'
+  
   const props = defineProps(/* ... */)
 
   // convert `props.foo` into a ref, then pass into
@@ -94,7 +96,9 @@ Can be used to create a ref for a property on a source reactive object. The crea
   </script>
   ```
 
-  `toRef()` will return a usable ref even if the source property doesn't currently exist. This makes it especially useful when working with optional props, which wouldn't be picked up by [`toRefs`](#torefs).
+  When `toRef` is used with component props, the usual restrictions around mutating the props still apply. Attempting to assign a new value to the ref is equivalent to trying to modify the prop directly and is not allowed. In that scenario you may want to consider using [`computed`](./reactivity-core.html#computed) with `get` and `set` instead. See the guide to [using `v-model` with components](/guide/components/events.html#usage-with-v-model) for more information.
+
+  `toRef()` will return a usable ref even if the source property doesn't currently exist. This makes it possible to work with optional properties, which wouldn't be picked up by [`toRefs`](#torefs).
 
 ## toRefs()
 


### PR DESCRIPTION
This is my attempt at addressing the concern raised in #1567.

The API entry for `toRef` mentions using it to create refs from props. This change attempts to clarify that the usual restriction on not mutating a prop still applies, using `toRef` is not a fix for that.

I've also made a few other tweaks to this entry:

* It said `string` when it meant `number`.
* An example wasn't importing `toRef`. Usually I wouldn't show the imports, but given the `<script setup>` tag was shown, I felt the import should be shown too.
* The final note about using `toRef` with optional properties was added back when props did not include omitted values. That has since been changed, so props now includes all props, even if they aren't passed. I've reworded that note to avoid mentioning props.