### PR TITLE
docs: document mixing named and default slots

### DIFF
--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -415,6 +415,7 @@ Note the `name` of a slot won't be included in the props because it is reserved 
 If you are mixing named slots with the default scoped slot, you need to use an explicit `<template>` tag for the default slot. Attempting to place the `v-slot` directive directly on the component will result in a compilation error. This is to avoid any ambiguity about the scope of the props of the default slot. For example:
 
 ```vue-html
+<!-- This template won't compile -->
 <template>
   <MyComponent v-slot="{ message }">
     <p>{{ message }}</p>

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -276,36 +276,6 @@ Now everything inside the `<template>` elements will be passed to the correspond
 
 </div>
 
-Note that if you are mixing named slots with the default slot, you need to explicitly define the default template. Otherwise, it would hint that the data of the default slot would be available in the other slots scopes.
-
-```vue-html
-<template>
-  <BaseLayout v-slot="{ message }">
-    <p>{{ message }}</p>
-    <template #footer>
-      <!-- message belongs to the default slot, and is not available here -->
-      <p>{{ message }}</p>
-    </template>
-  </BaseLayout>
-</template>
-```
-
-Instead, you will need to write it as follows:
-```vue-html
-<template>
-  <MyComponent>
-    <!-- Use explicit default slot -->
-    <template #default="{ message }">
-      <p>{{ message }}</p>
-    </template>
-
-    <template #footer>
-      <p>Here's some contact info</p>
-    </template>
-  </MyComponent>
-</template>
-```
-
 Again, it may help you understand named slots better using the JavaScript function analogy:
 
 ```js
@@ -441,6 +411,36 @@ Passing props to a named slot:
 ```
 
 Note the `name` of a slot won't be included in the props because it is reserved - so the resulting `headerProps` would be `{ message: 'hello' }`.
+
+Also note that if you are mixing named scoped slots with the default scoped slot, you need to explicitly define the default template. Otherwise, it would hint that the data of the default scoped slot would be available in the other slots scopes.
+
+```vue-html
+<template>
+  <BaseLayout v-slot="{ message }">
+    <p>{{ message }}</p>
+    <template #footer>
+      <!-- message belongs to the default slot, and is not available here -->
+      <p>{{ message }}</p>
+    </template>
+  </BaseLayout>
+</template>
+```
+
+Instead, you will need to write it as follows:
+```vue-html
+<template>
+  <MyComponent>
+    <!-- Use explicit default slot -->
+    <template #default="{ message }">
+      <p>{{ message }}</p>
+    </template>
+
+    <template #footer>
+      <p>Here's some contact info</p>
+    </template>
+  </MyComponent>
+</template>
+```
 
 ### Fancy List Example
 

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -412,6 +412,54 @@ Passing props to a named slot:
 
 Note the `name` of a slot won't be included in the props because it is reserved - so the resulting `headerProps` would be `{ message: 'hello' }`.
 
+Also note that if you are mixing named slots with the default slot, you need to explicitly define the default template. Otherwise, it would hint that the data of the default slot would be available in the other slots scopes.
+
+```vue-html
+<template>
+  <TabSelector v-model="currentTab" v-slot="{ setTab }">
+    <button @click="setTab('a')">
+      Click on A
+    </button>
+
+    <template #a>
+      This is A content
+      <!-- setTab belongs to the default slot, and is not available here -->
+      <button @click="setTab('b')">
+        Click on B
+      </button>
+      <button @click="setTab('c')">
+        Click on B
+      </button>
+    </template>
+    <template #b>
+      This is B content
+    </template>
+  </TabSelector>
+</template>
+```
+
+Instead, you will need to write it as follows:
+```vue-html
+<template>
+  <TabSelector v-model="currentTab">
+    <!-- Use explicit default slot -->
+    <template #default="{ setTab }">
+      <button @click="setTab('a')">
+        Click on A
+      </button>
+    </template>
+
+    <template #a>
+      This is A content
+    </template>
+    <template #b>
+      This is B content
+    </template>
+  </TabSelector>
+</template>
+```
+
+
 ### Fancy List Example
 
 You may be wondering what would be a good use case for scoped slots. Here's an example: imagine a `<FancyList>` component that renders a list of items - it may encapsulate the logic for loading remote data, using the data to display a list, or even advanced features like pagination or infinite scrolling. However, we want it to be flexible with how each item looks and leave the styling of each item to the parent component consuming it. So the desired usage may look like this:

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -412,7 +412,7 @@ Passing props to a named slot:
 
 Note the `name` of a slot won't be included in the props because it is reserved - so the resulting `headerProps` would be `{ message: 'hello' }`.
 
-Also note that if you are mixing named scoped slots with the default scoped slot, you need to explicitly define the default template. Otherwise, it would hint that the data of the default scoped slot would be available in the other slots scopes.
+If you are mixing named slots with the default scoped slot, you need to use an explicit `<template>` tag for the default slot. Attempting to place the `v-slot` directive directly on the component will result in a compilation error. This is to avoid any ambiguity about the scope of the props of the default slot. For example:
 
 ```vue-html
 <template>

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -427,7 +427,8 @@ If you are mixing named slots with the default scoped slot, you need to use an e
 </template>
 ```
 
-Instead, you will need to write it as follows:
+Using an explicit `<template>` tag for the default slot helps to make it clear that the `message` prop is not available inside the other slot:
+
 ```vue-html
 <template>
   <MyComponent>

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -416,13 +416,13 @@ Also note that if you are mixing named scoped slots with the default scoped slot
 
 ```vue-html
 <template>
-  <BaseLayout v-slot="{ message }">
+  <MyComponent v-slot="{ message }">
     <p>{{ message }}</p>
     <template #footer>
       <!-- message belongs to the default slot, and is not available here -->
       <p>{{ message }}</p>
     </template>
-  </BaseLayout>
+  </MyComponent>
 </template>
 ```
 

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -276,6 +276,36 @@ Now everything inside the `<template>` elements will be passed to the correspond
 
 </div>
 
