### PR TITLE
Update Vue School banner copy

### DIFF
--- a/.vitepress/theme/components/VueSchoolBanner.vue
+++ b/.vitepress/theme/components/VueSchoolBanner.vue
@@ -13,10 +13,10 @@
     <div class="vs-core">
       <div class="vs-slogan">
         <div class="vs-slogan-title">
-          Get up to <strong>40% off</strong> your Vue School Subscription
+          Extended for <strong>48 hours!</strong>
         </div>
         <div class="vs-slogan-subtitle">
-          Time Limited Offer
+          Get up to 40% off your Vue School Subscription
         </div>
       </div>
       <div class="vs-button">
@@ -37,7 +37,9 @@ import { ref, onMounted } from 'vue'
 const isVisible = ref(false)
 
 onMounted(() => {
-  isVisible.value = !localStorage.getItem('VS_FW_22_OFFER')
+  const now = new Date()
+  const end = new Date('2022-05-04T00:00:00+02:00')
+  isVisible.value = !localStorage.getItem('VS_FW_22_OFFER') && (now < end)
   if (isVisible.value) document.body.classList.add('has-top-banner')
 })
 


### PR DESCRIPTION
This PR updates the text of the Vue School top banner to announce the promo is extended for 48 hs.

Please merge this on `2022-05-01T00:00:00+02:00` (so, on the first minute of Sunday, or soon later).

The banner will stop appearing automatically on `2022-05-04T00:00:00+02:00`, the date is hard-coded.

[Click here to see screenshots of the banner](https://imgur.com/a/jp0BmUY)