### PR TITLE
Revert "Document v-bind.attr shorthand in API section."

### DIFF
--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -319,16 +319,13 @@ Dynamically bind one or more attributes, or a component prop to an expression.
   <svg><a :xlink:special="foo"></a></svg>
   ```
 
-  The `.prop` and `.attr` modifiers also have a dedicated shorthand, `.` and `^` respectively:
+  The `.prop` modifier also has a dedicated shorthand, `.`:
 
   ```vue-html
   <div :someProperty.prop="someObject"></div>
+
   <!-- equivalent to -->
   <div .someProperty="someObject"></div>
-  
-  <div :someProperty.attr="someString"></div>
-  <!-- equivalent to -->
-  <div ^someProperty="someString"></div>
   ```
 
   The `.camel` modifier allows camelizing a `v-bind` attribute name when using in-DOM templates, e.g. the SVG `viewBox` attribute:


### PR DESCRIPTION
Reverts vuejs/docs#1571

Following discussion with @LinusBorg and others, it appears that the `^` shorthand isn't currently supported in the template compiler. While it almost works anyway, the attribute value is treated as a string rather than as an expression. It is not currently equivalent to using `.attr`.

The reason it almost works is because `.attr` is compiled into a `^` prefix, so using a `^` directly gives a similar result. Whether `^` was actually supposed to be used as a shorthand is unclear, so for now we're reverting the docs change. The documentation for `^` can be reintroduced if it gets proper support in the compiler.