### PR TITLE
chore: update partner's company after rebranding

### DIFF
--- a/src/about/team/members-partner.json
+++ b/src/about/team/members-partner.json
@@ -354,8 +354,8 @@
   {
     "name": "Erick Petrucelli",
     "title": "Head of Engineering",
-    "company": "Airbank",
-    "companyLink": "https://www.joinairbank.com/",
+    "company": "Friday Finance",
+    "companyLink": "https://www.fridayfinance.com/",
     "location": "João Pessoa, Brazil",
     "languages": ["Portuguese", "English"],
     "projects": [


### PR DESCRIPTION
## Description of Problem

My company has passed by a rebranding from [Airbank](https://www.joinairbank.com/) to [Friday Finance](https://www.fridayfinance.com/).

## Proposed Solution

The `/about/team/members-partner.json` has been updated with the change.

## Additional Information

N/A.