### PR TITLE
chore: consistent headings for API docs

### DIFF
--- a/src/api/application.md
+++ b/src/api/application.md
@@ -144,7 +144,7 @@ Provide a value that can be injected in all descendent components within the app
 
   </div>
 
-- **See also:**
+- **See also**
   - [Provide / Inject](/guide/components/provide-inject.html)
   - [App-level Provide](/guide/components/provide-inject.html#app-level-provide)
 
@@ -389,7 +389,7 @@ Assign a custom handler for runtime warnings from Vue.
 
 Set this to `true` to enable component init, compile, render and patch performance tracing in the browser devtool performance/timeline panel. Only works in development mode and in browsers that support the [performance.mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) API.
 
-- **Type**: `boolean`
+- **Type:** `boolean`
 
 - **See also:** [Guide - Performance](/guide/best-practices/performance.html)
 

--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -26,7 +26,7 @@ Update the element's [innerHTML](https://developer.mozilla.org/en-US/docs/Web/AP
 
 - **Expects:** `string`
 
-- **Details:**
+- **Details**
 
   Contents of `v-html` are inserted as plain HTML - Vue template syntax will not be processed. If you find yourself trying to compose templates using `v-html`, try to rethink the solution by using components instead.
 
@@ -36,7 +36,7 @@ Update the element's [innerHTML](https://developer.mozilla.org/en-US/docs/Web/AP
 
   In [Single-File Components](/guide/scaling-up/sfc), `scoped` styles will not apply to content inside `v-html`, because that HTML is not processed by Vue's template compiler. If you want to target `v-html` content with scoped CSS, you can instead use [CSS modules](./sfc-css-features.html#css-modules) or an additional, global `<style>` element with a manual scoping strategy such as BEM.
 
-- **Example:**
+- **Example**
 
   ```vue-html
   <div v-html="html"></div>
@@ -164,7 +164,7 @@ Render the element or template block multiple times based on the source data.
 
   `v-for` can also work on values that implement the [Iterable Protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterable_protocol), including native `Map` and `Set`.
 
-- **See also:**
+- **See also**
   - [List Rendering](/guide/essentials/list.html)
 
 ## v-on
@@ -177,7 +177,7 @@ Attach an event listener to the element.
 
 - **Argument:** `event` (optional if using Object syntax)
 
-- **Modifiers:**
+- **Modifiers**
 
   - `.stop` - call `event.stopPropagation()`.
   - `.prevent` - call `event.preventDefault()`.
@@ -200,7 +200,7 @@ Attach an event listener to the element.
 
   `v-on` also supports binding to an object of event / listener pairs without an argument. Note when using the object syntax, it does not support any modifiers.
 
-- **Example:**
+- **Example**
 
   ```vue-html
   <!-- method handler -->
@@ -249,7 +249,7 @@ Attach an event listener to the element.
   <MyComponent @my-event="handleThis(123, $event)" />
   ```
 
-- **See also:**
+- **See also**
   - [Event Handling](/guide/essentials/event-handling.html)
   - [Components - Custom Events](/guide/essentials/component-basics.html#listening-to-events)
 
@@ -263,13 +263,13 @@ Dynamically bind one or more attributes, or a component prop to an expression.
 
 - **Argument:** `attrOrProp (optional)`
 
-- **Modifiers:**
+- **Modifiers**
 
   - `.camel` - transform the kebab-case attribute name into camelCase.
   - `.prop` - force a binding to be set as a DOM property. <sup class="vt-badge">3.2+</sup>
   - `.attr` - force a binding to be set as a DOM attribute. <sup class="vt-badge">3.2+</sup>
 
-- **Usage:**
+- **Usage**
 
   When used to bind the `class` or `style` attribute, `v-bind` supports additional value types such as Array or Objects. See linked guide section below for more details.
 
@@ -279,7 +279,7 @@ Dynamically bind one or more attributes, or a component prop to an expression.
 
   When used without an argument, can be used to bind an object containing attribute name-value pairs.
 
-- **Example:**
+- **Example**
 
   ```vue-html
   <!-- bind an attribute -->
@@ -336,7 +336,7 @@ Dynamically bind one or more attributes, or a component prop to an expression.
 
   `.camel` is not needed if you are using string templates, or pre-compiling the template with a build step.
 
-- **See also:**
+- **See also**
   - [Class and Style Bindings](/guide/essentials/class-and-style.html)
   - [Components - Prop Passing Details](/guide/components/props.html#prop-passing-details)
 
@@ -346,20 +346,20 @@ Create a two-way binding on a form input element or a component.
 
 - **Expects:** varies based on value of form inputs element or output of components
 
-- **Limited to:**
+- **Limited to**
 
   - `<input>`
   - `<select>`
   - `<textarea>`
   - components
 
-- **Modifiers:**
+- **Modifiers**
 
   - [`.lazy`](/guide/essentials/forms.html#lazy) - listen to `change` events instead of `input`
   - [`.number`](/guide/essentials/forms.html#number) - cast valid input string to numbers
   - [`.trim`](/guide/essentials/forms.html#trim) - trim input
 
-- **See also:**
+- **See also**
 
   - [Form Input Bindings](/guide/essentials/forms.html)
   - [Component Events - Usage with `v-model`](/guide/components/events.html#usage-with-v-model)
@@ -374,12 +374,12 @@ Denote named slots or scoped slots that expect to receive props.
 
 - **Argument:** slot name (optional, defaults to `default`)
 
-- **Limited to:**
+- **Limited to**
 
   - `<template>`
   - [components](/guide/components/slots.html#scoped-slots) (for a lone default slot with props)
 
-- **Example:**
+- **Example**
 
   ```vue-html
   <!-- Named slots -->
@@ -412,7 +412,7 @@ Denote named slots or scoped slots that expect to receive props.
   </Mouse>
   ```
 
-- **See also:**
+- **See also**
   - [Components - Slots](/guide/components/slots.html)
 
 ## v-pre
@@ -425,7 +425,7 @@ Skip compilation for this element and all its children.
 
   Inside the element with `v-pre`, all Vue template syntax will be preserved and rendered as-is. The most common use case of this is displaying raw mustache tags.
 
-- **Example:**
+- **Example**
 
   ```vue-html
   <span v-pre>{{ this will not be compiled }}</span>
@@ -459,7 +459,7 @@ Render the element and component once only, and skip future updates.
 
   Since 3.2, you can also memoize part of the template with invalidation conditions using [`v-memo`](#v-memo).
 
-- **See also:**
+- **See also**
   - [Data Binding Syntax - interpolations](/guide/essentials/template-syntax.html#text-interpolation)
   - [v-memo](#v-memo)
 
@@ -500,7 +500,7 @@ Render the element and component once only, and skip future updates.
 
   `v-memo` can also be used on components to manually prevent unwanted updates in certain edge cases where the child component update check has been de-optimized. But again, it is the developer's responsibility to specify correct dependency arrays to avoid skipping necessary updates.
 
-- **See also:**
+- **See also**
   - [v-once](#v-once)
 
 ## v-cloak
@@ -517,7 +517,7 @@ Used to hide un-compiled template until it is ready.
 
   `v-cloak` will remain on the element until the associated component instance is mounted. Combined with CSS rules such as `[v-cloak] { display: none }`, it can be used to hide the raw templates until the component is ready.
 
-- **Example:**
+- **Example**
 
   ```css
   [v-cloak] {

--- a/src/api/built-in-special-attributes.md
+++ b/src/api/built-in-special-attributes.md
@@ -100,7 +100,7 @@ Used for binding [dynamic components](/guide/essentials/component-basics.html#dy
   </table>
   ```
 
-- **See also:**
+- **See also**
 
   - [Built-in Special Element - `<component>`](/api/built-in-special-elements.html#component)
   - [Dynamic Components](/guide/essentials/component-basics.html#dynamic-components)

--- a/src/api/component-instance.md
+++ b/src/api/component-instance.md
@@ -151,7 +151,7 @@ An object of DOM elements and component instances, registered via [template refs
   }
   ```
 
-- **See also:**
+- **See also**
 
   - [Template refs](/guide/essentials/template-refs.html)
   - [Special Attributes - ref](./built-in-special-attributes.md#ref)
@@ -174,7 +174,7 @@ An object that contains the component's fallthrough attributes.
 
   By default, everything in `$attrs` will be automatically inherited on the component's root element if there is only a single root element. This behavior is disabled if the component has multiple root nodes, and can be explicitly disabled with the [`inheritAttrs`](./options-misc.html#inheritattrs) option.
 
-- **See also:**
+- **See also**
 
   - [Fallthrough Attributes](/guide/components/attrs.html)
 
@@ -257,7 +257,7 @@ Imperative API for creating watchers.
   unwatch()
   ```
 
-- **See also:**
+- **See also**
   - [Options - `watch`](/api/options-state.html#watch)
   - [Guide - Watchers](/guide/essentials/watchers.html)
 
@@ -286,7 +286,7 @@ Trigger a custom event on the current instance. Any additional arguments will be
   }
   ```
 
-- **See also:**
+- **See also**
 
   - [Component - Events](/guide/components/events.html)
   - [`emits` option](./options-state.html#emits)

--- a/src/api/composition-api-dependency-injection.md
+++ b/src/api/composition-api-dependency-injection.md
@@ -37,7 +37,7 @@ Provides a value that can be injected by descendent components.
   </script>
   ```
 
-- **See also**:
+- **See also**
   - [Guide - Provide / Inject](/guide/components/provide-inject.html)
   - [Guide - Typing Provide / Inject](/guide/typescript/composition-api.html#typing-provide-inject)
 
@@ -101,6 +101,6 @@ Injects a value provided by an ancestor component or the application (via `app.p
   </script>
   ```
 
-- **See also**:
+- **See also**
   - [Guide - Provide / Inject](/guide/components/provide-inject.html)
   - [Guide - Typing Provide / Inject](/guide/typescript/composition-api.html#typing-provide-inject)

--- a/src/api/general.md
+++ b/src/api/general.md
@@ -204,7 +204,7 @@ This method accepts the same argument as [`defineComponent`](#definecomponent), 
   customElements.define('my-vue-element', MyVueElement)
   ```
 
-- **See also:**
+- **See also**
 
   - [Guide - Building Custom Elements with Vue](/guide/extras/web-components.html#building-custom-elements-with-vue)
 

--- a/src/api/options-composition.md
+++ b/src/api/options-composition.md
@@ -12,7 +12,7 @@ Provide values that can be injected by descendent components.
   }
   ```
 
-- **Details:**
+- **Details**
 
   `provide` and [`inject`](#inject) are used together to allow an ancestor component to serve as a dependency injector for all its descendants, regardless of how deep the component hierarchy is, as long as they are in the same parent chain.
 
@@ -181,7 +181,7 @@ An array of option objects to be mixed into the current component.
   }
   ```
 
-- **Details:**
+- **Details**
 
   The `mixins` option accepts an array of mixin objects. These mixin objects can contain instance options like normal instance objects, and they will be merged against the eventual options using the certain option merging logic. For example, if your mixin contains a `created` hook and the component itself also has one, both functions will be called.
 
@@ -191,7 +191,7 @@ An array of option objects to be mixed into the current component.
   In Vue 2, mixins were the primary mechanism for creating reusable chunks of component logic. While mixins continue to be supported in Vue 3, [Composition API](/guide/reusability/composables.html) is now the preferred approach for code reuse between components.
   :::
 
-- **Example:**
+- **Example**
 
   ```js
   const mixin = {
@@ -215,7 +215,7 @@ An array of option objects to be mixed into the current component.
 
 A "base class" component to extend from.
 
-- **Type:**
+- **Type**
 
   ```ts
   interface ComponentOptions {
@@ -223,7 +223,7 @@ A "base class" component to extend from.
   }
   ```
 
-- **Details:**
+- **Details**
 
   Allows one component to extend another, inheriting its component options.
 
@@ -233,7 +233,7 @@ A "base class" component to extend from.
 
   As with `mixins`, any options will be merged using the relevant merge strategy.
 
-- **Example:**
+- **Example**
 
   ```js
   const CompA = { ... }

--- a/src/api/options-rendering.md
+++ b/src/api/options-rendering.md
@@ -51,13 +51,13 @@ A function that programmatically returns the virtual DOM tree of the component.
   type VNodeArrayChildren = (VNodeArrayChildren | VNodeChildAtom)[]
   ```
 
-- **Details:**
+- **Details**
 
   `render` is an alternative to string templates that allows you to leverage the full programmatic power of JavaScript to declare the render output of the component.
 
   Pre-compiled templates, for example those in Single-File Components, are compiled into the `render` option at build time. If both `render` and `template` are present in a component, `render` will take higher priority.
 
-- **See also:**
+- **See also**
   - [Rendering Mechanism](/guide/extras/rendering-mechanism.html)
   - [Render Functions](/guide/extras/render-function.html)
 

--- a/src/api/reactivity-advanced.md
+++ b/src/api/reactivity-advanced.md
@@ -32,7 +32,7 @@ Shallow version of [`ref()`](./reactivity-core.html#ref).
   state.value = { count: 2 }
   ```
 
-- **See also:**
+- **See also**
   - [Guide - Reduce Reactivity Overhead for Large Immutable Structures](/guide/best-practices/performance.html#reduce-reactivity-overhead-for-large-immutable-structures)
   - [Guide - Integration with External State Systems](/guide/extras/reactivity-in-depth.html#integration-with-external-state-systems)
 

--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -39,7 +39,7 @@ Takes an inner value and returns a reactive and mutable ref object, which has a 
   console.log(count.value) // 1
   ```
 
-- **See also:**
+- **See also**
   - [Guide - Reactive Variables with `ref()`](/guide/essentials/reactivity-fundamentals.html#reactive-variables-with-ref)
   - [Guide - Typing `ref()`](/guide/typescript/composition-api.html#typing-ref)
 
@@ -108,7 +108,7 @@ Takes a getter function and returns a readonly reactive [ref](#ref) object for t
   })
   ```
 
-- **See also:**
+- **See also**
   - [Guide - Computed Properties](/guide/essentials/computed.html)
   - [Guide - Computed Debugging](/guide/extras/reactivity-in-depth.html#computed-debugging)
   - [Guide - Typing `computed()`](/guide/typescript/composition-api.html#typing-computed)
@@ -186,7 +186,7 @@ Returns a reactive proxy of the object.
   console.log(obj.count === count.value) // true
   ```
 
-- **See also:**
+- **See also**
   - [Guide - Reactivity Fundamentals](/guide/essentials/reactivity-fundamentals.html)
   - [Guide - Typing `reactive()`](/guide/typescript/composition-api.html#typing-reactive)
 
@@ -308,7 +308,7 @@ Runs a function immediately while reactively tracking its dependencies and re-ru
   })
   ```
 
-- **See also**:
+- **See also**
   - [Guide - Watchers](/guide/essentials/watchers.html#watcheffect)
   - [Guide - Watcher Debugging](/guide/extras/reactivity-in-depth.html#watcher-debugging)
 
@@ -457,7 +457,7 @@ Watches one or more reactive data sources and invokes a callback function when t
   })
   ```
 
-- **See also**:
+- **See also**
 
   - [Guide - Watchers](/guide/essentials/watchers.html)
   - [Guide - Watcher Debugging](/guide/extras/reactivity-in-depth.html#watcher-debugging)


### PR DESCRIPTION
## Description of Problem

## Proposed Solution
With colon if there is text on the same line.
Otherwise, no colon.

## Additional Information
Or, should I add a colon to all headings for more clarity?
