### PR TITLE
Fix Caveats about props in TS with Options API

### DIFF
--- a/src/guide/typescript/options-api.md
+++ b/src/guide/typescript/options-api.md
@@ -67,7 +67,7 @@ export default defineComponent({
 
 ### Caveats
 
-Because of a [design limitation](https://github.com/microsoft/TypeScript/issues/38845) in TypeScript, you have to be careful when using function values for `validator` and `default` prop options - make sure to use arrow functions:
+If your TypeScript version is less than `4.7`, you have to be careful when using function values for `validator` and `default` prop options - make sure to use arrow functions:
 
 ```ts
 import { defineComponent } from 'vue'
@@ -82,7 +82,7 @@ export default defineComponent({
   props: {
     bookA: {
       type: Object as PropType<Book>,
-      // Make sure to use arrow functions
+      // Make sure to use arrow functions if your TypeScript version is less than 4.7
       default: () => ({
         title: 'Arrow Function Expression'
       }),
@@ -92,7 +92,7 @@ export default defineComponent({
 })
 ```
 
-This prevents TypeScript from having to infer the type of `this` inside these functions, which, unfortunately, can cause the type inference to fail.
+This prevents TypeScript from having to infer the type of `this` inside these functions, which, unfortunately, can cause the type inference to fail. It was a previous [design limitation](https://github.com/microsoft/TypeScript/issues/38845), and now has been improved in [TypeScript 4.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#improved-function-inference-in-objects-and-methods).
 
 ## Typing Component Emits
 


### PR DESCRIPTION
The Document URL is : https://vuejs.org/guide/typescript/options-api.html#typing-component-props

## Description of Problem
The caveats explaination of type inference problem need to update because it has been improved by TypeScript.
[TypeScript release notes 4.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#improved-function-inference-in-objects-and-methods)
[TypeScript PR #48538](https://github.com/microsoft/TypeScript/pull/48538)

## Proposed Solution
Add additional instructions of TypeScript version.
## Additional Information
No more.