### PR TITLE
added twitter community to the community-guide

### DIFF
--- a/src/about/community-guide.md
+++ b/src/about/community-guide.md
@@ -25,9 +25,10 @@ Our [Code of Conduct](/about/coc) is a guide to make it easier to enrich all of 
 
 - [Discord Chat](https://chat.vuejs.org/): A place for Vue devs to meet and chat in real time.
 - [Forum](https://forum.vuejs.org/): The best place to ask questions and get answers about Vue and its ecosystem.
-- [DEV Community](https://dev.to/t/vue): share and discuss Vue related topics on Dev.to.
+- [DEV Community](https://dev.to/t/vue): Share and discuss Vue related topics on Dev.to.
 - [Meetups](https://events.vuejs.org/meetups): Want to find local Vue enthusiasts like yourself? Interested in becoming a community leader? We have the help and support you need right here!
 - [GitHub](https://github.com/vuejs): If you have a bug to report or feature to request, that's what the GitHub issues are for. Please respect the rules specified in each repository's issue template.
+- [Twitter Community (unofficial)](https://twitter.com/i/communities/1516368750634840064): A Twitter community, where you can meet other Vue enthusiasts, get help, or just chat about Vue.
 
 ### Explore the Ecosystem
 


### PR DESCRIPTION
## Description of Problem
The newly created (unofficial) Twitter community was missing from the community guide.

## Proposed Solution
Add a link to the community to the guide.

## Additional Information
I also fixed an uppercase/lowercase typo