### PR TITLE
Update component-instance.md

### DIFF
--- a/src/api/component-instance.md
+++ b/src/api/component-instance.md
@@ -321,6 +321,6 @@ Instance-bound version of the global [`nextTick()`](./general.html#nexttick).
 
 - **Details**
 
-  The only different from the global version of `nextTick()` is that the callback passed to `this.$nextTick()` will have its `this` context bound to the current component instance.
+  The only difference from the global version of `nextTick()` is that the callback passed to `this.$nextTick()` will have its `this` context bound to the current component instance.
 
 - **See also:** [`nextTick()`](./general.html#nexttick)


### PR DESCRIPTION
Fixed a typo in `$nextTick()` details.

## Description of Problem
The details of the `$nextTick()`-section use a wrong word. It starts with "The only **different** from the global version...". This should be "The only **difference** from the global version...".

## Proposed Solution
Change "different" into "difference".
