### PR TITLE
Change emit example function name for clarity

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -19,11 +19,6 @@ A component can emit custom events directly in template expressions (e.g. in a `
 
 The `$emit()` method is also available on the component instance as `this.$emit()`:
 
-```vue-html
-<!-- MyComponent -->
-<button @click="submit">click me</button>
-```
-  
 ```js
 export default {
   methods: {

--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -19,11 +19,16 @@ A component can emit custom events directly in template expressions (e.g. in a `
 
 The `$emit()` method is also available on the component instance as `this.$emit()`:
 
+```vue-html
+<!-- MyComponent -->
+<button @click="submit">click me</button>
+```
+  
 ```js
 export default {
   methods: {
     submit() {
-      this.$emit('submit')
+      this.$emit('someEvent')
     }
   }
 }


### PR DESCRIPTION
## Description of Problem
As-is, I did not immediately see the connection between `this.$emit('submit')` and the following code, `<MyComponent @some-event="callback" />` in the "component instance" example

## Proposed Solution
I suggest changing the function name from `submit` to `someEvent` (and also possibly adding some extra HTML example code for added clarity)

## Additional Information
I'm just learning Vue and was a little confused by this section in the docs. It's very possible I'm still confused, in which case, please disregard :)
