### PR TITLE
Various tweaks to how events are documented

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -8,7 +8,7 @@
 
 ## Emitting and Listening to Events
 
-A component can emit custom events directly in template expressions (e.g. in a `v-on` handler) using the built-in `$emit` function:
+A component can emit custom events directly in template expressions (e.g. in a `v-on` handler) using the built-in `$emit` method:
 
 ```vue-html
 <!-- MyComponent -->
@@ -17,7 +17,17 @@ A component can emit custom events directly in template expressions (e.g. in a `
 
 <div class="options-api">
 
-The `$emit()` function is also available on the component instance as `this.$emit()`.
+The `$emit()` method is also available on the component instance as `this.$emit()`:
+
+```js
+export default {
+  methods: {
+    submit() {
+      this.$emit('submit')
+    }
+  }
+}
+```
 
 </div>
 
@@ -90,25 +100,48 @@ All extra arguments passed to `$emit()` after the event name will be forwarded t
 
 ## Declaring Emitted Events
 
-Emitted events can be explicitly declared on the component via the <span class="composition-api">[`defineEmits()`](/api/sfc-script-setup.html#defineprops-defineemits) macro</span><span class="options-api">[`emits`](/api/options-state.html#emits) option</span>.
+Emitted events can be explicitly declared on the component via the <span class="composition-api">[`defineEmits()`](/api/sfc-script-setup.html#defineprops-defineemits) macro</span><span class="options-api">[`emits`](/api/options-state.html#emits) option</span>:
 
 <div class="composition-api">
 
 ```vue
 <script setup>
-const emit = defineEmits(['inFocus', 'submit'])
+defineEmits(['inFocus', 'submit'])
 </script>
 ```
 
-The returned `emit` function can be used to emit events in JavaScript.
+The `$emit` method that we used in the `<template>` isn't accessible within the `<script setup>` section of a component, but `defineEmits()` returns an equivalent function that we can use instead:
 
-If not using `<script setup>`, events should be declared using the [`emits`](/api/options-state.html#emits) option, and the `emit` function is exposed on the `setup()` context:
+```vue
+<script setup>
+const emit = defineEmits(['inFocus', 'submit'])
+
+function buttonClick() {
+  emit('submit')
+}
+</script>
+```
+
+The `defineEmits()` macro **cannot** be used inside a function, it must be placed directly within `<script setup>`, as in the example above.
+
+If you're using an explicit `setup` function instead of `<script setup>`, events should be declared using the [`emits`](/api/options-state.html#emits) option, and the `emit` function is exposed on the `setup()` context:
 
 ```js
 export default {
   emits: ['inFocus', 'submit'],
   setup(props, ctx) {
     ctx.emit('submit')
+  }
+}
+```
+
+As with other properties of the `setup()` context, `emit` can safely be destructured:
+
+```js
+export default {
+  emits: ['inFocus', 'submit'],
+  setup(props, { emit }) {
+    emit('submit')
   }
 }
 ```

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -357,7 +357,7 @@ Now let's add a button to the `<BlogPost>` component's template:
 </template>
 ```
 
-The button currently doesn't do anything yet - we want clicking the button to communicate to the parent that it should enlarge the text of all posts. To solve this problem, component instances provide a custom events system. The parent can choose to listen to any event on the child component instance with `v-on` or `@`, just as we would with a native DOM event:
+The button doesn't do anything yet - we want clicking the button to communicate to the parent that it should enlarge the text of all posts. To solve this problem, components provide a custom events system. The parent can choose to listen to any event on the child component instance with `v-on` or `@`, just as we would with a native DOM event:
 
 ```vue-html{3}
 <BlogPost
@@ -422,20 +422,14 @@ This documents all the events that a component emits and optionally [validates t
 
 <div class="composition-api">
 
-Similar to `defineProps`, `defineEmits` is also only usable in `<script setup>` and doesn't need to be imported. It returns an `emit` function that can be used to emit events:
+Similar to `defineProps`, `defineEmits` is only usable in `<script setup>` and doesn't need to be imported. It returns an `emit` function that is equivalent to the `$emit` method. It can be used to emit events in the `<script setup>` section of a component, where `$emit` isn't directly accessible:
 
 ```vue
-<!-- BlogPost.vue -->
 <script setup>
 const emit = defineEmits(['enlarge-text'])
+
+emit('enlarge-text')
 </script>
-  
-<template>
-  <div class="blog-post">
-    <h4>{{ title }}</h4>
-    <button @click="emit('enlarge-text')">Enlarge text</button>
-  </div>
-</template>
 ```
 
 See also: [Typing Component Emits](/guide/typescript/composition-api.html#typing-component-emits) <sup class="vt-badge ts" />


### PR DESCRIPTION
Over the last few weeks I've encountered various examples of people misunderstanding some of the basics of component events. I've tried to address some of the potential sources of confusion in the two pages of the guide that introduce this topic: `component-basics.md` and `events.md`.

One specific problem is understanding the difference between `emit` and `$emit`: I've even encountered people who thought one or the other was a typo in the docs. As I understand it, when Evan rewrote the docs he chose to introduce `$emit` in the  `<template>` first, irrespective of which API people were using. `emit` was then introduced later, in the context of `defineEmits()`, as a way to emit events "in JavaScript", i.e. in the `<script setup>` section. This same approach to introducing the topic was used in both `component-basics.md` and `events.md`. This was lost somewhat when PR #1724 changed an existing example to use `emit` in the `<template>` section. That updated example isn't necessarily wrong, but we lose the attempt to motivate the design of `defineEmits()`. I've rolled back that example as part of this PR and instead I've expanded the text to try to explain the relationship between `$emit` and `emit` a bit more explicitly.

Some other misunderstandings I've encountered that I've tried to address:

* Trying to use `defineEmits()` inside a function.
* Not understanding how to use the `emit` function returned by `defineEmits()` (it's obvious if you understand it's the same as `$emit`, but not everyone gets that).
* Thinking that the `const emit =` part is required, even if you aren't using it. They then can't figure out how to solve the linter error about `emit` being unused. I've tried to address this implicitly, by making the first example in `events.md` use `defineEmits()` without the `const emit =` part.