### PR TITLE
fix: tutorial breaks the back button

### DIFF
--- a/src/tutorial/TutorialRepl.vue
+++ b/src/tutorial/TutorialRepl.vue
@@ -70,7 +70,7 @@ function updateExample(scroll = false) {
   let hash = location.hash.slice(1)
   if (!data.hasOwnProperty(hash)) {
     hash = 'step-1'
-    location.hash = `#${hash}`
+    location.replace(`/tutorial/#${hash}`)
   }
   currentStep.value = hash
 


### PR DESCRIPTION
## Description of Problem
#1768
The tutorial route automatically adds the hash '#step-1' which creates a new history entry. This breaks the back button because every time we go back to the route without the hash it will automatically add the hash again.

## Proposed Solution
Instead of changing the hash, replace the history entry