### PR TITLE
fix withDefaults demo

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -302,7 +302,7 @@ export interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   msg: 'hello',
-  labels: () => ['one', 'two']
+  labels: ['one', 'two']
 })
 ```
 


### PR DESCRIPTION
The  `labels`  is  `string[]`  in  Prop Interface, but the default value is a function