### PR TITLE
Update web-components.md example

### DIFF
--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -55,7 +55,7 @@ module.exports = {
         ...options,
         compilerOptions: {
           // treat any tag that starts with ion- as custom elements
-          isCustomElement: tag => tag.startsWith('ion-')
+          isCustomElement: tag => tag.startsWith('icon-')
         }
       }))
   }


### PR DESCRIPTION
Maybe change tag.startsWith('ion-')  to tag.startsWith('icon-')  is more reasonable

## Description of Problem
tag.startsWith('ion-')  seems to be a syntax error 

## Proposed Solution
tag.startsWith('icon-')   is more reasonable


## Additional Information
