### PR TITLE
Fix examples in HTML mode

### DIFF
--- a/src/examples/src/cells/Cell/template.html
+++ b/src/examples/src/cells/Cell/template.html
@@ -5,6 +5,6 @@
     @change="update"
     @blur="update"
     @vnode-mounted="({ el }) => el.focus()"
-  />
+  >
   <span v-else>{{ evalCell(cells[c][r]) }}</span>
 </div>

--- a/src/examples/src/circle-drawer/App/composition.js
+++ b/src/examples/src/circle-drawer/App/composition.js
@@ -57,10 +57,12 @@ export default {
 
     return {
       history,
+      index,
       circles,
       selected,
       adjusting,
       onClick,
+      adjust,
       undo,
       redo
     }

--- a/src/examples/src/circle-drawer/App/template.html
+++ b/src/examples/src/circle-drawer/App/template.html
@@ -23,5 +23,5 @@
 
 <div class="dialog" v-if="adjusting" @click.stop>
   <p>Adjust radius of circle at ({{ selected.cx }}, {{ selected.cy }})</p>
-  <input type="range" v-model="selected.r" min="1" max="300" />
+  <input type="range" v-model="selected.r" min="1" max="300">
 </div>

--- a/src/examples/src/flight-booker/App/template.html
+++ b/src/examples/src/flight-booker/App/template.html
@@ -3,8 +3,8 @@
   <option value="return flight">Return Flight</option>
 </select>
 
-<input type="date" v-model="departureDate" />
-<input type="date" v-model="returnDate" :disabled="!isReturn" />
+<input type="date" v-model="departureDate">
+<input type="date" v-model="returnDate" :disabled="!isReturn">
 
 <button :disabled="!canBook" @click="book">Book</button>
 

--- a/src/examples/src/form-bindings/App/template.html
+++ b/src/examples/src/form-bindings/App/template.html
@@ -1,8 +1,8 @@
 <h2>Text Input</h2>
-<input v-model="text" /> {{ text }}
+<input v-model="text"> {{ text }}
 
 <h2>Checkbox</h2>
-<input type="checkbox" id="checkbox" v-model="checked" />
+<input type="checkbox" id="checkbox" v-model="checked">
 <label for="checkbox">Checked: {{ checked }}</label>
 
 <!--
@@ -10,21 +10,21 @@
   array v-model value
 -->
 <h2>Multi Checkbox</h2>
-<input type="checkbox" id="jack" value="Jack" v-model="checkedNames" />
+<input type="checkbox" id="jack" value="Jack" v-model="checkedNames">
 <label for="jack">Jack</label>
-<input type="checkbox" id="john" value="John" v-model="checkedNames" />
+<input type="checkbox" id="john" value="John" v-model="checkedNames">
 <label for="john">John</label>
-<input type="checkbox" id="mike" value="Mike" v-model="checkedNames" />
+<input type="checkbox" id="mike" value="Mike" v-model="checkedNames">
 <label for="mike">Mike</label>
 <p>Checked names: <pre>{{ checkedNames }}</pre></p>
 
 <h2>Radio</h2>
-<input type="radio" id="one" value="One" v-model="picked" />
+<input type="radio" id="one" value="One" v-model="picked">
 <label for="one">One</label>
-<br />
-<input type="radio" id="two" value="Two" v-model="picked" />
+<br>
+<input type="radio" id="two" value="Two" v-model="picked">
 <label for="two">Two</label>
-<br />
+<br>
 <span>Picked: {{ picked }}</span>
 
 <h2>Select</h2>

--- a/src/examples/src/timer/App/template.html
+++ b/src/examples/src/timer/App/template.html
@@ -5,7 +5,7 @@
 <div>{{ (elapsed / 1000).toFixed(1) }}s</div>
 
 <div>
-  Duration: <input type="range" v-model="duration" min="1" max="30000" />
+  Duration: <input type="range" v-model="duration" min="1" max="30000">
   {{ (duration / 1000).toFixed(1) }}s
 </div>
 

--- a/src/examples/src/todomvc/App/template.html
+++ b/src/examples/src/todomvc/App/template.html
@@ -6,7 +6,7 @@
       autofocus
       placeholder="What needs to be done?"
       @keyup.enter="addTodo"
-    />
+    >
   </header>
   <section class="main" v-show="todos.length">
     <input
@@ -15,7 +15,7 @@
       type="checkbox"
       :checked="remaining === 0"
       @change="toggleAll"
-    />
+    >
     <label for="toggle-all">Mark all as complete</label>
     <ul class="todo-list">
       <li
@@ -25,7 +25,7 @@
         :class="{ completed: todo.completed, editing: todo === editedTodo }"
       >
         <div class="view">
-          <input class="toggle" type="checkbox" v-model="todo.completed" />
+          <input class="toggle" type="checkbox" v-model="todo.completed">
           <label @dblclick="editTodo(todo)">{{ todo.title }}</label>
           <button class="destroy" @click="removeTodo(todo)"></button>
         </div>
@@ -38,7 +38,7 @@
           @blur="doneEdit(todo)"
           @keyup.enter="doneEdit(todo)"
           @keyup.escape="cancelEdit(todo)"
-        />
+        >
       </li>
     </ul>
   </section>


### PR DESCRIPTION
Fixes #1634.

Several of the examples don't work correctly if the HTML/SFC switch is set to HTML.

The main problem is that `<input />` and `<br />` is transformed to `<input></input>` and `<br></br>`. For some examples this is harmless and just leads to strange-looking code, but for other examples it breaks the parsing, leading to incorrect rendering or an error.

Rather than fixing the transform I've just removed the unnecessary closing slash from those tags.

There were also a couple of problems with the Circle Drawer demo. These only applied to the Composition API version. Two things used in the template were not being returned from `setup`. In SFC mode this still worked because the `return` is stripped out by a transform, but in HTML mode that `return` needs to return the correct things.