### PR TITLE
Fix confusing and unnecessary method access in comments

### DIFF
--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -281,7 +281,7 @@ Do not use `.passive` and `.prevent` together, because `.passive` already indica
 When listening for keyboard events, we often need to check for specific keys. Vue allows adding key modifiers for `v-on` or `@` when listening for key events:
 
 ```vue-html
-<!-- only call `vm.submit()` when the `key` is `Enter` -->
+<!-- only call `submit` when the `key` is `Enter` -->
 <input @keyup.enter="submit" />
 ```
 


### PR DESCRIPTION
## Description of Problem
Confusing and unnecessary method access `vm.submit()` in Key Modifiers section.

## Proposed Solution
Replace `vm.submit()` with simple `submit` method name.
