### PR TITLE
Update component-basics.md

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -468,7 +468,7 @@ This can be achieved using Vue's custom `<slot>` element:
 ```vue{4}
 <template>
   <div class="alert-box">
-    <strong>Error!</strong>
+    <strong>This is an Error for Demo Purposes</strong>
     <slot />
   </div>
 </template>


### PR DESCRIPTION
Changed the code example to fit with the render example. It was 'Error' in code but rendered as 'This is an Error for Demo Purposes'.

## Description of Problem
Code example was not fitting with rendered result. 
## Proposed Solution
Changing 'Error!' text to  'This is an Error for Demo Purposes' to avoid confusion.
 ## Additional Information
