### PR TITLE
Hyphenate Single-File Component

### DIFF
--- a/src/guide/scaling-up/sfc.md
+++ b/src/guide/scaling-up/sfc.md
@@ -1,8 +1,8 @@
-# Single File Components
+# Single-File Components
 
 ## Introduction
 
-Vue Single File Components (a.k.a. `*.vue` files, abbreviated as **SFC**) is a special file format that allows us to encapsulate the template, logic, **and** styling of a Vue component in a single file. Here's an example SFC:
+Vue Single-File Components (a.k.a. `*.vue` files, abbreviated as **SFC**) is a special file format that allows us to encapsulate the template, logic, **and** styling of a Vue component in a single file. Here's an example SFC:
 
 ```vue
 <script>
@@ -78,4 +78,4 @@ To answer this question, it is important for us to agree that **separation of co
 
 In modern UI development, we have found that instead of dividing the codebase into three huge layers that interweave with one another, it makes much more sense to divide them into loosely-coupled components and compose them. Inside a component, its template, logic, and styles are inherently coupled, and colocating them actually makes the component more cohesive and maintainable.
 
-Note even if you don't like the idea of Single File Components, you can still leverage its hot-reloading and pre-compilation features by separating your JavaScript and CSS into separate files using [Src Imports](/api/sfc-spec.html#src-imports).
+Note even if you don't like the idea of Single-File Components, you can still leverage its hot-reloading and pre-compilation features by separating your JavaScript and CSS into separate files using [Src Imports](/api/sfc-spec.html#src-imports).


### PR DESCRIPTION
## Description of Problem

Both "Single File Component" and "Single-File Component" were in the documentation

## Proposed Solution

Change "Single File Component" to "Single-File Component" in the documentation to be more consistent with the usual rules for English hyphenation of compound adjectives.

## Additional Information

See #1786 for an explanation (which clarified and reverted #1785)