### PR TITLE
docs(vue-tsc): fix broken link for vue-tsc

### DIFF
--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -88,7 +88,7 @@ Main article: [Using Vue with TypeScript](/guide/typescript/overview).
 
 - [Volar](https://github.com/johnsoncodehk/volar) provides type checking for SFCs using `<script lang="ts">` blocks, including template expressions and cross-component props validation.
 
-- Use [`vue-tsc`](https://github.com/johnsoncodehk/volar/tree/master/packages/vue-tsc) for performing the same type checking from the command line, or for generating `d.ts` files for SFCs.
+- Use [`vue-tsc`](https://github.com/johnsoncodehk/vue-tsc) for performing the same type checking from the command line, or for generating `d.ts` files for SFCs.
 
 ## Testing
 


### PR DESCRIPTION
## Description of Problem
The vue-tsc link is 404.

## Proposed Solution
Fixed the url to point to correct vue-tsc repo.

## Additional Information
N/A