### PR TITLE
Web Components: Add Event Handling Caveat

### DIFF
--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -6,7 +6,7 @@ We consider Vue and Web Components to be primarily complementary technologies. V
 
 ## Using Custom Elements in Vue
 
-Vue [scores a perfect 100% in the Custom Elements Everywhere tests](https://custom-elements-everywhere.com/libraries/vue/results/results.html). Consuming custom elements inside a Vue application largely works the same as using native HTML elements, with a few things to keep in mind:
+Consuming custom elements inside a Vue application largely works the same as using native HTML elements, with a few things to keep in mind:
 
 ### Skipping Component Resolution
 
@@ -74,6 +74,30 @@ However, there could be rare cases where the data must be passed as a DOM proper
 <!-- shorthand equivalent -->
 <my-element .user="{ name: 'jack' }"></my-element>
 ```
+
+### Handling Events with Capital Letters
+
+The `v-on` directive handles lowercase and kebab-case events dispatched from custom elements. However, the `v-on` directive does not support listening for events whose names include capital letters. For example, adding `v-on:myInput` to a custom element adds a listener for events with the name `my-input`, which does not handle an event with the name `myInput`.
+
+If your app uses custom elements that dispatch events with capital letters, you can use a custom directive to add the correct event listener to the element.
+
+#### Example Custom Directive to Handle Specific Events
+
+```js
+// ex. <my-element v-event:eventName="handler" />
+app.directive('event', {
+  beforeMount(el, { arg: eventName, value: handler }) {
+    el.addEventListener(eventName, handler)
+  },
+  beforeUnmount(el, { arg: eventName, value: handler }) {
+    el.removeEventListener(eventName, handler)
+  }
+})
+```
+
+**See also:**
+  - [Custom Directives](/guide/reusability/custom-directives.html)
+  - [Built-in "v-on" Directive](/api/built-in-directives.html#v-on)
 
 ## Building Custom Elements with Vue
 

--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -79,9 +79,7 @@ However, there could be rare cases where the data must be passed as a DOM proper
 
 The `v-on` directive handles lowercase and kebab-case events dispatched from custom elements. However, the `v-on` directive does not support listening for events whose names include capital letters. For example, adding `v-on:myInput` to a custom element adds a listener for events with the name `my-input`, which does not handle an event with the name `myInput`.
 
-If your app uses custom elements that dispatch events with capital letters, you can use a custom directive to add the correct event listener to the element.
-
-#### Example Custom Directive to Handle Specific Events
+If you use custom elements that dispatch events with capital letters, you can use a custom directive to add the correct event listener to the element:
 
 ```js
 // ex. <my-element v-event:eventName="handler" />


### PR DESCRIPTION
## Description of Problem

The custom elements section currently includes an incorrect score from Custom Elements Everywhere. Even if Custom Elements Everywhere decided to accept custom directives as satisfactory (which they have not), I don't think the score is all that relevant. Bottom line: custom elements work, and there are some caveats.

The caveat around listening for events with capital letters currently is not documented, and neither is the recommended solution.

## Proposed Solution

- Remove the sentence referring to Custom Elements Everywhere
- Document the caveat around listening to events with names other than lowercase and kebab-case names
- Document the recommended solution of using a custom directive

## Additional Information

Related issue: https://github.com/vuejs/core/issues/5401
Related closed PR: https://github.com/vuejs/docs/pull/1553
Related RFC discussion: https://github.com/vuejs/rfcs/discussions/451
Closes #1708