### PR TITLE
Fixed typo (plural s missing)

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -296,7 +296,7 @@ You can check out [this example](/examples/#fetching-data) with `watchEffect` an
 
 ## Callback Flush Timing
 
-When you mutate reactive state, it may trigger both Vue component updates and watcher callbacks created by you.
+When you mutate reactive states, it may trigger both Vue component updates and watcher callbacks created by you.
 
 By default, user-created watcher callbacks are called **before** Vue component updates. This means if you attempt to access the DOM inside a watcher callback, the DOM will be in the state before Vue has applied any updates.
 


### PR DESCRIPTION
When you mutate reactive state, it [...] should be either When you mutate a reactive state, it [...] or When you mutate reactive states, it [...]

## Description of Problem

## Proposed Solution

## Additional Information
