### PR TITLE
Explain attribute inheritance for functional components

### DIFF
--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -687,4 +687,10 @@ MyComponent.emits = ['click']
 
 If the `props` option is not specified, then the `props` object passed to the function will contain all attributes, the same as `attrs`. The prop names will not be normalized to camelCase unless the `props` option is specified.
 
+For functional components with explicit `props`, [attribute fallthrough](/guide/components/attrs.html) works much the same as with normal components. However, for functional components that don't explicitly specify their `props`, only the `class`, `style`, and `onXxx` event listeners will be inherited from the `attrs` by default. In either case, `inheritAttrs` can be set to `false` to disable attribute inheritance:
+
+```js
+MyComponent.inheritAttrs = false
+```
+
 Functional components can be registered and consumed just like normal components. If you pass a function as the first argument to `h()`, it will be treated as a functional component.


### PR DESCRIPTION
Functional components have slightly different rules for handling attribute inheritance. It isn't currently documented, so I've added an extra paragraph outlining the key points about how it works.

If you'd like to see the various cases for yourself, here's an example:

* [Playground Example](https://sfc.vuejs.org/#eNqNklFrwjAQx7/KkZcqaPreqSADYW9724PxodbURtok5K66IX73XVrrOoYwKDSX++Wfy93/Ktbey3OrRSYWWATjCVBT61fKmsa7QHCFCm5QBtdAwmCirLKFs0hQBJ2T3tjXxsMSJlNYruCqLEBghWDHO4+9apIczDmZQUL6k5JpTN6U5W9Q3dgPQ9V7cB5ZdXTHhOFRUvo7st1Fkd/HXUtPFP5wb7bSwdCzu34Iafr/mihE4TKvUSu7SPu+ccc4IN34mlU4AliM31LUOeJSiaAPSgBScPYI6Zh7FP0vdKj7KbxIR8VwiPRVx6Vksp9K4WoXMh7N4aUbQezitlfY9UTpLM0v2hwrymDv6g6MGL+6kxMz0ftk3uRentBZdlJ3VN0TqEQ2mEAJdlCMlaiIPGZpimUR/XdC6cIx5ZUMrSXTaKmxme+Du6AOLKzEYBVx+wZBRPJ9)

The relevant bit of the Vue source is:

<https://github.com/vuejs/core/blob/f67bb500b6071bc0e55a89709a495a27da73badd/packages/runtime-core/src/componentRenderUtils.ts#L296>