### PR TITLE
Remove claim that vue scores 100% in the Custom Elements Everywhere tests

### DIFF
--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -6,7 +6,7 @@ We consider Vue and Web Components to be primarily complementary technologies. V
 
 ## Using Custom Elements in Vue
 
-Vue [scores a perfect 100% in the Custom Elements Everywhere tests](https://custom-elements-everywhere.com/libraries/vue/results/results.html). Consuming custom elements inside a Vue application largely works the same as using native HTML elements, with a few things to keep in mind:
+Consuming custom elements inside a Vue application largely works the same as using native HTML elements, with a few things to keep in mind:
 
 ### Skipping Component Resolution
 


### PR DESCRIPTION
## Description of Problem
Vue doesn't actually score a perfect 100% in the Custom Elements Everywhere tests 😅 ([see here](https://custom-elements-everywhere.com/#vue))

## Additional Information
vuejs/core#5401 is closed with a `wontfix` label, so I assume the test results won't change anytime soon, hence the false claim should be removed.

