### PR TITLE
fix: typo v-bind CSS

### DIFF
--- a/src/api/utility-types.md
+++ b/src/api/utility-types.md
@@ -130,7 +130,7 @@ Used to augment allowed values in style property bindings.
   :::
   
   :::info See also
-SFC `<style>` tags support linking CSS values to dynamic component state using the `v-bind CSS` function. This allows for custom properties without type augmentation. 
+SFC `<style>` tags support linking CSS values to dynamic component state using the `v-bind` CSS function. This allows for custom properties without type augmentation. 
 
 - [v-bind() in CSS](/api/sfc-css-features.html#v-bind-in-css)
   :::


### PR DESCRIPTION
## Description of Problem
component state using the `v-bind CSS` function.
update
component state using the `v-bind` CSS function.

