### PR TITLE
Update link to Takeover Mode

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -357,4 +357,4 @@ const openModal = () => {
 </script>
 ```
 
-Note if you want to use this technique in TypeScript files instead of Vue SFCs, you need to enable Volar's [Takeover Mode](./overview.html#takeover-mode).
+Note if you want to use this technique in TypeScript files instead of Vue SFCs, you need to enable Volar's [Takeover Mode](./overview.html#volar-takeover-mode).


### PR DESCRIPTION
The section heading 'Takeover Mode' was recently renamed to 'Volar Takeover Mode'. This PR updates a link to reflect the new hash.