### PR TITLE
Fix: remove extraneous reference to v-bind

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -297,8 +297,6 @@ Then want to render a component for each one, using `v-for`:
 
 </div>
 
-Notice how `v-bind` is used to pass dynamic prop values. This is especially useful when you don't know the exact content you're going to render ahead of time.
-
 That's all you need to know about props for now, but once you've finished reading this page and feel comfortable with its content, we recommend coming back later to read the full guide on [Props](/guide/components/props.html).
 
 ## Listening to Events


### PR DESCRIPTION
## Description of Problem
This leads the reader to search for the use of `v-bind` but it isn't used in the examples or anywhere in the page so the search is a waste of time and the note is unhelpful.

## Proposed Solution
Remove the note about `v-bind`.

## Additional Information
