### PR TITLE
Note the use of GreenSock in an example

### DIFF
--- a/src/guide/built-ins/transition-group.md
+++ b/src/guide/built-ins/transition-group.md
@@ -102,7 +102,7 @@ By communicating with JavaScript transitions through data attributes, it's also 
 </TransitionGroup>
 ```
 
-Then, in JavaScript hooks, we animate the element with a delay based on the data attribute:
+Then, in JavaScript hooks, we animate the element with a delay based on the data attribute. This example is using the [GreenSock library](https://greensock.com/) to perform the animation:
 
 ```js{5}
 function onEnter(el, done) {


### PR DESCRIPTION
Closes #1750.

The use of GreenSock is already noted in the guide to `<Transition>`, but the `<TransitionGroup>` page uses it without any explanation. This PR adds a note that GreenSock is being used.