### PR TITLE
Added transition mode `default`

### DIFF
--- a/src/api/built-in-components.md
+++ b/src/api/built-in-components.md
@@ -55,7 +55,7 @@ Provides animated transition effects to a **single** element or component.
      * Controls the timing sequence of leaving/entering transitions.
      * Default behavior is simultaneous.
      */
-    mode?: 'in-out' | 'out-in'
+    mode?: 'in-out' | 'out-in' | 'default'
     /**
      * Whether to apply transition on initial render.
      * Default: false


### PR DESCRIPTION
## Description of Problem
According to the TypeScript interface ([here](https://github.com/vuejs/core/blob/main/packages/runtime-core/src/components/BaseTransition.ts#L24)) the default mode is `default`.

This was missing from the docs.

## Proposed Solution
So I added it to this API docs page.

## Additional Information
However, this might **also** be useful to mention in the guide where it introduces the `mode` parameter/attribute ([VueJS.org](https://vuejs.org/guide/built-ins/transition.html#transition-modes) / [GitHub source](https://github.com/vuejs/docs/blob/main/src/guide/built-ins/transition.md#transition-modes)). So developers know what to use for the default behaviour (if you have to set it explicitly).

It might seem obvious when you *know* the default value is `default`... but otherwise you might try an empty string, or `'sync'` / `false` / null / etc.
