### PR TITLE
Fix vue mastery banner z-order

### DIFF
--- a/.vitepress/theme/components/VueMasteryBanner.vue
+++ b/.vitepress/theme/components/VueMasteryBanner.vue
@@ -43,7 +43,7 @@ function close () {
   overflow: hidden;
   position: fixed;
   top: 0;
-  z-index: 2;
+  z-index: var(--vp-z-index-banner);
   width: 100%;
   transition: all 0.3s ease-out 0.1s;
 }


### PR DESCRIPTION
Looks like there's already a CSS variable to properly handle banner z-index so I switched it to that.
closes #1846
