### PR TITLE
Fix Testing Library example

### DIFF
--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -133,13 +133,11 @@ Component tests should focus on the component's public interfaces rather than in
 <div class="testing-library-api">
 
 ```js
-render(Stepper, {
+const { getByText } = render(Stepper, {
   props: {
     max: 1
   }
 })
-
-const { getByText } = render(Component)
 
 getByText('0') // Implicit assertion that "0" is within the component
 


### PR DESCRIPTION
## Description of Problem
I think the current example is wrong. It seems to render the component twice and uses different variable names for it (`Component` vs `Stepper`).

## Proposed Solution
I guess the proper solution is to refer to the component as `Stepper`, like in the rest of the examples, and render only once.
