### PR TITLE
Fix wording about component use with <script setup>

### DIFF
--- a/src/guide/components/registration.md
+++ b/src/guide/components/registration.md
@@ -65,7 +65,7 @@ Local registration scopes the availability of the registered components to the c
 
 <div class="composition-api">
 
-When using SFC with `<script setup>`, imported components are automatically registered locally:
+When using SFC with `<script setup>`, imported components can be locally used without registration:
 
 ```vue
 <script setup>


### PR DESCRIPTION
Fix #1638.

The first paragraph mentions that:

> A Vue component needs to be "registered" so that Vue knows where to locate its implementation when it is encountered in a template. There are two ways to register components: global and local.

Now that the content contradicts it, I wonder if we need to reword it, too.