### PR TITLE
Align description about props default between composition/options API

### DIFF
--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -398,8 +398,10 @@ defineProps({
   propE: {
     type: Object,
     // Object or array defaults must be returned from
-    // a factory function
-    default() {
+    // a factory function. The function receives the raw
+    // props received by the component as the argument.
+    default(rawProps) {
+      // default function receives the raw props object as argument
       return { message: 'hello' }
     }
   },

--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -401,7 +401,6 @@ defineProps({
     // a factory function. The function receives the raw
     // props received by the component as the argument.
     default(rawProps) {
-      // default function receives the raw props object as argument
       return { message: 'hello' }
     }
   },
@@ -455,7 +454,6 @@ export default {
       // a factory function. The function receives the raw
       // props received by the component as the argument.
       default(rawProps) {
-        // default function receives the raw props object as argument
         return { message: 'hello' }
       }
     },


### PR DESCRIPTION
## Description of Problem

I spotted differences in the descriptions about the argument for prop default between composition/options API.

Composition API says:
```
  // Object with a default value
  propE: {
    type: Object,
    // Object or array defaults must be returned from
    // a factory function
    default() {
      return { message: 'hello' }
    }
  },
```

Options API says:
```
    // Object with a default value
    propE: {
      type: Object,
      // Object or array defaults must be returned from
      // a factory function. The function receives the raw
      // props received by the component as the argument.
      default(rawProps) {
        // default function receives the raw props object as argument
        return { message: 'hello' }
      }
    },
```

The difference seems to be introduced after
b0f5fff833c556f73672997693f11bfbe09031db
and
046ea54be8218ed495cf486e099cb652f8d1c068
These are adding explanations about rowProps into the options API.

## Proposed Solution

Apply the same explanations to composition API too.
The part
```
        // default function receives the raw props object as argument
```
looks duplicate of the main text, so I suggest to remove it as well.

## Additional Information

I tested with following code and confirmed that both composition/options API provides the rawProps arg.

App.vue
```
<template>
  <div>
    <Comp :propA="43" />
    <Comp :propA="44" :propE="{ message: 'good day' }" />
    <Opt :propA="43" />
    <Opt :propA="44" :propE="{ message: 'good day' }" />
  </div>
</template>
```

Comp.vue
```
<template>
  <div>Comp: {{ propE }}</div>
</template>

<script setup>
defineProps({
  propA: {
    type: Number,
    default: 42,
  },
  propE: {
    type: Object,
    default(rawProps) {
      return {
        message: `hello ${rawProps.propA}`
      };
    },
  },
});
</script>
```

Opt.vue
```
<template>
  <div>Opt: {{ propE }}</div>
</template>

<script>
export default {
  props: {
    propA: {
      type: Number,
      default: 42,
    },
    propE: {
      type: Object,
      default(rawProps) {
        return {
          message: `hello ${rawProps.propA}`
        };
      },
    },
  }
};
</script>
```