### PR TITLE
Fix for #1691

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@types/markdown-it': ^12.2.3

--- a/src/tutorial/src/step-15/description.md
+++ b/src/tutorial/src/step-15/description.md
@@ -4,10 +4,10 @@ You have finished the tutorial!
 
 At this point, you should have a good idea of what it's like to work with Vue. However, we covered a lot of things really fast and glossed over the details, so definitely keep learning! As a next step, you can:
 
-- Set up a real Vue project on your machine by following the <a target="_blank" href="/guide/quick-start.html"> Quick Start </a>.
+- Set up a real Vue project on your machine by following the <a target="_blank" href="/guide/quick-start.html">Quick Start</a>.
 
-- Go through the <a target="_blank" href="/guide/essentials/application.html"> Main Guide </a>, which covers all the topics we learned so far in greater details, and much more.
+- Go through the <a target="_blank" href="/guide/essentials/application.html">Main Guide</a>, which covers all the topics we learned so far in greater details, and much more.
 
-- Check out some more practical <a target="_blank" href="/examples"> Examples </a>.
+- Check out some more practical <a target="_blank" href="/examples">Examples</a>.
 
 We can't wait to see what you build next!

--- a/src/tutorial/src/step-15/description.md
+++ b/src/tutorial/src/step-15/description.md
@@ -4,10 +4,10 @@ You have finished the tutorial!
 
 At this point, you should have a good idea of what it's like to work with Vue. However, we covered a lot of things really fast and glossed over the details, so definitely keep learning! As a next step, you can:
 
-- Set up a real Vue project on your machine by following the <a target="_blank" href="/guide/quick-start.html">Quick Start</a>.
+- Set up a real Vue project on your machine by following the [Quick Start](/guide/quick-start.html).
 
-- Go through the <a target="_blank" href="/guide/essentials/application.html">Main Guide</a>, which covers all the topics we learned so far in greater details, and much more.
+- Go through the [Main Guide](/guide/essentials/application.html), which covers all the topics we learned so far in greater details, and much more.
 
-- Check out some more practical <a target="_blank" href="/examples">Examples</a>.
+- Check out some more practical [Examples](/examples/).
 
 We can't wait to see what you build next!

--- a/src/tutorial/src/step-15/description.md
+++ b/src/tutorial/src/step-15/description.md
@@ -4,10 +4,10 @@ You have finished the tutorial!
 
 At this point, you should have a good idea of what it's like to work with Vue. However, we covered a lot of things really fast and glossed over the details, so definitely keep learning! As a next step, you can:
 
-- Set up a real Vue project on your machine by following the [Quick Start](/guide/quick-start.html).
+- Set up a real Vue project on your machine by following the <a target="_blank" href="/guide/quick-start.html"> Quick Start </a>.
 
-- Go through the [Main Guide](/guide/essentials/application.html), which covers all the topics we learned so far in greater details, and much more.
+- Go through the <a target="_blank" href="/guide/essentials/application.html"> Main Guide </a>, which covers all the topics we learned so far in greater details, and much more.
 
-- Check out some more practical [Examples](/examples/).
+- Check out some more practical <a target="_blank" href="/examples"> Examples </a>.
 
 We can't wait to see what you build next!

--- a/src/tutorial/tutorial.data.ts
+++ b/src/tutorial/tutorial.data.ts
@@ -11,7 +11,7 @@ export default {
     const md = createMarkdownRenderer(process.cwd(), {
       // @ts-ignore
       highlight: await createHighlighter()
-    })
+    }, '/')
     const files = readExamples(path.resolve(__dirname, './src'))
     for (const step in files) {
       const stepFiles = files[step]


### PR DESCRIPTION
## Description of Problem

404 errors on the links in /tutorials/#step-15 
- Quick Start
- Main Guide
- Examples

## Proposed Solution

Changing the links from markdown based links `[]() to <a href="">` like in the previous steps

## Additional Information
Tough unrelated, it is my first time committing to an open source.