### PR TITLE
fix: toRef is used without import

### DIFF
--- a/src/api/composition-api-setup.md
+++ b/src/api/composition-api-setup.md
@@ -64,7 +64,7 @@ Note that if you destructure the `props` object, the destructured variables will
 If you really need to destructure the props, or need to pass a prop into an external function while retaining reactivity, you can do so with the [toRefs()](./reactivity-utilities.html#torefs) and [toRef()](/api/reactivity-utilities.html#toref) utility APIs:
 
 ```js
-import { toRefs } from 'vue'
+import { toRefs, toRef } from 'vue'
 
 export default {
   setup(props) {


### PR DESCRIPTION
## Description of Problem
we used `toRef` in Accessing Props section, but we didn't import it.

## Proposed Solution
add `toRef` to list of imported properties from `vue` package.

## Additional Information
