### PR TITLE
Update class-and-style.md

### DIFF
--- a/src/guide/essentials/class-and-style.md
+++ b/src/guide/essentials/class-and-style.md
@@ -338,3 +338,20 @@ You can provide an array of multiple (prefixed) values to a style property, for 
 ```
 
 This will only render the last value in the array which the browser supports. In this example, it will render `display: flex` for browsers that support the unprefixed version of flexbox.
+
+### CSS Functions
+It is best to practice to use JavaScript objects to return CSS functions like `url()`:
+```vue-html
+<div :style=:style="{backgroundImage: this.myUrl}"></div>
+```
+```javascript
+  computed: {
+    myUrl() {
+      return 'url(https://www.foo.com' + this.icon + '.png)'
+    }
+  },
+```
+However, it is also possible to place them in-line using quotes:
+```vue-html
+<div :style=:style="{ 'backgroundImage': 'url(' + this.icon + '.png)' }"></div>
+```


### PR DESCRIPTION
Adds an example for using CSS Functions.

## Description of Problem
Binding in-line styles that contain CSS functions is not directly discussed in the existing docs.

## Proposed Solution
Adds two examples of how CSS functions can be used.

## Additional Information
Please feel free to edit/amend the suggested examples in any way.