### PR TITLE
Reword passing of prop values to components

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -297,7 +297,7 @@ Then want to render a component for each one, using `v-for`:
 
 </div>
 
-Notice how we can use `v-bind` to pass dynamic props. This is especially useful when you don't know the exact content you're going to render ahead of time.
+Notice how `v-bind` is used  to pass dynamic prop values. This is especially useful when you don't know the exact content you're going to render ahead of time.
 
 That's all you need to know about props for now, but once you've finished reading this page and feel comfortable with its content, we recommend coming back later to read the full guide on [Props](/guide/components/props.html).
 

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -297,7 +297,7 @@ Then want to render a component for each one, using `v-for`:
 
 </div>
 
-Notice how `v-bind` is used  to pass dynamic prop values. This is especially useful when you don't know the exact content you're going to render ahead of time.
+Notice how `v-bind` is used to pass dynamic prop values. This is especially useful when you don't know the exact content you're going to render ahead of time.
 
 That's all you need to know about props for now, but once you've finished reading this page and feel comfortable with its content, we recommend coming back later to read the full guide on [Props](/guide/components/props.html).
 


### PR DESCRIPTION
#1713 raised a problem with the current wording, which refers to 'dynamic props'. It isn't clear what exactly that means, as both prop names and their values could be dynamic.

I've reworded that sentence to mention 'prop values', as well as making it slightly more explicit that the sentence is talking about the example above.