### PR TITLE
Update the note about Vue Router and lazy loading

### DIFF
--- a/src/guide/best-practices/performance.md
+++ b/src/guide/best-practices/performance.md
@@ -71,7 +71,7 @@ function loadLazy() {
 }
 ```
 
-Lazy loading is best used on features that are not immediately needed after initial page load. In Vue applications, this is typically used in combination with Vue's [Async Component](/guide/components/async.html) feature to create split chunks for component trees:
+Lazy loading is best used on features that are not immediately needed after initial page load. In Vue applications, this can be used in combination with Vue's [Async Component](/guide/components/async.html) feature to create split chunks for component trees:
 
 ```js
 import { defineAsyncComponent } from 'vue'
@@ -82,7 +82,7 @@ import { defineAsyncComponent } from 'vue'
 const Foo = defineAsyncComponent(() => import('./Foo.vue'))
 ```
 
-If using client-side routing via Vue Router, it is strongly recommended to use async components as route components. See [Lazy Loading Routes](https://router.vuejs.org/guide/advanced/lazy-loading.html) for more details.
+For applications using Vue Router, it is strongly recommended to use lazy loading for route components. Vue Router has explicit support for lazy loading, separate from `defineAsyncComponent`. See [Lazy Loading Routes](https://router.vuejs.org/guide/advanced/lazy-loading.html) for more details.
 
 ### SSR / SSG
 


### PR DESCRIPTION
This is inspired by the change proposed in #1869.

In Vue 2, Vue Router used Async Components for the lazy loading of route components. However, in Vue 3 these are two similar but distinct features. The description in `performance.md` hasn't taken this separation into account.

The main change is to the paragraph describing the use of lazy loading with Vue Router. This has been updated to reflect the separation between these two features.

I've also tweaked an earlier paragraph to remove the word 'typically'. I think that was a little misleading in a Vue 3 context, as lazy loaded routes are more typical than explicitly using `defineAsyncComponent`.