### PR TITLE
Fix broken 'ref-unwrapping-in-templates' link to

### DIFF
--- a/src/api/composition-api-setup.md
+++ b/src/api/composition-api-setup.md
@@ -38,7 +38,7 @@ export default {
 </template>
 ```
 
-Note that [refs](/api/reactivity-core.html#ref) returned from `setup` are [automatically shallow unwrapped](/guide/essentials/reactivity-fundamentals.html#ref-unwrapping-in-templates) when accessed in the template so you do not need to use `.value` when accessing them. They are also unwrapped in the same way when accessed on `this`.
+Note that [refs](/api/reactivity-core.html#ref) returned from `setup` are [automatically shallow unwrapped](/guide/essentials/reactivity-fundamentals.html#deep-reactivity) when accessed in the template so you do not need to use `.value` when accessing them. They are also unwrapped in the same way when accessed on `this`.
 
 :::tip
 `setup()` itself does not have access to the component instance - `this` will have a value of `null` inside `setup()`. You can access Composition-API-exposed values from Options API, but not the other way around.


### PR DESCRIPTION
## Description of Problem
Problem described in https://github.com/vuejs/docs/issues/1625

## Proposed Solution
The solution is partial—fix the link. The other problems from the issue will still remain.