### PR TITLE
Swapping `indexOf` to `includes` in comparisons

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -19,7 +19,7 @@ export default {
   watch: {
     // whenever question changes, this function will run
     question(newQuestion, oldQuestion) {
-      if (newQuestion.indexOf('?') > -1) {
+      if (newQuestion.includes('?')) {
         this.getAnswer()
       }
     }


### PR DESCRIPTION
This proposal is to remove the usage of the `indexOf` method when testing for the presence of a given character in a string. While `indexOf` is compatible with IE, `includes` is friendlier to newer JavaScript developers and it improves code readability.

## Description of Problem
`indexOf` is the legacy method of checking if a string contains a substring.

## Proposed Solution
Removing usage of `indexOf` and replacing with `includes`

## Additional Information
