### PR TITLE
Fix reference to another page on Fallthrough Attributes

### DIFF
--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -8,7 +8,7 @@
 
 ## Props Declaration
 
-Vue components require explicit props declaration so that Vue knows what external props passed to the component should be treated as fallthrough attributes (which will be discussed in the next section).
+Vue components require explicit props declaration so that Vue knows what external props passed to the component should be treated as fallthrough attributes (which will be discussed in [its dedicated section](/guide/components/attrs)).
 
 <div class="composition-api">
 


### PR DESCRIPTION
## Description of Problem

"The next section" does not seem to exist within the page.
I guess it is located in the same submenu -> Components in depth -> Fallthrough Attributes.
(/guide/components/attrs)

## Proposed Solution

Add link and link text.
```
(which will be discussed in [its dedicated section](/guide/components/attrs)).
```

## Additional Information
