### PR TITLE
fix: TeamList sticky info overlap

### DIFF
--- a/src/about/team/TeamList.vue
+++ b/src/about/team/TeamList.vue
@@ -61,18 +61,26 @@ defineProps<{
 @media (min-width: 768px) {
   .info {
     position: sticky;
-    top: 32px;
+    top: calc(var(--vt-banner-height) + 32px);
     left: 0;
     padding: 0 24px 0 0;
     width: 256px;
+  }
+
+  html.banner-dismissed .info {
+    top: 32px;
   }
 }
 
 @media (min-width: 960px) {
   .info {
-    top: 88px;
+    top: calc(var(--vt-banner-height) + 88px);
     padding: 0 64px 0 0;
     width: 384px;
+  }
+
+  html.banner-dismissed .info {
+    top: 88px;
   }
 }
 


### PR DESCRIPTION
## Description of Problem
Vue docs **`banner`** caused overlapping TeamList sticky info title ( e.g. Core Team Members ) under header ( VPNav )

https://vuejs.org/about/team.html

![Screenshot 2022-10-22 120434](https://user-images.githubusercontent.com/17789047/197330068-2c506e0e-e3a2-45e7-b95a-03345eddcc15.png)

## Proposed Solution

- `html.banner-dismissed`
- Use predefined `--vt-banner-height` CSS variable and CSS `calc()` for calculate correct **`top`** value for `sticky` position

## Additional Information
