### PR TITLE
fix: banner height error

### DIFF
--- a/.vitepress/theme/components/VueSchoolBanner.vue
+++ b/.vitepress/theme/components/VueSchoolBanner.vue
@@ -147,7 +147,7 @@ function close () {
 }
 
 .has-top-banner {
-  --vt-banner-height: 104px;
+  --vt-banner-height: 80px;
 }
 
 .has-top-banner .banner {


### PR DESCRIPTION
## Description of Problem
Wrong banner height(Vue School Banner) leads to wrong nav-bar position

## Proposed Solution
VueSchoolBanner.vue:
```
.has-top-banner {
  --vt-banner-height: 80px;
}
```

## Additional Information
![Screen Shot 2022-04-25 at 17.54.25.png](https://s2.loli.net/2022/04/25/k2TyMahWtjbqfnZ.png)