+Note that if you are mixing named slots with the default slot, you need to explicitly define the default template. Otherwise, it would hint that the data of the default slot would be available in the other slots scopes.
+
+```vue-html
+<template>
+  <BaseLayout v-slot="{ message }">
+    <p>{{ message }}</p>
+    <template #footer>
+      <!-- message belongs to the default slot, and is not available here -->
+      <p>{{ message }}</p>
+    </template>
+  </BaseLayout>
+</template>
+```
+
+Instead, you will need to write it as follows:
+```vue-html
+<template>
+  <MyComponent>
+    <!-- Use explicit default slot -->
+    <template #default="{ message }">
+      <p>{{ message }}</p>
+    </template>
+
+    <template #footer>
+      <p>Here's some contact info</p>
+    </template>
+  </MyComponent>
+</template>
+```
+
 Again, it may help you understand named slots better using the JavaScript function analogy:
 
 ```js
@@ -411,54 +441,6 @@ Passing props to a named slot:
 ```
 
 Note the `name` of a slot won't be included in the props because it is reserved - so the resulting `headerProps` would be `{ message: 'hello' }`.
-
-Also note that if you are mixing named slots with the default slot, you need to explicitly define the default template. Otherwise, it would hint that the data of the default slot would be available in the other slots scopes.
-
-```vue-html
-<template>
-  <TabSelector v-model="currentTab" v-slot="{ setTab }">
-    <button @click="setTab('a')">
-      Click on A
-    </button>
-
-    <template #a>
-      This is A content
-      <!-- setTab belongs to the default slot, and is not available here -->
-      <button @click="setTab('b')">
-        Click on B
-      </button>
-      <button @click="setTab('c')">
-        Click on B
-      </button>
-    </template>
-    <template #b>
-      This is B content
-    </template>
-  </TabSelector>
-</template>
-```
-
-Instead, you will need to write it as follows:
-```vue-html
-<template>
-  <TabSelector v-model="currentTab">
-    <!-- Use explicit default slot -->
-    <template #default="{ setTab }">
-      <button @click="setTab('a')">
-        Click on A
-      </button>
-    </template>
-
-    <template #a>
-      This is A content
-    </template>
-    <template #b>
-      This is B content
-    </template>
-  </TabSelector>
-</template>
-```
-
 
 ### Fancy List Example
 


### PR DESCRIPTION
https://github.com/vuejs/core/issues/6549

## Description of Problem

Regarding [this issue](https://github.com/vuejs/core/issues/6549), the compiler doesn't inform what's the real problem with mixing named slot and default. This PR updates the documentation to explain how to avoid this error. The compiler error still needs to be clearer.

## Proposed Solution

Provide an example on how to use default slots along named slots

## Additional Information

—