### PR TITLE
fix: partner shuffling bug in prod mode

### DIFF
--- a/src/partners/components/PartnerList.vue
+++ b/src/partners/components/PartnerList.vue
@@ -45,7 +45,7 @@ function shuffle(array: Array<any>) {
 
 <template>
   <div class="PartnerList" v-show="mounted">
-    <!-- to skip SSG since the members are shuffled -->
+    <!-- to skip SSG since the partners are shuffled -->
     <ClientOnly>
       <PartnerCard v-for="p in filtered" :key="p.name" :data="p" />
     </ClientOnly>

--- a/src/partners/components/PartnerList.vue
+++ b/src/partners/components/PartnerList.vue
@@ -45,7 +45,10 @@ function shuffle(array: Array<any>) {
 
 <template>
   <div class="PartnerList" v-show="mounted">
-    <PartnerCard v-for="p in filtered" :key="p.name" :data="p" />
+    <!-- to skip SSG since the members are shuffled -->
+    <ClientOnly>
+      <PartnerCard v-for="p in filtered" :key="p.name" :data="p" />
+    </ClientOnly>
   </div>
 </template>
 


### PR DESCRIPTION
## Description of Problem

The "All partners" page is rendered randomly incorrect due to the shuffling logic.

## Proposed Solution

Force render in client-side within `<ClientOnly>`

## Additional Information

no