### PR TITLE
fixed API filter bug #1759

### DIFF
--- a/src/api/ApiIndex.vue
+++ b/src/api/ApiIndex.vue
@@ -31,7 +31,9 @@ const filtered = computed(() => {
             return item
           }
           // filter headers
-          const matchedHeaders = item.headers.map(h => h.text).filter(matches)
+          const matchedHeaders = item.headers.filter(
+            ({ text, anchor }) => matches(text) || matches(anchor)
+          )
           return matchedHeaders.length
             ? { text: item.text, link: item.link, headers: matchedHeaders }
             : null

--- a/src/api/api.data.ts
+++ b/src/api/api.data.ts
@@ -4,15 +4,17 @@ import fs from 'fs'
 import path from 'path'
 import { sidebar } from '../../.vitepress/config'
 
+interface APIHeader {
+  anchor: string
+  text: string
+}
+
 export interface APIGroup {
   text: string
   items: {
     text: string
     link: string
-    headers: {
-      anchor: string
-      text: string
-    }[]
+    headers: APIHeader[]
   }[]
 }
 
@@ -37,10 +39,7 @@ export default {
 const headersCache = new Map<
   string,
   {
-    headers: {
-      anchor: string
-      text: string
-    }[]
+    headers: APIHeader[]
     timestamp: number
   }
 >()
@@ -56,10 +55,7 @@ function parsePageHeaders(link: string) {
 
   const src = fs.readFileSync(fullPath, 'utf-8')
   const h2s = src.match(/^## [^\n]+/gm)
-  let headers: {
-    anchor: string
-    text: string
-  }[] = []
+  let headers: APIHeader[] = []
   if (h2s) {
     headers = h2s.map((h) => {
         const text = h


### PR DESCRIPTION
## Description of Problem

API Reference Page's filter with no result breaks page as described on #1759 

## Proposed Solution

Fixed the data matching logic.

## Additional Information

#1757