### PR TITLE
Minor gramatical error in attrs.md

### DIFF
--- a/src/guide/components/attrs.md
+++ b/src/guide/components/attrs.md
@@ -177,7 +177,7 @@ export default {
 }
 ```
 
-Note that although the `attrs` object here always reflect the latest fallthrough attributes, it isn't reactive (for performance reasons). You cannot use watchers to observe its changes. If you need reactivity, use a prop. Alternatively, you can use `onUpdated()` to perform side effects with latest `attrs` on each update.
+Note that although the `attrs` object here always reflects the latest fallthrough attributes, it isn't reactive (for performance reasons). You cannot use watchers to observe its changes. If you need reactivity, use a prop. Alternatively, you can use `onUpdated()` to perform side effects with latest `attrs` on each update.
 
 </div>
 


### PR DESCRIPTION
## Description of Problem
There is an 's' missing at the end of 'reflect'...

## Proposed Solution
Add an 's'.
