### PR TITLE
Adjust an example template in animation.md

### DIFF
--- a/src/guide/extras/animation.md
+++ b/src/guide/extras/animation.md
@@ -165,6 +165,11 @@ watch(number, (n) => {
 })
 ```
 
+```vue-html
+Type a number: <input v-model.number="number" />
+<p>{{ tweened.number.toFixed(0) }}</p>
+```
+
 </div>
 <div class="options-api">
 
@@ -186,12 +191,12 @@ export default {
 }
 ```
 
-</div>
-
 ```vue-html
 Type a number: <input v-model.number="number" />
-<p>{{ tweened.number.toFixed(0) }}</p>
+<p>{{ tweened.toFixed(0) }}</p>
 ```
+
+</div>
 
 <AnimateWatcher />
 


### PR DESCRIPTION
This fixes the problem reported in #1899.

The final example in `animation.md` needs a slightly different template for the Options and Composition API examples. The Playgrounds already include this difference, but the code shown in the docs was sharing the same template.

The current template has been moved up, so that it is inside the `<div class="composition-api">`. A copy is now included inside the `<div class="options-api">`, with `tweened.number.toFixed(0)` changed to `tweened.toFixed(0)`.