### PR TITLE
feat: add french translations repo link

### DIFF
--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -13,6 +13,7 @@ aside: false
 ## Work in Progress Languages
 
 - [Українська / Ukrainian](https://ua.vuejs.org) [[source](https://github.com/vuejs-translations/docs-ua)]
+- [Français / French](https://fr.vuejs.org) [[source](https://github.com/vuejs-translations/docs-fr)]
 
 ## Starting a new Translation
 

--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -13,7 +13,7 @@ aside: false
 ## Work in Progress Languages
 
 - [Українська / Ukrainian](https://ua.vuejs.org) [[source](https://github.com/vuejs-translations/docs-ua)]
-- [Français / French](https://fr.vuejs.org) [[source](https://github.com/vuejs-translations/docs-fr)]
+- [Français / French](https://vuejs-docs-fr.netlify.app) [[source](https://github.com/vuejs-translations/docs-fr)]
 
 ## Starting a new Translation
 


### PR DESCRIPTION
## Description of Problem

French translation docs is missing.

## Proposed Solution

Here the link for getting the link from the english version.

## Additional Information

We need to translate the current version of [fr.vuejs.org](https://fr.vuejs.org) to [fr.v2.vuejs.org](https://fr.v2.vuejs.org). The repo responsible of the current version is https://github.com/vuejs-fr/vuejs.org.

Check-up list before merge:

- [ ] Make sure [fr.v2.vuejs.org](https://fr.v2.vuejs.org) is pointing to the legacy french version of [v2.vuejs.org](https://v2.vuejs.org)
