### PR TITLE
fix: add reactivity debugging link

### DIFF
--- a/src/guide/best-practices/production-deployment.md
+++ b/src/guide/best-practices/production-deployment.md
@@ -6,7 +6,7 @@ During development, Vue provides a number of features to improve the development
 
 - Warning for common errors and pitfalls
 - Props / events validation
-- Reactivity debugging hooks
+- [Reactivity debugging hooks](/guide/extras/reactivity-in-depth.html#reactivity-debugging)
 - Devtools integration
 
 However, these features become useless in production. Some of the warning checks can also incur a small amount of performance overhead. When deploying to production, we should drop all the unused, development-only code branches for smaller payload size and better performance.


### PR DESCRIPTION
# The Problem
While translating `production-deployment.md` file in French, I came across "Reactivity debugging" that was tricky to translate because this concept was not clear to me and had to look for it on the internet to find the corresponding article.

## Proposed Solution
I would suggest to add a link to the Reactivity Debugging doc, for users that didn't know about this concept like me. 

Linked to #2041