### PR TITLE
Fixed mistype

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -103,7 +103,7 @@ Note how the components can be used as variables in a ternary expression.
 
 ### Recursive Components
 
-An SFC can implicitly refer to itself via its filename. E.g. a file named `FooBar.vue` can refer to itself as `<FooBar/>` in its template.
+A SFC can implicitly refer to itself via its filename. E.g. a file named `FooBar.vue` can refer to itself as `<FooBar/>` in its template.
 
 Note this has lower priority than imported components. If you have a named import that conflicts with the component's inferred name, you can alias the import:
 


### PR DESCRIPTION
From `An SFC` to `A SFC`

## Description of Problem
There is one mistype, using `An SFC` in the beginning of the sentence.

## Proposed Solution
Change it from `An SFC` to `A SFC`

## Additional Information
Nothing else