### PR TITLE
TS Composition API: Mention explicit PropType on prop runtime declaration

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -22,6 +22,22 @@ props.bar // number | undefined
 
 This is called "runtime declaration", because the argument passed to `defineProps()` will be used as the runtime `props` option.
 
+Prop types can also be explicitly declared when using runtime declaration:
+
+```vue
+<script setup lang="ts">
+const props = defineProps({
+  foo: {
+    type: String as PropType<string>,
+    required: true
+  },
+  bar: Number as PropType<number>,
+})
+props.foo // string
+props.bar // number | undefined
+</script>
+```
+
 However, it is usually more straightforward to define props with pure types via a generic type argument:
 
 ```vue


### PR DESCRIPTION
## Description of Problem

Right now, the guide does not mention a way to have explicit prop type declarations and default values at the same time.
The only (close) solution, Reactivity Transform, is experimental and opt-in.

## Proposed Solution

Mentioning the `as PropType <Foo>` syntax, as in this PR.

## Additional Information

I'm filing this PR not only to contribute to the docs and hopefully help others, but also to verify my own approach on the problem. I'd be keen on maintainers' input on this.
