### PR TITLE
Update reactivity-fundamentals.md

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -514,7 +514,7 @@ console.log(count.value) // 1
 
 Ref unwrapping only happens when nested inside a deep reactive object. It does not apply when it is accessed as a property of a [shallow reactive object](/api/reactivity-advanced.html#shallowreactive).
 
-#### Ref Unwrapping in Arrays and Collections
+### Ref Unwrapping in Arrays and Collections
 
 Unlike reactive objects, there is no unwrapping performed when the ref is accessed as an element of a reactive array or a native collection type like `Map`:
 


### PR DESCRIPTION
Fixed the nesting of "Ref Unwrapping in Arrays and Collections", it was depth 4, should be depth 3

## Description of Problem

"Ref Unwrapping in Arrays and Collections" is h4 (**####**), so it's not in the navigation. Should be h3 (**###**)

## Proposed Solution

Removed one "#"

## Additional Information
