### PR TITLE
Add computed refs to isReadonly

### DIFF
--- a/src/api/reactivity-utilities.md
+++ b/src/api/reactivity-utilities.md
@@ -183,7 +183,9 @@ Checks if an object is a proxy created by [`reactive()`](./reactivity-core.html#
 
 ## isReadonly()
 
-Checks if an object is a proxy created by [`readonly()`](./reactivity-core.html#readonly) or [`shallowReadonly()`](./reactivity-advanced.html#shallowreadonly).
+Checks whether the passed value is a readonly object. The properties of a readonly object can change, but they can't be assigned directly via the passed object.
+
+The proxies created by [`readonly()`](./reactivity-core.html#readonly) and [`shallowReadonly()`](./reactivity-advanced.html#shallowreadonly) are both considered readonly, as is a [`computed()`](./reactivity-core.html#computed) ref without a `set` function.
 
 - **Type**
 


### PR DESCRIPTION
The `isReadonly()` function will return `true` for a `computed()` ref that doesn't have a `set` function. That isn't currently mentioned.

I've added a brief description of what it means for an object to be 'readonly', otherwise the list that follows may seem a bit arbitrary. I've then included `computed()` refs in the list of things that are readonly.