### PR TITLE
docs: update bundle.js.org to bundlejs.com

### DIFF
--- a/src/guide/best-practices/performance.md
+++ b/src/guide/best-practices/performance.md
@@ -53,7 +53,7 @@ One of the most effective ways to improve page load performance is shipping smal
 
   - If using a build step, prefer dependencies that offer ES module formats and are tree-shaking friendly. For example, prefer `lodash-es` over `lodash`.
 
-  - Check a dependency's size and evaluate whether it is worth the functionality it provides. Note if the dependency is tree-shaking friendly, the actual size increase will depend on the APIs you actually import from it. Tools like [bundle.js.org](https://bundle.js.org/) can be used for quick checks, but measuring with your actual build setup will always be the most accurate.
+  - Check a dependency's size and evaluate whether it is worth the functionality it provides. Note if the dependency is tree-shaking friendly, the actual size increase will depend on the APIs you actually import from it. Tools like [bundlejs.com](https://bundlejs.com/) can be used for quick checks, but measuring with your actual build setup will always be the most accurate.
 
 - If you are using Vue primarily for progressive enhancement and prefer to avoid a build step, consider using [petite-vue](https://github.com/vuejs/petite-vue) (only **6kb**) instead.
 


### PR DESCRIPTION
https://bundle.js.org is moving to a new domain, namely https://bundlejs.com

## Description of Problem

## Proposed Solution

## Additional Information
