### PR TITLE
Update _redirects for existing v2 runtime warning links

### DIFF
--- a/src/public/_redirects
+++ b/src/public/_redirects
@@ -3,10 +3,18 @@
 /ecosystem/partners.html  /partners/
 /resources/*              /ecosystem/:splat
 
-/guide/computed.html                /guide/essentials/computed.html
-/guide/custom-directive.html        /guide/reusability/custom-directives.html
-/guide/list.html                    /guide/essentials/list.html
-/guide/deployment.html              /guide/best-practices/production-deployment.html
+# From Vue v2 runtime warnings
+
+/guide/computed.html                https://v2.vuejs.org/v2/guide/computed.html
+/guide/custom-directive.html        https://v2.vuejs.org/v2/guide/custom-directive.html
+/guide/deployment.html              https://v2.vuejs.org/v2/guide/deployment.html
+/guide/list.html                    https://v2.vuejs.org/v2/guide/list.html
+# https://vuejs.org/v2/api/#data
+# /v2/api/                            https://v2.vuejs.org/v2/api/
+# https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties
+# /v2/guide/reactivity.html           https://v2.vuejs.org/v2/guide/reactivity.html
+# https://vuejs.org/v2/guide/components.html#data-Must-Be-a-Function
+# /v2/guide/components.html           https://v2.vuejs.org/v2/guide/components.html
 
 /v2/guide/team.html                 /about/team.html
 /v2/guide/join.html                 /about/community-guide.html

--- a/src/public/_redirects
+++ b/src/public/_redirects
@@ -3,6 +3,11 @@
 /ecosystem/partners.html  /partners/
 /resources/*              /ecosystem/:splat
 
+/guide/computed.html                https://v2.vuejs.org/v2/guide/computed.html
+/guide/custom-directive.html        https://v2.vuejs.org/v2/guide/custom-directive.html
+/guide/list.html                    https://v2.vuejs.org/v2/guide/list.html
+/guide/deployment.html              https://v2.vuejs.org/v2/guide/deployment.html
+
 /v2/guide/team.html                 /about/team.html
 /v2/guide/join.html                 /about/community-guide.html
 /v2/examples/                       https://vuejs.org/examples/#markdown

--- a/src/public/_redirects
+++ b/src/public/_redirects
@@ -3,10 +3,10 @@
 /ecosystem/partners.html  /partners/
 /resources/*              /ecosystem/:splat
 
-/guide/computed.html                https://v2.vuejs.org/v2/guide/computed.html
-/guide/custom-directive.html        https://v2.vuejs.org/v2/guide/custom-directive.html
-/guide/list.html                    https://v2.vuejs.org/v2/guide/list.html
-/guide/deployment.html              https://v2.vuejs.org/v2/guide/deployment.html
+/guide/computed.html                /guide/essentials/computed.html
+/guide/custom-directive.html        /guide/reusability/custom-directives.html
+/guide/list.html                    /guide/essentials/list.html
+/guide/deployment.html              /guide/best-practices/production-deployment.html
 
 /v2/guide/team.html                 /about/team.html
 /v2/guide/join.html                 /about/community-guide.html


### PR DESCRIPTION
## Description of Problem

Some links from v2 runtime warnings currently are broken like:

https://vuejs.org/guide/computed.html (should be https://v2.vuejs.org/v2/guide/computed.html)
https://vuejs.org/guide/list.html#key (should be https://v2.vuejs.org/v2/guide/list.html#Maintaining-State)

Some of them are already redirected to the v3 doc site, which I think inappropriate:

- https://vuejs.org/v2/api/#data -> https://vuejs.org/api/#data no such an anchor and relevant information there
- https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties -> https://vuejs.org/guide/extras/reactivity-in-depth.html no such anchor and relevant information there
- https://vuejs.org/v2/guide/components.html#data-Must-Be-a-Function -> https://vuejs.org/guide/essentials/component-basics.html no such anchor and relevant information there

**I added 3 new redirects as comments for further discussion.**

## Proposed Solution

## Additional Information

https://github.com/vuejs/vue/pull/12653

Test links:

https://vuejs.org/guide/computed.html
https://v2.vuejs.org/v2/guide/computed.html

https://vuejs.org/guide/custom-directive.html
https://v2.vuejs.org/v2/guide/custom-directive.html

https://vuejs.org/guide/list.html#key
https://v2.vuejs.org/v2/guide/list.html#Maintaining-State

https://vuejs.org/guide/deployment.html
https://v2.vuejs.org/v2/guide/deployment.html

https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties
https://v2.vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties

https://vuejs.org/v2/api/#data
https://v2.vuejs.org/v2/api/#data

https://vuejs.org/v2/guide/components.html#data-Must-Be-a-Function
https://v2.vuejs.org/v2/guide/components.html#data-Must-Be-a-Function
