### PR TITLE
Update reactive API limitation 2

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -343,12 +343,12 @@ The `reactive()` API has two limitations:
 
 1. It only works for object types (objects, arrays, and [collection types](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#keyed_collections) such as `Map` and `Set`). It cannot hold [primitive types](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) such as `string`, `number` or `boolean`.
 
-2. Since Vue's reactivity tracking works over property access, we must always keep the same reference to the reactive object. This means we can't easily "replace" a reactive object:
+2. Since Vue's reactivity tracking works over property access, we must always keep the same reference to the reactive object. This means we can't easily "replace" a reactive object because the reactivity connection to the first reference is lost:
 
    ```js
    let state = reactive({ count: 0 })
 
-   // this won't work!
+   // the above reference ({ count: 0 }) is no longer being tracked (reactivity connection is lost!)
    state = reactive({ count: 1 })
    ```
 


### PR DESCRIPTION
## Description of Problem
The [Reactivity Fundamentals](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#reactive-proxy-vs-original-1) states on the limitations of [reactive()](https://vuejs.org/api/reactivity-core.html#reactive):

> Since Vue's reactivity tracking works over property access, we must always keep the same reference to the reactive object. This means we can't easily "replace" a reactive object:

```js
let state = reactive({ count: 0 })

// this won't work!
state = reactive({ count: 1 })
```

While this is great, I thought it could be expounded a little further to make the concept clearer.

Addresses https://github.com/vuejs/docs/issues/1630

## Proposed Solution
Indicate the fact that the the reactivity connection to the first reference is lost when we re-assign a variable to a new reactive value.

## Additional Information

Once a value has been re-assigned, [reactive()](https://vuejs.org/api/reactivity-core.html#reactive) starts tracking the re-assigned reference and loses tracking of the initial reference as seen on this [sfc.vuejs.org](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlYWN0aXZlLCB3YXRjaCB9IGZyb20gJ3Z1ZSdcbmxldCBzdGF0ZSA9IHJlYWN0aXZlKHsgY291bnQ6IDAgfSlcbndhdGNoKCgpID0+IHN0YXRlLmNvdW50LCAobmV3VmFsdWUpID0+IGNvbnNvbGUubG9nKCdGaXJzdCByZWFjdGl2ZSBjaGFuZ2VkJywgbmV3VmFsdWUpKVxuXG5zdGF0ZSA9IHJlYWN0aXZlKHsgY291bnQ6IDEgfSlcbndhdGNoKCgpID0+IHN0YXRlLmNvdW50LCAobmV3VmFsdWUpID0+IGNvbnNvbGUubG9nKCdTZWNvbmQgcmVhY3RpdmUgY2hhbmdlZCcsIG5ld1ZhbHVlKSlcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIDxoMT57eyBzdGF0ZS5jb3VudCB9fTwvaDE+XG4gIDxidXR0b24gQGNsaWNrPVwic3RhdGUuY291bnQrK1wiPlxuICAgIEluY3JlbWVudCBjb3VudFxuICA8L2J1dHRvbj5cbjwvdGVtcGxhdGU+IiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9zZmMudnVlanMub3JnL3Z1ZS5ydW50aW1lLmVzbS1icm93c2VyLmpzXCJcbiAgfVxufSJ9) instance.