### PR TITLE
Conflicting details on async components with vue router

### DIFF
--- a/src/guide/best-practices/performance.md
+++ b/src/guide/best-practices/performance.md
@@ -82,7 +82,7 @@ import { defineAsyncComponent } from 'vue'
 const Foo = defineAsyncComponent(() => import('./Foo.vue'))
 ```
 
-If using client-side routing via Vue Router, it is strongly recommended to use async components as route components. See [Lazy Loading Routes](https://router.vuejs.org/guide/advanced/lazy-loading.html) for more details.
+If using client-side routing via Vue Router, it is strongly recommended to **not** use async components as route components. Async components can still be used inside route components but route component themselves are just dynamic imports. See [Lazy Loading Routes](https://router.vuejs.org/guide/advanced/lazy-loading.html) for more details.
 
 ### SSR / SSG
 

--- a/src/guide/best-practices/performance.md
+++ b/src/guide/best-practices/performance.md
@@ -82,7 +82,9 @@ import { defineAsyncComponent } from 'vue'
 const Foo = defineAsyncComponent(() => import('./Foo.vue'))
 ```
 
-If using client-side routing via Vue Router, it is strongly recommended to **not** use async components as route components. Async components can still be used inside route components but route component themselves are just dynamic imports. See [Lazy Loading Routes](https://router.vuejs.org/guide/advanced/lazy-loading.html) for more details.
+:::tip
+If using client-side routing via [Vue Router](https://router.vuejs.org/), asynchronous loading with route components is strongly recommended, but not via `defineAsyncComponent`. See [Lazy Loading Routes](https://router.vuejs.org/guide/advanced/lazy-loading.html) for more details.
+:::
 
 ### SSR / SSG
 


### PR DESCRIPTION
The vue docs appear to conflict with vue router's advice on using async components for routes.

*"Do not use Async components for routes. Async components can still be used inside route components but route component themselves are just dynamic imports."* from [Vue Router Docs](https://router.vuejs.org/guide/advanced/lazy-loading.html#lazy-loading-routes)
