### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -69,6 +69,16 @@ If you are looking for a lighter-weight alternative for no-build-step usage, che
 
   - emacs support via [lsp-mode](https://emacs-lsp.github.io/lsp-mode/page/lsp-volar/)
 
+## Autocomplete
+
+You can get IDE-style autocompletions for Vue with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ## Browser Devtools
 
 <VueSchoolLink href="https://vueschool.io/lessons/using-vue-dev-tools-with-vuejs-3" title="Free Vue.js Devtools Lesson"/>


### PR DESCRIPTION
[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Vue. It looks like this:

<img width="373" alt="image" src="https://user-images.githubusercontent.com/4949076/181380122-12a44007-049a-4478-a146-fdfd348566e0.png">

We think this will help users become more efficient with Vue CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!
