### PR TITLE
Explain v-model with :is and native elements

### DIFF
--- a/src/api/built-in-special-elements.md
+++ b/src/api/built-in-special-elements.md
@@ -90,6 +90,24 @@ A "meta component" for rendering dynamic components or elements.
 
   Registration is not required if you pass the component itself to `is` rather than its name, e.g. in `<script setup>`.
 
+  If `v-model` is used on a `<component>` tag, the template compiler will expand it to a `modelValue` prop and `update:modelValue` event listener, much like it would for any other component. However, this won't be compatible with native HTML elements, such as `<input>` or `<select>`. As a result, using `v-model` with a dynamically created native element won't work: 
+
+  ```vue
+  <script setup>
+  import { ref } from 'vue'
+  
+  const tag = ref('input')
+  const username = ref('')
+  </script>
+
+  <template>
+    <!-- This won't work as 'input' is a native HTML element -->
+    <component :is="tag" v-model="username" />
+  </template>
+  ```
+
+  In practice, this edge case isn't common as native form fields are typically wrapped in components in real applications. If you do need to use a native element directly then you can split the `v-model` into an attribute and event manually.
+
 - **See also:** [Dynamic Components](/guide/essentials/component-basics.html#dynamic-components)
 
 ## `<slot>`


### PR DESCRIPTION
This is an attempt to address the problem raised in #1783.

In brief, `<component :is="'input'" v-model="...">` won't work because the template compiler assumes it is a component `v-model`, not an `<input>` `v-model`.

#1783 attempted to address this in the guide. However, I think it would be better to address this in the API Reference instead. The API Reference already covers some other edge cases involving `<component :is>` that aren't directly mentioned in the guide. It also gives us the freedom to discuss the problem at greater length, without worrying about derailing the narrative flow of the guide.

In particular, the section of the guide that covers `<component :is>` comes before the section on component `v-model`, so it's trying to explain something that the reader isn't expected to have encountered yet.

I don't think this edge case is common enough to justify inclusion in the **Essentials** section of the guide.