### PR TITLE
Extend the examples for async components

### DIFF
--- a/src/guide/components/async.md
+++ b/src/guide/components/async.md
@@ -28,23 +28,56 @@ const AsyncComp = defineAsyncComponent(() =>
 )
 ```
 
-The resulting `AsyncComp` is a wrapper component that only calls the loader function when it is actually rendered on the page. In addition, it will pass along any props to the inner component, so you can use the async wrapper to seamlessly replace the original component while achieving lazy loading.
+The resulting `AsyncComp` is a wrapper component that only calls the loader function when it is actually rendered on the page. In addition, it will pass along any props and slots to the inner component, so you can use the async wrapper to seamlessly replace the original component while achieving lazy loading.
+
+As with normal components, async components can be [registered globally](/guide/components/registration.html#global-registration) using `app.component()`:
+
+```js
+app.component('MyComponent', defineAsyncComponent(() =>
+  import('./components/MyComponent.vue')
+))
+```
 
 <div class="options-api">
 
 You can also use `defineAsyncComponent` when [registering a component locally](/guide/components/registration.html#local-registration):
 
-```js
+```vue
+<script>
 import { defineAsyncComponent } from 'vue'
 
 export default {
-  // ...
   components: {
-    AsyncComponent: defineAsyncComponent(() =>
-      import('./components/AsyncComponent.vue')
+    AdminPage: defineAsyncComponent(() =>
+      import('./components/AdminPageComponent.vue')
     )
   }
 }
+</script>
+
+<template>
+  <AdminPage />
+</template>
+```
+
+</div>
+
+<div class="composition-api">
+
+They can also be defined directly inside their parent component:
+
+```vue
+<script setup>
+import { defineAsyncComponent } from 'vue'
+
+const AdminPage = defineAsyncComponent(() =>
+  import('./components/AdminPageComponent.vue')
+)
+</script>
+
+<template>
+  <AdminPage />
+</template>
 ```
 
 </div>


### PR DESCRIPTION
Attempting to address the problem described in #1782, I've added/extended some examples of async component usage. The main problem to be addressed is showing an example of how an async component is used in the `<template>`. This is described in the text, but it isn't currently shown.

The changes, in order, are:

1. Mention that slots are passed along, as well as props.
2. Show an example of registering an async component using `app.component()`.
3. Extend the existing Options API example to be a full SFC, including a template.
4. Add a roughly equivalent Composition API example.

I do have one concern about the Composition API example. Defining the async component inside `<script setup>` leads to a new wrapper component being created each time the parent component is created. While I would expect `import()` caching to make this unimportant in most cases, I can see an argument for putting the `defineAsyncComponent()` outside of `<script setup>`, so that the wrapper can be reused between instances, with the full benefit of the wrapper's internal cache. I'm unclear whether the docs should address that head on, rather than showing it the way I've shown it here.