### PR TITLE
Update component-basics.md

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -422,12 +422,20 @@ This documents all the events that a component emits and optionally [validates t
 
 <div class="composition-api">
 
-Similar to `defineProps`, `defineEmits` is also only usable in `<script setup>` and doesn't need to be imported. It returns an `emit` function that can be used to emit events in JavaScript code:
+Similar to `defineProps`, `defineEmits` is also only usable in `<script setup>` and doesn't need to be imported. It returns an `emit` function that can be used to emit events:
 
-```js
+```vue
+<!-- BlogPost.vue -->
+<script setup>
 const emit = defineEmits(['enlarge-text'])
-
-emit('enlarge-text')
+</script>
+  
+<template>
+  <div class="blog-post">
+    <h4>{{ title }}</h4>
+    <button @click="emit('enlarge-text')">Enlarge text</button>
+  </div>
+</template>
 ```
 
 See also: [Typing Component Emits](/guide/typescript/composition-api.html#typing-component-emits) <sup class="vt-badge ts" />


### PR DESCRIPTION
## Description of Problem
Previous example didn't show how to use the new script setup defineEmits pattern in the template. This is important because there is no $ before the emit with the new emit pattern. 

## Proposed Solution
I changed the code snippet to be demonstrate how 'emit' using defineEmits would be used in markup.

## Additional Information
