### PR TITLE
:memo: Composition api is available in Vue 2.7

### DIFF
--- a/src/guide/extras/composition-api-faq.md
+++ b/src/guide/extras/composition-api-faq.md
@@ -18,7 +18,7 @@ Composition API is a set of APIs that allows us to author Vue components using i
 
 - [Dependency Injection](/api/composition-api-dependency-injection.html), i.e. `provide()` and `inject()`, that allow us to leverage Vue's dependency injection system while using Reactivity APIs.
 
-Composition API is a built-in feature of Vue 3, and is currently available to Vue 2 via the officially maintained [`@vue/composition-api`](https://github.com/vuejs/composition-api) plugin. In Vue 3, it is also primarily used together with the [`<script setup>`](/api/sfc-script-setup.html) syntax in Single-File Components. Here's a basic example of a component using Composition API:
+Composition API is a built-in feature of Vue 3 and [Vue 2.7](https://blog.vuejs.org/posts/vue-2-7-naruto.html). For older Vue 2 versions, use the officially maintained [`@vue/composition-api`](https://github.com/vuejs/composition-api) plugin. In Vue 3, it is also primarily used together with the [`<script setup>`](/api/sfc-script-setup.html) syntax in Single-File Components. Here's a basic example of a component using Composition API:
 
 ```vue
 <script setup>


### PR DESCRIPTION
## Description of Problem

Currently Vue3 docs does not reffer to the composition api added in Vue 2.7

## Proposed Solution

Added link to [Vue 2.7](https://blog.vuejs.org/posts/vue-2-7-naruto.html)

## Additional Information
