### PR TITLE
docs: update the explanation of nextTick

### DIFF
--- a/src/api/general.md
+++ b/src/api/general.md
@@ -16,7 +16,7 @@ Exposes the current version of Vue.
 
 ## nextTick()
 
-A utility for waiting for the next DOM update flush.
+A utility for delaying task execution at next tick, which you can use to wait for the next DOM update flush.
 
 - **Type**
 

--- a/src/api/general.md
+++ b/src/api/general.md
@@ -16,7 +16,7 @@ Exposes the current version of Vue.
 
 ## nextTick()
 
-A utility for delaying task execution at next tick, which you can use to wait for the next DOM update flush.
+A utility for deferring a task execution until the next tick, which you can use to wait for the next DOM update flush.
 
 - **Type**
 


### PR DESCRIPTION
When we use nextTick before mutating the reactive state, I found that it will run before the next DOM update refresh. I think the documentation explanation is misleading, should we keep the original semantics of "next tick"?