### PR TITLE
These code snippets don't match their description

### DIFF
--- a/src/guide/essentials/application.md
+++ b/src/guide/essentials/application.md
@@ -62,13 +62,15 @@ The `.mount()` method should always be called after all app configurations and a
 When using Vue without a build step, we can write our root component's template directly inside the mount container:
 
 ```html
+<script src="https://unpkg.com/vue@3"></script>
+
 <div id="app">
   <button @click="count++">{{ count }}</button>
 </div>
 ```
 
 ```js
-import { createApp } from 'vue'
+const { createApp } = Vue
 
 const app = createApp({
   data() {


### PR DESCRIPTION
## Description of Problem
The document says 'When using Vue _without_ a build step' under [the section 'In-DOM Root Component Template'](https://vuejs.org/guide/essentials/application.html#in-dom-root-component-template). But the first line in the js code snippet seems to require a build step such as Vite?
`import { createApp } from 'vue'`
Since the module name 'vue' doesn't start with a path sign, the code snippet should require a build step such as Vite. ([Reference](https://stackoverflow.com/search?q=Relative+references+must+start+with+either))
## Proposed Solution
Therefore, I edited these two code snippets with reference to [the section 'Without Build Tools'](https://vuejs.org/guide/quick-start.html#without-build-tools) in the article 'Quick Start' in Vue documentation.
I think my edit is proper for documentation readers regards the consistence.
## Additional Information
By the way, I am also a Vue beginner. Let me know if I am wrong.
[See also](https://forum.vuejs.org/t/am-i-right-there-must-be-a-build-step-such-as-vite-as-long-as-you-see-this-code-wherever-import-from-vue/131526).