### PR TITLE
Add a note about `flush: 'sync'`, with links from elsewhere

### DIFF
--- a/src/api/component-instance.md
+++ b/src/api/component-instance.md
@@ -218,7 +218,7 @@ Imperative API for creating watchers.
 
   - **`immediate`**: trigger the callback immediately on watcher creation. Old value will be `undefined` on the first call.
   - **`deep`**: force deep traversal of the source if it is an object, so that the callback fires on deep mutations. See [Deep Watchers](/guide/essentials/watchers.html#deep-watchers).
-  - **`flush`**: adjust the callback's flush timing. See [Callback Flush Timing](/guide/essentials/watchers.html#callback-flush-timing).
+  - **`flush`**: adjust the callback's flush timing. See [Callback Flush Timing](/guide/essentials/watchers.html#callback-flush-timing) and [`watchEffect()`](/api/reactivity-core.html#watcheffect).
   - **`onTrack / onTrigger`**: debug the watcher's dependencies. See [Watcher Debugging](/guide/extras/reactivity-in-depth.html#watcher-debugging).
 
 - **Example**

--- a/src/api/options-state.md
+++ b/src/api/options-state.md
@@ -291,7 +291,7 @@ Declare watch callbacks to be invoked on data change.
 
   - **`immediate`**: trigger the callback immediately on watcher creation. Old value will be `undefined` on the first call.
   - **`deep`**: force deep traversal of the source if it is an object or an array, so that the callback fires on deep mutations. See [Deep Watchers](/guide/essentials/watchers.html#deep-watchers).
-  - **`flush`**: adjust the callback's flush timing. See [Callback Flush Timing](/guide/essentials/watchers.html#callback-flush-timing).
+  - **`flush`**: adjust the callback's flush timing. See [Callback Flush Timing](/guide/essentials/watchers.html#callback-flush-timing) and [`watchEffect()`](/api/reactivity-core.html#watcheffect).
   - **`onTrack / onTrigger`**: debug the watcher's dependencies. See [Watcher Debugging](/guide/extras/reactivity-in-depth.html#watcher-debugging).
 
   Avoid using arrow functions when declaring watch callbacks as they will not have access to the component instance via `this`.

--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -256,6 +256,8 @@ Runs a function immediately while reactively tracking its dependencies and re-ru
 
   The second argument is an optional options object that can be used to adjust the effect's flush timing or to debug the effect's dependencies.
 
+  By default, watchers will run just prior to component rendering. Setting `flush: 'post'` will defer the watcher until after component rendering. See [Callback Flush Timing](/guide/essentials/watchers.html#callback-flush-timing) for more information. In rare cases, it might be necessary to trigger a watcher immediately when a reactive dependency changes, e.g. to invalidate a cache. This can be achieved using `flush: 'sync'`. However, this setting should be used with caution, as it can lead to problems with performance and data consistency if multiple properties are being updated at the same time.
+
   The return value is a handle function that can be called to stop the effect from running again.
 
 - **Example**
@@ -382,7 +384,7 @@ Watches one or more reactive data sources and invokes a callback function when t
 
   - **`immediate`**: trigger the callback immediately on watcher creation. Old value will be `undefined` on the first call.
   - **`deep`**: force deep traversal of the source if it is an object, so that the callback fires on deep mutations. See [Deep Watchers](/guide/essentials/watchers.html#deep-watchers).
-  - **`flush`**: adjust the callback's flush timing. See [Callback Flush Timing](/guide/essentials/watchers.html#callback-flush-timing).
+  - **`flush`**: adjust the callback's flush timing. See [Callback Flush Timing](/guide/essentials/watchers.html#callback-flush-timing) and [`watchEffect()`](/api/reactivity-core.html#watcheffect).
   - **`onTrack / onTrigger`**: debug the watcher's dependencies. See [Watcher Debugging](/guide/extras/reactivity-in-depth.html#watcher-debugging).
 
   Compared to [`watchEffect()`](#watcheffect), `watch()` allows us to:


### PR DESCRIPTION
#1798 proposed adding information about `flush: 'sync'` to the main guide.

In my opinion, `flush: 'sync'` is an escape hatch that should be rarely used and is not something we want to encourage. Such features are typically only mentioned in the API reference, rather than the guide. I think mentioning it in an advanced guide would be fine (e.g. a detailed guide to the scheduler queue), but currently there isn't a suitable advanced guide where this topic can be covered.

The existence of `flush: 'sync'` is already mentioned in the API reference, but as far as I'm aware there isn't currently any explanation about what it does.

In this PR I've added a paragraph to `watchEffect()`, giving a brief explanation of `flush: 'sync'`. I have intentionally not given a lot of information or an example, for the same reason I don't think it should be in the guide.

I've also included links to `watchEffect()` in the entries for `watch`, `$watch()` and `watch()`, under the `flush` option. The alternative was to duplicate the explanation 4 times, which I didn't want to do.