### PR TITLE
Subject-verb agreement with "component state"

### DIFF
--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -8,7 +8,7 @@ import SpreadSheet from './demos/SpreadSheet.vue'
 
 # Reactivity in Depth
 
-One of Vue’s most distinct features is the unobtrusive reactivity system. Component state are reactive JavaScript objects. When you modify them, the view updates. It makes state management simple and intuitive, but it’s also important to understand how it works to avoid some common gotchas. In this section, we are going to dig into some of the lower-level details of Vue’s reactivity system.
+One of Vue’s most distinct features is the unobtrusive reactivity system. Component state is reactive JavaScript objects. When you modify them, the view updates. It makes state management simple and intuitive, but it’s also important to understand how it works to avoid some common gotchas. In this section, we are going to dig into some of the lower-level details of Vue’s reactivity system.
 
 ## What is Reactivity?
 


### PR DESCRIPTION
First, I know more about grammar than reactivity/components and this is my first contribution to this, so I'm sorry if this degree of persnicketiness is unwanted, but it seems "component state" is a singular object (grammatically speaking), so "is" would be the correct form of the verb. Furthermore, I think a more succinct sentence would be "Component state is composed of reactive JavaScript objects." Without the word "composed" the sentence seems to indicate that the two things are synonymous, which would be, strictly speaking, false.

## Description of Problem
grammar mistake and hazy language in one important sentence

## Proposed Solution
"Component state is composed of reactive JavaScript objects."

## Additional Information
