### PR TITLE
Remove @next tag from @test-library/vue package

### DIFF
--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -288,7 +288,7 @@ When end-to-end (E2E) tests are run in continuous integration / deployment pipel
 In a Vite-based Vue project, run:
 
 ```sh
-> npm install -D vitest happy-dom @testing-library/vue@next
+> npm install -D vitest happy-dom @testing-library/vue
 ```
 
 Next, update the Vite configuration to add the `test` option block:


### PR DESCRIPTION
## Description of Problem
As of [this commit](https://github.com/testing-library/testing-library-docs/commit/ac0737e57af1b3b86cea039beef631e7e52b67f7) the testing library dependency for vue3 is the default one, so no need for the `next` tag.

## Proposed Solution
Remove the `@next` tag from the the npm install command

## Additional Information
