### PR TITLE
CRUD Example Patch

### DIFF
--- a/src/examples/src/crud/App/composition.js
+++ b/src/examples/src/crud/App/composition.js
@@ -15,7 +15,7 @@ export default {
     )
 
     watch(selected, (name) => {
-      ;[last.value, first.value] = name.split(', ')
+      [last.value, first.value] = name.split(', ')
     })
 
     function create() {

--- a/src/examples/src/crud/App/options.js
+++ b/src/examples/src/crud/App/options.js
@@ -17,7 +17,7 @@ export default {
   },
   watch: {
     selected(name) {
-      ;[this.last, this.first] = name.split(', ')
+      [this.last, this.first] = name.split(', ')
     }
   },
   methods: {


### PR DESCRIPTION
## Description of Problem
A semicolon is in-front of the watch function for the CRUD example.

## Proposed Solution
Remove semicolon in options and composition API examples.

## Additional Information
