### PR TITLE
options api - immediate watcher handler runs before "created"

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -244,7 +244,7 @@ export default {
 }
 ```
 
-In above scenario the initial execution of handler will happen after `beforeCreate` hook, but before `created`.
+The initial execution of the handler function will happen just before the `created` hook. Vue will have already processed the `data`, `computed`, and `methods` options, so those properties will be available on the first invocation.
 </div>
 
 <div class="composition-api">

--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -244,6 +244,7 @@ export default {
 }
 ```
 
+In above scenario the initial execution of handler will happen after `beforeCreate` hook, but before `created`.
 </div>
 
 <div class="composition-api">


### PR DESCRIPTION
## Description of Problem
Although it's mentioned that in Options API immediate watcher handler will run on component creation, it might be not instantly obvious that "created" hook will be executed after. Introduced few bugs before I realized it.

## Proposed Solution
Maybe could be useful to explicitly mention in the guide that immediate watcher handler runs before "created" hook.

## Additional Information
