### PR TITLE
Fix Team sticky headers

### DIFF
--- a/src/about/team/TeamList.vue
+++ b/src/about/team/TeamList.vue
@@ -61,7 +61,7 @@ defineProps<{
 @media (min-width: 768px) {
   .info {
     position: sticky;
-    top: calc(var(--vt-banner-height) + 32px);
+    top: calc(var(--vt-banner-height, 0px) + 32px);
     left: 0;
     padding: 0 24px 0 0;
     width: 256px;
@@ -74,7 +74,7 @@ defineProps<{
 
 @media (min-width: 960px) {
   .info {
-    top: calc(var(--vt-banner-height) + 88px);
+    top: calc(var(--vt-banner-height, 0px) + 88px);
     padding: 0 64px 0 0;
     width: 384px;
   }


### PR DESCRIPTION
This is a tweak to #2043. The fix provided in that PR worked fine when the page had a banner (even if it was dismissed), but now the banner has been removed the variable `--vt-banner-height` is unavailable. This PR adds a default of `0px` (just using `0` doesn't work).

This impacts the sticky header sections on the Team page.