### PR TITLE
Fixed rendering about ending lines in example desc

### DIFF
--- a/src/examples/utils.ts
+++ b/src/examples/utils.ts
@@ -131,9 +131,9 @@ export function resolveSFCExample(
     raw,
     files,
     (filename, { template, composition, options, style }) => {
-      const desc = raw['description.txt']
+      const desc = raw['description.txt'] as string
       let sfcContent =
-        desc && filename === 'App' ? `<!--\n${desc}\n-->\n\n` : ``
+        desc && filename === 'App' ? `<!--\n${desc.trim()}\n-->\n\n` : ``
       if (preferComposition && composition) {
         sfcContent += `<script setup>\n${toScriptSetup(
           composition,
@@ -159,8 +159,8 @@ export function resolveNoBuildExample(
 ) {
   const files: Record<string, string> = {}
 
-  const desc = raw['description.txt']
-  let html = desc ? `<!--\n${desc}\n-->\n\n` : ``
+  const desc = raw['description.txt'] as string
+  let html = desc ? `<!--\n${desc.trim()}\n-->\n\n` : ``
   let css = ''
 
   // set it first for ordering


### PR DESCRIPTION
## Description of Problem

The common IDE option like "Files: Insert Final Newline" in VSCode which add ending lines for files automatically when you save them, causes an additional empty line in the description comment from `description.txt` in examples.

## Proposed Solution

Just trim the `desc` string in `src/examples/util.ts`

## Additional Information

Original source file:
<img width="274" alt="image" src="https://user-images.githubusercontent.com/206848/169933050-35ffd821-d9c2-48c9-bb6e-49c95726cb36.png">

After saving it with the newline option in VSCode:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/206848/169933098-de5d46b9-4de8-4c08-9d08-c77b3123a358.png">

Then the render result:
<img width="218" alt="image" src="https://user-images.githubusercontent.com/206848/169932719-a7e8d48a-9418-4fe7-a854-c72bd47d10b2.png">

After trimming the desc in `util.ts`:
<img width="211" alt="image" src="https://user-images.githubusercontent.com/206848/169932694-d75d7d01-2bc6-4d75-96b1-5c95d442a920.png">

Thanks.