### PR TITLE
Fixed small typo

### DIFF
--- a/src/api/component-instance.md
+++ b/src/api/component-instance.md
@@ -55,7 +55,7 @@ The root DOM node that the component instance is managing.
   - For components with multiple root nodes, `$el` will be the placeholder DOM node that Vue uses to keep track of the component's position in the DOM (a text node, or a comment node in SSR hydration mode).
 
   :::tip
-  For consistency, its is recommended to use [template refs](/guide/essentials/template-refs.html) for direct access to elements instead of relying on `$el`.
+  For consistency, it is recommended to use [template refs](/guide/essentials/template-refs.html) for direct access to elements instead of relying on `$el`.
   :::
 
 ## $options


### PR DESCRIPTION
## Description of Problem
A small typo: "For consistency, **_its is_** recommended to use [template refs](https://vuejs.org/guide/essentials/template-refs.html)"

## Proposed Solution
Just fixed it, removing the letter 's'
"For consistency, **_it is_** recommended to use [template refs](https://vuejs.org/guide/essentials/template-refs.html)"

