### PR TITLE
Be explicit about Composition API style

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -48,7 +48,7 @@ If you are unsure about an option, simply choose `No` by hitting enter for now. 
 <span class="line"><span style="color:var(--vt-c-green);">&gt; </span><span style="color:#A6ACCD;">npm run dev</span></span>
 <span class="line"></span></code></pre></div>
 
-You should now have your first Vue project running! Here are some additional tips:
+You should now have your first Vue project running! You should note here that the components in the generated app are written in [Composition API](guide/extras/composition-api-faq.html) style. Here are some additional tips:
 
 - The recommended IDE setup is [Visual Studio Code](https://code.visualstudio.com/) + [Volar extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar). [WebStorm](https://www.jetbrains.com/webstorm/) is also viable.
 - More tooling details, including integration with backend frameworks, are discussed in the [Tooling Guide](/guide/scaling-up/tooling.html).

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -48,7 +48,7 @@ If you are unsure about an option, simply choose `No` by hitting enter for now. 
 <span class="line"><span style="color:var(--vt-c-green);">&gt; </span><span style="color:#A6ACCD;">npm run dev</span></span>
 <span class="line"></span></code></pre></div>
 
-You should now have your first Vue project running! You should note here that the components in the generated app are written in [Composition API](guide/extras/composition-api-faq.html) style. Here are some additional tips:
+You should now have your first Vue project running! You should note here that the components in the generated app are written in [Composition API](https://vuejs.org/guide/extras/composition-api-faq.html) style. Here are some additional tips:
 
 - The recommended IDE setup is [Visual Studio Code](https://code.visualstudio.com/) + [Volar extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar). [WebStorm](https://www.jetbrains.com/webstorm/) is also viable.
 - More tooling details, including integration with backend frameworks, are discussed in the [Tooling Guide](/guide/scaling-up/tooling.html).


### PR DESCRIPTION
## Description of Problem
The Composition API is fairly new and folks who are more familiar with the Options API may feel a bit lost when `npm unit vue/@latest` generates SFCs (HelloWorld.vue, etc.) written in Composition style.

## Proposed Solution
I think it should be explicitly made clear that the init Vue scaffolding Single File Components are in Composition API style. I think explicit is better than implicit. Helps beginners feel more safe. 

## Additional Information
