### PR TITLE
Added a note about prop modifiers on render function examples

### DIFF
--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -319,13 +319,22 @@ Dynamically bind one or more attributes, or a component prop to an expression.
   <svg><a :xlink:special="foo"></a></svg>
   ```
 
-  The `.prop` modifier also has a dedicated shorthand, `.`:
+  The `.prop` modifier has a dedicated shorthand, `.`:
 
   ```vue-html
   <div :someProperty.prop="someObject"></div>
 
   <!-- equivalent to -->
   <div .someProperty="someObject"></div>
+  ```
+
+  The `.attr` modifier has a shorthand `^`:
+
+  ```vue-html
+  <div :someProperty.attr="someObject"></div>
+
+  <!-- equivalent to -->
+  <div ^someProperty="someObject"></div>
   ```
 
   The `.camel` modifier allows camelizing a `v-bind` attribute name when using in-DOM templates, e.g. the SVG `viewBox` attribute:

--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -319,22 +319,13 @@ Dynamically bind one or more attributes, or a component prop to an expression.
   <svg><a :xlink:special="foo"></a></svg>
   ```
 
-  The `.prop` modifier has a dedicated shorthand, `.`:
+  The `.prop` modifier also has a dedicated shorthand, `.`:
 
   ```vue-html
   <div :someProperty.prop="someObject"></div>
 
   <!-- equivalent to -->
   <div .someProperty="someObject"></div>
-  ```
-
-  The `.attr` modifier has a shorthand `^`:
-
-  ```vue-html
-  <div :someProperty.attr="someObject"></div>
-
-  <!-- equivalent to -->
-  <div ^someProperty="someObject"></div>
   ```
 
   The `.camel` modifier allows camelizing a `v-bind` attribute name when using in-DOM templates, e.g. the SVG `viewBox` attribute:

--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -40,7 +40,7 @@ h('div', { id: 'foo' })
 h('div', { class: 'bar', innerHTML: 'hello' })
 
 // props modifiers such as .prop and .attr can be added via shorthands
-h('div', { .name: 'some-name', ^width: '100' })
+h('div', { '.name': 'some-name', '^width': '100' })
 
 // class and style have the same object / array
 // value support that they have in templates

--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -39,7 +39,8 @@ h('div', { id: 'foo' })
 // Vue automatically picks the right way to assign it
 h('div', { class: 'bar', innerHTML: 'hello' })
 
-// props modifiers such as .prop and .attr can be added via shorthands
+// props modifiers such as .prop and .attr can be added
+// with '.' and `^' prefixes respectively
 h('div', { '.name': 'some-name', '^width': '100' })
 
 // class and style have the same object / array

--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -39,6 +39,9 @@ h('div', { id: 'foo' })
 // Vue automatically picks the right way to assign it
 h('div', { class: 'bar', innerHTML: 'hello' })
 
+// props modifiers such as .prop and .attr can be added via shorthands
+h('div', { .name: 'some-name', ^width: '100' })
+
 // class and style have the same object / array
 // value support that they have in templates
 h('div', { class: [foo, { bar }], style: { color: 'red' } })
@@ -112,11 +115,7 @@ import { h } from 'vue'
 export default {
   setup() {
     // use an array to return multiple root nodes
-    return () => [
-      h('div'),
-      h('div'),
-      h('div')
-    ]
+    return () => [h('div'), h('div'), h('div')]
   }
 }
 ```
@@ -163,11 +162,7 @@ import { h } from 'vue'
 export default {
   render() {
     // use an array to return multiple root nodes
-    return [
-      h('div'),
-      h('div'),
-      h('div')
-    ]
+    return [h('div'), h('div'), h('div')]
   }
 }
 ```
@@ -563,8 +558,8 @@ Passing slots as functions allows them to be invoked lazily by the child compone
 import { h, KeepAlive, Teleport, Transition, TransitionGroup } from 'vue'
 
 export default {
-  setup () {
-    return () => h(Transition, { mode: 'out-in' }, /* ... */)
+  setup() {
+    return () => h(Transition, { mode: 'out-in' } /* ... */)
   }
 }
 ```
@@ -576,8 +571,8 @@ export default {
 import { h, KeepAlive, Teleport, Transition, TransitionGroup } from 'vue'
 
 export default {
-  render () {
-    return h(Transition, { mode: 'out-in' }, /* ... */)
+  render() {
+    return h(Transition, { mode: 'out-in' } /* ... */)
   }
 }
 ```
@@ -614,7 +609,8 @@ export default {
   render() {
     return h(SomeComponent, {
       modelValue: this.modelValue,
-      'onUpdate:modelValue': (value) => this.$emit('update:modelValue', value)
+      'onUpdate:modelValue': (value) =>
+        this.$emit('update:modelValue', value)
     })
   }
 }
@@ -631,8 +627,12 @@ import { h, withDirectives } from 'vue'
 
 // a custom directive
 const pin = {
-  mounted() { /* ... */ },
-  updated() { /* ... */ }
+  mounted() {
+    /* ... */
+  },
+  updated() {
+    /* ... */
+  }
 }
 
 // <div v-pin:top.animate="200"></div>

--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -115,7 +115,11 @@ import { h } from 'vue'
 export default {
   setup() {
     // use an array to return multiple root nodes
-    return () => [h('div'), h('div'), h('div')]
+    return () => [
+      h('div'),
+      h('div'),
+      h('div')
+    ]
   }
 }
 ```
@@ -162,7 +166,11 @@ import { h } from 'vue'
 export default {
   render() {
     // use an array to return multiple root nodes
-    return [h('div'), h('div'), h('div')]
+    return [
+      h('div'),
+      h('div'),
+      h('div')
+    ]
   }
 }
 ```
@@ -558,8 +566,8 @@ Passing slots as functions allows them to be invoked lazily by the child compone
 import { h, KeepAlive, Teleport, Transition, TransitionGroup } from 'vue'
 
 export default {
-  setup() {
-    return () => h(Transition, { mode: 'out-in' } /* ... */)
+  setup () {
+    return () => h(Transition, { mode: 'out-in' }, /* ... */)
   }
 }
 ```
@@ -571,8 +579,8 @@ export default {
 import { h, KeepAlive, Teleport, Transition, TransitionGroup } from 'vue'
 
 export default {
-  render() {
-    return h(Transition, { mode: 'out-in' } /* ... */)
+  render () {
+    return h(Transition, { mode: 'out-in' }, /* ... */)
   }
 }
 ```
@@ -609,8 +617,7 @@ export default {
   render() {
     return h(SomeComponent, {
       modelValue: this.modelValue,
-      'onUpdate:modelValue': (value) =>
-        this.$emit('update:modelValue', value)
+      'onUpdate:modelValue': (value) => this.$emit('update:modelValue', value)
     })
   }
 }
@@ -627,12 +634,8 @@ import { h, withDirectives } from 'vue'
 
 // a custom directive
 const pin = {
-  mounted() {
-    /* ... */
-  },
-  updated() {
-    /* ... */
-  }
+  mounted() { /* ... */ },
+  updated() { /* ... */ }
 }
 
 // <div v-pin:top.animate="200"></div>


### PR DESCRIPTION
## Description of Problem

See https://github.com/vuejs/docs/issues/1649

## Proposed Solution

Add a shorthand for `.attr` in the directives guide and a note on how to use modifiers in the render function

Close #1649 