### PR TITLE
Fixed a typo (changed an to a, due to consonant)

### DIFF
--- a/src/guide/essentials/list.md
+++ b/src/guide/essentials/list.md
@@ -317,7 +317,7 @@ Check out [this example of a simple todo list](https://sfc.vuejs.org/#eyJBcHAudn
 
 ### Mutation Methods
 
-Vue is able to detect when an reactive array's mutation methods are called and trigger necessary updates. These mutation methods are:
+Vue is able to detect when a reactive array's mutation methods are called and trigger necessary updates. These mutation methods are:
 
 - `push()`
 - `pop()`


### PR DESCRIPTION
## Description of Problem
The docs read 'Vue is able to detect when an reactive array's mutation methods are called and trigger necessary updates'.

## Proposed Solution
This should read 'Vue is able to detect when *a* reactive array's mutation methods are called and trigger necessary updates'
## Additional Information
