### PR TITLE
Fix wrong shuffled team members info

### DIFF
--- a/src/about/team/TeamList.vue
+++ b/src/about/team/TeamList.vue
@@ -20,9 +20,12 @@ defineProps<{
       </div>
 
       <div class="members">
-        <div v-for="member in members" :key="member.name" class="member">
-          <TeamMember :member="member" />
-        </div>
+        <!-- to skip SSG since the members are shuffled -->
+        <ClientOnly>
+          <div v-for="member in members" :key="member.name" class="member">
+            <TeamMember :member="member" />
+          </div>
+        </ClientOnly>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Description of Problem

Wrong sequence of team members info.

## Proposed Solution

Client-side rendering only for shuffled team members.

## Additional Information

#1880