### PR TITLE
Small tweaks to the introduction of reactivity-in-depth.md

### DIFF
--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -8,7 +8,7 @@ import SpreadSheet from './demos/SpreadSheet.vue'
 
 # Reactivity in Depth
 
-One of Vue’s most distinct features is the unobtrusive reactivity system. Component state are reactive JavaScript objects. When you modify them, the view updates. It makes state management simple and intuitive, but it’s also important to understand how it works to avoid some common gotchas. In this section, we are going to dig into some of the lower-level details of Vue’s reactivity system.
+One of Vue’s most distinctive features is the unobtrusive reactivity system. Component state consists of reactive JavaScript objects. When you modify them, the view updates. It makes state management simple and intuitive, but it’s also important to understand how it works to avoid some common gotchas. In this section, we are going to dig into some of the lower-level details of Vue’s reactivity system.
 
 ## What is Reactivity?
 


### PR DESCRIPTION
#1906 seems to have stalled, so I've made the proposed changes here instead.

***distinct*** seems like it should be ***distinctive*** instead.

***Component state are*** seems grammatically off, but it's tricky because we're equating a singular (state) with a plural (objects), making both ***are*** and ***is*** sound a bit wrong. I've attempted to dodge that altogether by changing it to ***consists of*** instead.