### PR TITLE
clarify that Object.keys is stable in modern ECMAScript

### DIFF
--- a/src/guide/essentials/list.md
+++ b/src/guide/essentials/list.md
@@ -199,7 +199,7 @@ And another for the index:
 </div>
 
 :::tip Note
-When iterating over an object, the order is based on the enumeration order of `Object.keys()`, which isn't guaranteed to be consistent across JavaScript engine implementations.
+When iterating over an object, the order is based on the enumeration order of `Object.keys()`, which has only been well-defined in modern versions of ECMAScript and could be inconsistent in older JavaScript engines.
 :::
 
 ## `v-for` with a Range


### PR DESCRIPTION
## Description of Problem

The docs claimed that `Object.keys()` is inconsistent across JS engines; this is not true in modern ECMAScript. The ordering is well-defined [in spec](https://tc39.es/ecma262/#sec-ordinaryownpropertykeys).

## Proposed Solution

Made it clearer that the ordering is only inconsistent in legacy engines (especially IE).

## Additional Information

I've done similar work in MDN docs. e.g. https://github.com/mdn/content/pull/17127