### PR TITLE
Add space in TodosMVC example

### DIFF
--- a/src/examples/src/todomvc/App/template.html
+++ b/src/examples/src/todomvc/App/template.html
@@ -45,7 +45,7 @@
   <footer class="footer" v-show="todos.length">
     <span class="todo-count">
       <strong>{{ remaining }}</strong>
-      <span>{{ remaining === 1 ? 'item' : 'items' }} left</span>
+      <span>{{ remaining === 1 ? ' item' : ' items' }} left</span>
     </span>
     <ul class="filters">
       <li>


### PR DESCRIPTION
## Description of the Problem
There is a missing space, which wrongly concats the {{ remaining }} value and the 'item'/'items' word.

## Proposed Solution
Added spaces
