### PR TITLE
Add a virtual list library

### DIFF
--- a/src/guide/best-practices/performance.md
+++ b/src/guide/best-practices/performance.md
@@ -138,6 +138,7 @@ Implementing list virtualization isn't easy, luckily there are existing communit
 
 - [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller)
 - [vue-virtual-scroll-grid](https://github.com/rocwang/vue-virtual-scroll-grid)
+- [vueuc/VVirtualList](https://github.com/07akioni/vueuc)
 
 ### Reduce Reactivity Overhead for Large Immutable Structures
 


### PR DESCRIPTION
Since [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller) don't have types, it's necessary to introduce a new library.

## Description of Problem

[vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller) don't have types.

## Proposed Solution

Introduce a new library.

## Additional Information
