### PR TITLE
Fix: Red Color never get set

### DIFF
--- a/src/examples/src/attribute-bindings/App/options.js
+++ b/src/examples/src/attribute-bindings/App/options.js
@@ -2,7 +2,7 @@ export default {
   data() {
     return {
       message: 'Hello World!',
-      isRed: true,
+      isRed: false,
       color: 'green'
     }
   },


### PR DESCRIPTION
## Description of Problem
Red color doesn't apply on the text on clicking the text.

## Proposed Solution
setting isRed: false fixes the problem

## Additional Information
_// docs/src/examples/src/attribute-bindings/App/options.js_ 
the property isRed is set to true
...isRed: true,

_//  docs/src/examples/src/attribute-bindings/App/template.html_ 
'  <p :class="{ red: isRed }" @click="toggleRed">
    This should be red... but click me to toggle it.
  </p>'

@click="toggleRed" is wating on click event to apply the colour but toggleRed() sets it to false, and the color doesn't get applied.