### PR TITLE
Update sfc-script-setup.md to align with best practices in accessbility

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -35,7 +35,7 @@ function log() {
 </script>
 
 <template>
-  <div @click="log">{{ msg }}</div>
+  <button @click="log">{{ msg }}</button>
 </template>
 ```
 


### PR DESCRIPTION
## Description of Problem
An example within the docs potentially encourages a a11y unfriendly practice of adding interactivity to a non-interactive by default element

## Proposed Solution
This makes a very small change to one of the examples given in the documentation.

There was a click handler on a `div` element as opposed to an interactive element such as `button`. This switches it to button simply to be consistent with best practices around accessibility


## Additional Information
[MDN Article On Button Role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#best_practices)
