### PR TITLE
docs: add links to free Vue School typescript tutorials

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -4,6 +4,8 @@
 
 ## Typing Component Props
 
+<VueSchoolLink href="https://vueschool.io/lessons/declaring-and-typing-component-props" title="Learn how to declare and type component props with this FREE video lesson from Vue School!"/>
+
 ### Using `<script setup>`
 
 When using `<script setup>`, the `defineProps()` macro supports inferring the props types based on its argument:
@@ -132,6 +134,8 @@ export default defineComponent({
 ```
 
 ## Typing Component Emits
+
+<VueSchoolLink href="https://vueschool.io/lessons/typing-component-events" title="Learn how to type component emits with this FREE video lesson from Vue School!"/>
 
 In `<script setup>`, the `emit` function can also be typed using either runtime declaration OR type declaration:
 

--- a/src/guide/typescript/options-api.md
+++ b/src/guide/typescript/options-api.md
@@ -8,6 +8,8 @@ While Vue does support TypeScript usage with Options API, it is recommended to u
 
 ## Typing Component Props
 
+<VueSchoolLink href="https://vueschool.io/lessons/typing-component-events" title="Learn how to type component emits with this FREE video lesson from Vue School!"/>
+
 Type inference for props in Options API requires wrapping the component with `defineComponent()`. With it, Vue is able to infer the types for the props based on the `props` option, taking additional options such as `required: true` and `default` into account:
 
 ```ts

--- a/src/guide/typescript/overview.md
+++ b/src/guide/typescript/overview.md
@@ -8,6 +8,8 @@ A type system like TypeScript can detect many common errors via static analysis 
 
 Vue is written in TypeScript itself and provides first-class TypeScript support. All official Vue packages come with bundled type declarations that should work out-of-the-box.
 
+<VueSchoolLink href="https://vueschool.io/lessons/introduction-to-typescript-with-vue-js-3" title="Learn about the Advantages Pairing TypeScript with Vue with this FREE video lesson from Vue School!"/>
+
 ## Project Setup
 
 [`create-vue`](https://github.com/vuejs/create-vue), the official project scaffolding tool, offers the options to scaffold a [Vite](https://vitejs.dev/)-powered, TypeScript-ready Vue project.


### PR DESCRIPTION
This PR adds video content for helping users work with TypeScript + Vue.

It includes: 
1. an introductory video on the benefits of using TS with Vue
2. a how-to video about typing props
3. a how-to video about typing component emits
4. and a how-to video on using TS with the options API

Thanks!