### PR TITLE
Fix spelling and grammar

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -14,13 +14,13 @@ footer: false
 
 ## Creating a Vue Application
 
-:::tip Pre-requisites
+:::tip Prerequisites
 
 - Familiarity with the command line
 - Install [Node.js](https://nodejs.org/) version 16.0 or higher
   :::
 
-In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue.html#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vitejs.dev), and allows us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).
+In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue.html#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vitejs.dev), and allow us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).
 
 Make sure you have an up-to-date version of [Node.js](https://nodejs.org/) installed, then run the following command in your command line (without the `>` sign):
 


### PR DESCRIPTION
## Description of Problem

"Pre-requisites" is spelled with a hyphen, which is an uncommon spelling (this is also inconsistent with other pages, where hyphen is not used in that word).

The usage of the word "allows" is confusing in the specified sentence, which begins in a future tense. It makes more sense to omit the "s" at the end of it and make it "allow".

## Proposed Solution

Pre-requisites -> Prerequisites

allows -> allow
