### PR TITLE
Clarify a partial transition example

### DIFF
--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -284,6 +284,8 @@ Although the transition classes are only applied to the direct child element in 
   transform: translateX(30px);
   opacity: 0;
 }
+
+/* ... other necessary CSS omitted */
 ```
 
 We can even add a transition delay to the nested element on enter, which creates a staggered enter animation sequence:


### PR DESCRIPTION
This adds the comment suggested in <https://github.com/vuejs/docs/pull/1767#issuecomment-1154643550>, clarifying that the CSS shown is not sufficient for a nested transition to work.