### PR TITLE
Adding `<meta name="theme-color" />` for docs

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -560,6 +560,7 @@ export default defineConfigWithTheme<ThemeConfig>({
   scrollOffset: 'header',
 
   head: [
+    ['meta', { name: 'theme-color', content: "#3c8772" }],
     ['meta', { name: 'twitter:site', content: '@vuejs' }],
     ['meta', { name: 'twitter:card', content: 'summary' }],
     [


### PR DESCRIPTION
Adding  `<meta name="theme-color" />` for the docs. For more info https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color

I choosed #3c8772 as a theme-color hence it looks nice in dark mode and white mode too, and that colour in presents in VUE JS logo too.

_Sorry if I made any mistakes :(_