### PR TITLE
Update Free Weekend Vue School banner

### DIFF
--- a/.vitepress/theme/components/Banner.vue
+++ b/.vitepress/theme/components/Banner.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { computed } from 'vue'
+
 /**
  * Adding a new banner:
  * 1. uncomment the banner slot in ../index.ts
@@ -7,6 +9,74 @@
  */
 
 let open = $ref(true)
+
+const items = [
+  {
+    banner: {
+      assets: "FREE_WEEKEND",
+      cta: "Book my spot",
+      link: "/free-weekend",
+      static: "FREE_WEEKEND",
+      subtitle: "Get Access to ALL Vue School premium courses",
+      title: "Free Weekend 1st & 2nd of October"
+    },
+    ends: "2022-09-30T23:59:59+02:00",
+    id: "FREE_WEEKEND_LOBBY",
+    isExtended: false
+  },
+  {
+    banner: {
+      assets: "FREE_WEEKEND",
+      cta: "WATCH FOR FREE",
+      link: "/free-weekend",
+      static: "FREE_WEEKEND_LIVE",
+      subtitle: "Get Access to ALL Vue School premium courses",
+      title: "Free Weekend <strong>NOW LIVE</strong>"
+    },
+    ends: "2022-10-02T23:59:59+02:00",
+    id: "FREE_WEEKEND_LIVE",
+    isExtended: false
+  },
+  {
+    banner: {
+      assets: "LEVELUP2022",
+      cta: "GET OFFER",
+      link: "/sales/levelup2022",
+      static: "LEVELUP2022",
+      subtitle: "Access 800+ lessons including the Vue.js 3 Masterclass",
+      title: "Less than <strong>_HOURS_ hours</strong> to get 45% off at Vue School today"
+    },
+    ends: "2022-10-04T23:59:59+02:00",
+    id: "LEVELUP2022",
+    isExtended: false
+  },
+  {
+    banner: {
+      assets: "LEVELUP2022",
+      cta: "GET OFFER",
+      link: "/sales/levelup2022",
+      static: "LEVELUP2022",
+      subtitle: "Extended! Access 800+ lessons including the Vue.js 3 Masterclass",
+      title: "Less than <strong>_HOURS_ hours</strong> to get 45% off at Vue School today"
+    },
+    ends: "2022-10-06T23:59:59+02:00",
+    id: "LEVELUP2022_EXTENDED",
+    isExtended: true
+  }
+]
+
+const now = new Date('2022-10-06')
+const phases = computed(() => items.map(phase => ({ ...phase, remaining: new Date(phase.ends) - now })))
+const activePhase = computed(() => phases.value.find(phase => phase.remaining > 0))
+const title = computed(() => {
+  if (!activePhase.value) return null
+  const hours = Math.ceil(activePhase.value.remaining / 1000 / 60 / 60)
+  return activePhase.value.banner.title.replace('_HOURS_', hours)
+})
+const activeBanner = computed(() => {
+  if (!activePhase.value) return null
+  return activePhase.value.banner
+})
 
 /**
  * Call this if the banner is dismissible
@@ -19,38 +89,29 @@ function dismiss() {
 </script>
 
 <template>
-  <div class="banner" v-if="open">
+  <div class="banner" v-if="open && activeBanner">
     <a
-      id="vs"
-      href="https://vueschool.io/free-weekend?friend=vuejs&utm_source=vuejs&utm_medium=website&utm_campaign=affiliate&utm_content=top_banner"
+      id="vs-top"
+      :href="`https://vueschool.io${activeBanner.link}?friend=vuejs&utm_source=vuerouter&utm_medium=website&utm_campaign=affiliate&utm_content=top_banner`"
       target="_blank"
-      rel="noreferrer">
-      <div
-        class="vs-background-wrapper">
-        <div class="vs-logo">
-          <img src="/images/vueschool/vs-iso.svg" class="logo-small">
-          <img src="/images/vueschool/vs-logo.svg" class="logo-big">
-        </div>
+      :class="activeBanner.assets">
+      <div class="vs-background-wrapper">
+        <div class="vs-logo" />
         <div class="vs-core">
           <div class="vs-slogan-wrapper">
-            <div class="vs-slogan">
-              Free Weekend 1st & 2nd of October
-            </div>
-            <div class="vs-subline">
-              Get Access to ALL Vue School premium courses
-            </div>
+            <div class="vs-slogan" v-html="title" />
+            <div class="vs-subline" v-html="activeBanner.subtitle" />
           </div>
           <div class="vs-button-wrapper">
             <div class="vs-button">
-              Join for Free
+              {{ activeBanner.cta }}
             </div>
           </div>
         </div>
         <div
-          id="vs-close"
           class="vs-close"
-          @click.stop.prevent="dismiss">
-          <img src="/images/vueschool/close.svg" alt="Close">
+          @click.prevent.stop="dismiss">
+          <img src="https://vueschool.io/images/close.svg" alt="Close">
         </div>
       </div>
     </a>
@@ -62,87 +123,81 @@ html:not(.banner-dismissed) {
   --vt-banner-height: 72px;
 }
 
-#vs {
-  background-color: #0A1124;
+#vs-top {
+  display: block;
   box-sizing: border-box;
-  color: #fff;
-  font-family: 'Roboto', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  height: 72px;
   position: fixed;
+  top: 0;
   left: 0;
   right: 0;
-  top: 0;
   z-index: 100;
-  height: 72px;
-  background: linear-gradient(to left, #161a35, #283065);
   line-height: 1;
 }
 
-#vs .vs-background-wrapper {
+#vs-top .vs-background-wrapper {
   align-items: center;
   justify-content: center;
   display: flex;
   padding: 0 10px;
   height: 100%;
   width: 100%;
-  background-image: url(/images/vueschool/bg-mobile.png);
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: top right;
 }
 
-#vs:hover {
+#vs-top:hover {
   text-decoration: none;
 }
 
-#vs:hover .vs-core .vs-button {
+#vs-top:hover .vs-core .vs-button {
   background-image: linear-gradient(to bottom, #5ccc45, #419E2D), linear-gradient(to bottom, #388f26, #50b83b);
 }
 
-#vs .vs-logo {
+#vs-top .vs-logo {
   position: absolute;
   left: 10px;
+  width: 36px;
+  height: 42px;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
-#vs .vs-logo .logo-big {
-  display: none;
-}
-
-#vs .vs-core {
+#vs-top .vs-core {
   display: flex;
   align-items: center;
   width: 288px;
 }
 
-#vs .vs-core .vs-slogan-wrapper {
+#vs-top .vs-core .vs-slogan-wrapper {
   text-align: center;
-  width: 170px;
+  width: 184px;
   margin: 0 auto;
 }
 
-#vs .vs-core .vs-slogan {
-  color: #fff;
+#vs-top .vs-core .vs-slogan {
   font-weight: bold;
-  font-size: 10px;
+  font-size: 12px;
+  font-family: 'Roboto', Arial, sans-serif;
 }
 
-#vs .vs-core .vs-subline {
-  color: #c6cdf7;
+#vs-top .vs-core .vs-subline {
   font-size: 10px;
-  margin-top: 4px;
+  font-family: 'Roboto', Arial, sans-serif;
+  text-align: center;
 }
 
-#vs .vs-core .vs-button-wrapper {
+#vs-top .vs-core .vs-button-wrapper {
   padding: 2px;
   background-image: linear-gradient(to bottom, #388f26, #50b83b);
   border-radius: 60px;
   overflow: hidden;
 }
 
-#vs .vs-core .vs-button {
+#vs-top .vs-core .vs-button {
+  background-image: linear-gradient(to bottom, #5ccc45, #368c24), linear-gradient(to bottom, #388f26, #50b83b);
   border-radius: 60px;
   color: #FFF;
   padding: 8px 6px;
-  background-image: linear-gradient(to bottom, #5ccc45, #368c24), linear-gradient(to bottom, #388f26, #50b83b);
   font-weight: bold;
   text-transform: uppercase;
   text-align: center;
@@ -151,82 +206,179 @@ html:not(.banner-dismissed) {
   white-space: nowrap;
 }
 
-#vs .vs-close {
+#vs-top .vs-close {
   right: 0;
   position: absolute;
   padding: 10px;
 }
 
-#vs .vs-close:hover {
+#vs-top .vs-close:hover {
   color: #56d8ff;
 }
 
 @media (min-width: 680px) {
-  #vs .vs-background-wrapper {
-    background-image: url(/images/vueschool/bg-tablet.svg);
-  }
-
-  #vs .vs-logo {
-    left: 20px;
-  }
-
-  #vs .vs-logo .logo-small {
-    display: none;
-  }
-
-  #vs .vs-logo .logo-big {
-    display: inline-block;
-    width: 90px;
-  }
-
-  #vs .vs-core {
+  #vs-top .vs-core {
     width: auto;
-    margin-right: -60px;
   }
 
-  #vs .vs-core .vs-slogan-wrapper {
+  #vs-top .vs-core .vs-slogan-wrapper {
     margin: 0 12px 0 0;
-    width: auto;
+    width: 458px;
   }
 
-  #vs .vs-core .vs-slogan {
-    font-size: 16px;
+  #vs-top .vs-core .vs-slogan {
+    font-size: 17px;
   }
 
-  #vs .vs-core .vs-subline {
-    font-size: 15px;
-    text-align: left;
+  #vs-top .vs-core .vs-subline {
+    font-size: 12px;
+    margin-top: 4px;
   }
 
-  #vs .vs-core .vs-button {
+  #vs-top .vs-core .vs-button {
     font-size: 13px;
     padding: 8px 15px;
-  }
-
-  #vs .vs-close {
-    right: 20px;
-  }
-}
-
-@media (min-width: 900px) {
-  #vs .vs-background-wrapper {
-    background-image: url(/images/vueschool/bg-desktop.svg);
-    background-position: top right -300px;
-  }
-
-  #vs .vs-logo .logo-big {
-    display: inline-block;
-    width: auto;
-  }
-
-  #vs .vs-core {
-    margin-right: 0;
   }
 }
 
 @media (min-width: 1280px) {
-  #vs .vs-background-wrapper {
-    background-position: top right;
+  #vs-top .vs-logo {
+    left: 20px;
+    width: 104px;
+  }
+
+  #vs-top .vs-core {
+    margin-right: 0;
+  }
+
+  #vs-top .vs-core .vs-slogan-wrapper {
+    width: auto;
+  }
+
+  #vs-top .vs-core .vs-subline {
+    font-size: 15px;
+  }
+}
+
+/* FREE_WEEKEND
+******************************************/
+
+#vs-top.FREE_WEEKEND {
+  color: #FFF;
+  background: linear-gradient(to left, #161a35, #283065);
+}
+
+#vs-top.FREE_WEEKEND .vs-logo {
+  background-image: url(https://vueschool.io/images/mark-vueschool-white.svg);
+}
+
+#vs-top.FREE_WEEKEND .vs-core .vs-slogan {
+  color: #fff;
+}
+
+#vs-top.FREE_WEEKEND .vs-core .vs-slogan strong {
+  color: #ff2556;
+}
+
+#vs-top.FREE_WEEKEND .vs-core .vs-subline {
+  color: #c6cdf7;
+}
+
+#vs-top.FREE_WEEKEND .vs-background-wrapper {
+  background-image: url(https://vueschool.io/images/banners/assets/FREE_WEEKEND/bg-mobile.png);
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: top right;
+}
+
+@media (min-width: 680px) {
+  #vs-top.FREE_WEEKEND .vs-background-wrapper {
+    background-image: url(https://vueschool.io/images/banners/assets/FREE_WEEKEND/bg-tablet.svg);
+  }
+}
+
+@media (min-width: 1280px) {
+  #vs-top.FREE_WEEKEND .vs-logo {
+    background-image: url(https://vueschool.io/images/icons/logo-white.svg);
+  }
+
+  #vs-top.FREE_WEEKEND .vs-background-wrapper {
+    background-image: url(https://vueschool.io/images/banners/assets/FREE_WEEKEND/bg-desktop.svg);
+    background-position: top right -60px;
+  }
+}
+
+/* LEVELUP2022
+******************************************/
+
+#vs-top.LEVELUP2022 {
+  color: #121733;
+  background: #EEF5FF;
+}
+
+#vs-top.LEVELUP2022 .vs-logo {
+  background-image: url(https://vueschool.io/images/mark-vueschool.svg);
+}
+
+#vs-top.LEVELUP2022 .vs-core .vs-slogan {
+  color: #121733;
+}
+
+#vs-top.LEVELUP2022 .vs-core .vs-slogan strong {
+  color: #ff2556;
+}
+
+#vs-top.LEVELUP2022 .vs-core .vs-subline {
+  color: #394170;
+}
+
+#vs-top.LEVELUP2022 .vs-core .vs-subline strong {
+  color: #48aa34;
+}
+
+#vs-top.LEVELUP2022 .vs-background-wrapper {
+  background-image: url(https://vueschool.io/images/banners/assets/LEVELUP2022/bg-mobile.png);
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: top right;
+}
+
+#vs-top.LEVELUP2022 .vs-core .vs-button-wrapper {
+  background-image: linear-gradient(to bottom, #d71b46, #fd2455);
+}
+
+#vs-top.LEVELUP2022 .vs-core .vs-button {
+  background-image: linear-gradient(to bottom, #ff2556, #d51b44), linear-gradient(to bottom, #d71b46, #fd2455);
+}
+
+@media (min-width: 680px) {
+  #vs-top.LEVELUP2022 .vs-background-wrapper {
+    background-image: url(https://vueschool.io/images/banners/assets/LEVELUP2022/bg-tablet.png);
+  }
+}
+
+@media (min-width: 1280px) {
+  #vs-top.LEVELUP2022 .vs-logo {
+    background-image: url(https://vueschool.io/images/icons/logo.svg);
+  }
+
+  #vs-top.LEVELUP2022 .vs-background-wrapper {
+    background-image:
+      url(https://vueschool.io/images/banners/assets/LEVELUP2022/bg-desktop-left.png),
+      url(https://vueschool.io/images/banners/assets/LEVELUP2022/bg-desktop-right.png);
+    background-position:
+      top left -120px,
+      top right -120px;
+    background-size: contain;
+    background-repeat: no-repeat;
+  }
+}
+
+@media (min-width: 1536px) {
+  #vs-top.LEVELUP2022 .vs-background-wrapper {
+    background-position:
+      top left,
+      top right;
   }
 }
 </style>

