### PR TITLE
fix: Typo in Typescript tip

### DIFF
--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -310,7 +310,7 @@ If you are using TypeScript, add `vitest/globals` to the `types` field in your `
 // tsconfig.json
 
 {
- "compileroptions": {
+ "compilerOptions": {
     "types": ["vitest/globals"]
   }
 }


### PR DESCRIPTION
## Description of Problem

Fix a typo within Tip example in Typescript configuration file.