### PR TITLE
Fix hiring link of Vehikl

### DIFF
--- a/src/partners/partners.json
+++ b/src/partners/partners.json
@@ -25,7 +25,7 @@
       "url": "https://www.vehikl.com?utm_source=vue_partners_page"
     },
     "contact": "go+vuepartner@vehikl.com",
-    "hiring": "www.vehikl.com/jobs/developer",
+    "hiring": "https://vehikl.com/jobs/developer/",
     "platinum": true
   },
   {


### PR DESCRIPTION
## Description of Problem
The hiring link show error 404 due to missing protocol.

![image](https://user-images.githubusercontent.com/5250117/182949253-e3046816-8131-4d5c-baaf-2f59f6e90abd.png)

![image](https://user-images.githubusercontent.com/5250117/182949298-03ede544-76bf-4cfe-8741-b40b553be32c.png)

## Proposed Solution
Add protocol to the link.