--- a/.vitepress/theme/components/Banner.vue
+++ b/.vitepress/theme/components/Banner.vue
@@ -44,7 +44,7 @@ const items = [
       link: "/sales/levelup2022",
       static: "LEVELUP2022",
       subtitle: "Access 800+ lessons including the Vue.js 3 Masterclass",
-      title: "Less than <strong>_HOURS_ hours</strong> to get 45% off at Vue School today"
+      title: "Less than <strong>_HOURS_ hours</strong> to get 45% off at Vue School"
     },
     ends: "2022-10-04T23:59:59+02:00",
     id: "LEVELUP2022",
@@ -57,7 +57,7 @@ const items = [
       link: "/sales/levelup2022",
       static: "LEVELUP2022",
       subtitle: "Extended! Access 800+ lessons including the Vue.js 3 Masterclass",
-      title: "Less than <strong>_HOURS_ hours</strong> to get 45% off at Vue School today"
+      title: "Less than <strong>_HOURS_ hours</strong> to get 45% off at Vue School"
     },
     ends: "2022-10-06T23:59:59+02:00",
     id: "LEVELUP2022_EXTENDED",
@@ -65,7 +65,7 @@ const items = [
   }
 ]
 
-const now = new Date('2022-10-06')
+const now = new Date()
 const phases = computed(() => items.map(phase => ({ ...phase, remaining: new Date(phase.ends) - now })))
 const activePhase = computed(() => phases.value.find(phase => phase.remaining > 0))
 const title = computed(() => {

--- a/.vitepress/theme/components/Banner.vue
+++ b/.vitepress/theme/components/Banner.vue
@@ -14,7 +14,7 @@ const items = [
   {
     banner: {
       assets: "FREE_WEEKEND",
-      cta: "Book my spot",
+      cta: "JOIN FOR FREE",
       link: "/free-weekend",
       static: "FREE_WEEKEND",
       subtitle: "Get Access to ALL Vue School premium courses",

--- a/.vitepress/theme/components/Banner.vue
+++ b/.vitepress/theme/components/Banner.vue
@@ -92,7 +92,7 @@ function dismiss() {
   <div class="banner" v-if="open && activeBanner">
     <a
       id="vs-top"
-      :href="`https://vueschool.io${activeBanner.link}?friend=vuejs&utm_source=vuerouter&utm_medium=website&utm_campaign=affiliate&utm_content=top_banner`"
+      :href="`https://vueschool.io${activeBanner.link}?friend=vuejs&utm_source=vuejs&utm_medium=website&utm_campaign=affiliate&utm_content=top_banner`"
       target="_blank"
       :class="activeBanner.assets">
       <div class="vs-background-wrapper">


### PR DESCRIPTION
This PR updates the top banner of vuejs.org to inform users about Vue School’s Free Weekend promotion.

The banner is closable and opens Vue School's site in a new tab. The banner will not reappear if a user has closed it (stored in localStorage following the repo instructions).

The banner has different phases, each with an end date. The copy, graphics and link of the banner depending on the current phase.

Here is the list of phases:

**Free Weekend subscription** (the current banner, no changes)
Ends 2022-09-30T23:59:59+02:00
Links to https://vueschool.io/free-weekend with UTMs
[Screenshots](https://imgur.com/a/oI41Ady)

**Free Weekend now live**
Ends 2022-10-02T23:59:59+02:00
Links to https://vueschool.io/free-weekend with UTMs
[Screenshots](https://imgur.com/a/GoUIk19)

**Special Offer**
Ends 2022-10-04T23:59:59+02:00
Links to https://vueschool.io/sales/levelup2022 with UTMs
[Screenshots](https://imgur.com/a/mxCa38r)

**Special Offer Extended**
Ends 2022-10-06T23:59:59+02:00
Links to https://vueschool.io/sales/levelup2022 with UTMs
[Screenshots](https://imgur.com/a/jXGccYA)

**For testing:** You can emulate each phase by editing line 68 of `Banner.vue` and setting different date values. Please check that each phase link works as expected.

**Note:** You will receive a new PR that hides this banner, to be merged before the promo ends.



