### PR TITLE
bugfix: circle A behind B, when a click both trigger them, should select B.

### DIFF
--- a/src/examples/src/circle-drawer/App/composition.js
+++ b/src/examples/src/circle-drawer/App/composition.js
@@ -16,7 +16,7 @@ export default {
         return
       }
 
-      selected.value =  [...circles.value].reverse().find(({ cx, cy, r }) => {
+      selected.value = [...circles.value].reverse().find(({ cx, cy, r }) => {
         const dx = cx - x
         const dy = cy - y
         return Math.sqrt(dx * dx + dy * dy) <= r

--- a/src/examples/src/circle-drawer/App/composition.js
+++ b/src/examples/src/circle-drawer/App/composition.js
@@ -16,7 +16,7 @@ export default {
         return
       }
 
-      selected.value = circles.value.find(({ cx, cy, r }) => {
+      selected.value =  [...circles.value].reverse().find(({ cx, cy, r }) => {
         const dx = cx - x
         const dy = cy - y
         return Math.sqrt(dx * dx + dy * dy) <= r

--- a/src/examples/src/circle-drawer/App/options.js
+++ b/src/examples/src/circle-drawer/App/options.js
@@ -21,7 +21,7 @@ export default {
         return
       }
 
-      this.selected = this.circles.find(({ cx, cy, r }) => {
+      this.selected = [...this.circles].reverse().find(({ cx, cy, r }) => {
         const dx = cx - x
         const dy = cy - y
         return Math.sqrt(dx * dx + dy * dy) <= r


### PR DESCRIPTION
## Description of Problem
now, will select A;

## Proposed Solution
use reverse find circle from right

## Additional Information
