### PR TITLE
Update forms.md

### DIFF
--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -57,7 +57,7 @@ In addition, `v-model` can be used on inputs of different types, `<textarea>`, a
 ```
 
 <div class="demo">
-  <p>Message is: {{ message }}</p>
+  <p style="word-break:break-word;">Message is: {{ message }}</p>
   <input v-model="message" placeholder="edit me" />
 </div>
 
@@ -87,7 +87,7 @@ For languages that require an [IME](https://en.wikipedia.org/wiki/Input_method) 
 
 <div class="demo">
   <span>Multiline message is:</span>
-  <p style="white-space: pre-line;">{{ multilineText }}</p>
+  <p style="white-space: pre-line; word-break:break-word;">{{ multilineText }}</p>
   <textarea v-model="multilineText" placeholder="add multiple lines"></textarea>
 </div>
 


### PR DESCRIPTION
## Description of Problem
When I was reading the chapter "Form Input Bindings" about single-line text and multi-line text input, if the content I typed was consecutive characters without spaces, the content would overflow outside the demo module, affecting the reading, I wondered if this was a potential bug, so I added the word-break CSS property to them'word-break: break-word; '
![image](https://user-images.githubusercontent.com/80050599/201507346-2b56ea7b-990f-4a0e-b16e-6370456750ce.png)

## Proposed Solution
I added'word-break: break-word; 'to the < p > tag to make it wrap automatically to solve this problem, and the out of memory problem will be solved after modification
![image](https://user-images.githubusercontent.com/80050599/201507410-63ededa6-6ac2-42a0-86e1-f748bb022fe4.png)

## Additional Information
