### PR TITLE
Add missing possessive apostrophes

### DIFF
--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -251,7 +251,7 @@ To address this problem, Vue provides **event modifiers** for `v-on`. Recall tha
 ```
 
 ::: tip
-Order matters when using modifiers because the relevant code is generated in the same order. Therefore using `@click.prevent.self` will prevent **clicks default action on the element itself and its children** while `@click.self.prevent` will only prevent clicks default action on the element itself.
+Order matters when using modifiers because the relevant code is generated in the same order. Therefore using `@click.prevent.self` will prevent **click's default action on the element itself and its children**, while `@click.self.prevent` will only prevent click's default action on the element itself.
 :::
 
 The `.capture`, `.once`, and `.passive` modifiers mirror the [options of the native `addEventListener` method](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options):


### PR DESCRIPTION
## Description of Problem

The word "clicks" is supposed to be in a possessive form in this context, and therefore apostrophe before the last letter "s" in that word is warranted.

## Proposed Solution

Addition of possessive apostrophes, i.e. clicks -> click's.

## Additional Information

Additionally added a comma before the word "while" since it is used to express the contrast between the two examples of modifiers.
