### PR TITLE
Add Poseidon and Verona themes for PrimeVue

### DIFF
--- a/src/ecosystem/themes/themes.json
+++ b/src/ecosystem/themes/themes.json
@@ -166,6 +166,20 @@
         "image": "https://www.primefaces.org/vue-templates/diamond.jpg"
       },
       {
+        "name": "Poseidon",
+        "price": 59,
+        "description": "PrimeOne Design Admin Template",
+        "url": "https://www.primefaces.org/layouts/poseidon-vue?af_id=4218",
+        "image": "https://www.primefaces.org/vue-templates/poseidon.jpg"
+      },
+      {
+        "name": "Verona",
+        "price": 49,
+        "description": "PrimeOne Design Admin Template",
+        "url": "https://www.primefaces.org/layouts/verona-vue?af_id=4218",
+        "image": "https://www.primefaces.org/vue-templates/verona.jpg"
+      },
+      {
         "name": "Sapphire",
         "price": 49,
         "description": "Material Design Admin Template",


### PR DESCRIPTION
## Description of Problem

Themes page misses new themes from PrimeVue.

## Proposed Solution

Adds new Poseidon and Verona themes from PrimeVue.

