### PR TITLE
Fix layout inconsistency on Firefox

### DIFF
--- a/src/api/ApiIndex.vue
+++ b/src/api/ApiIndex.vue
@@ -169,6 +169,7 @@ h3 {
 
 .api-group {
   break-inside: avoid;
+  overflow: auto;
   margin-bottom: 20px;
   background-color: var(--vt-c-bg-soft);
   border-radius: 8px;


### PR DESCRIPTION
Fix #1542.

In Firefox, the `overflow` algorithm interferes with the `break-inside` property.