### PR TITLE
Added a warning regarding async setup

### DIFF
--- a/src/api/composition-api-setup.md
+++ b/src/api/composition-api-setup.md
@@ -45,7 +45,7 @@ Note that [refs](/api/reactivity-core.html#ref) returned from `setup` are [autom
 :::
 
 :::warning
-`setup()` should always be called _synchronously_. The only case when `async setup()` can be used is when the component is a descentand of a [Suspense](../guide/built-ins/suspense.html) component.
+`setup()` should return an object _synchronously_. The only case when `async setup()` can be used is when the component is a descendant of a [Suspense](../guide/built-ins/suspense.html) component.
 :::
 
 ## Accessing Props {#accessing-props}

--- a/src/api/composition-api-setup.md
+++ b/src/api/composition-api-setup.md
@@ -44,6 +44,10 @@ Note that [refs](/api/reactivity-core.html#ref) returned from `setup` are [autom
 `setup()` itself does not have access to the component instance - `this` will have a value of `undefined` inside `setup()`. You can access Composition-API-exposed values from Options API, but not the other way around.
 :::
 
+:::warning
+`setup()` should always be called _synchronously_. The only case when `async setup()` can be used is when the component is a descentand of a [Suspense](../guide/built-ins/suspense.html) component.
+:::
+
 ## Accessing Props {#accessing-props}
 
 The first argument in the `setup` function is the `props` argument. Just as you would expect in a standard component, `props` inside of a `setup` function are reactive and will be updated when new props are passed in.

--- a/src/api/composition-api-setup.md
+++ b/src/api/composition-api-setup.md
@@ -38,15 +38,11 @@ export default {
 </template>
 ```
 
-Note that [refs](/api/reactivity-core.html#ref) returned from `setup` are [automatically shallow unwrapped](/guide/essentials/reactivity-fundamentals.html#deep-reactivity) when accessed in the template so you do not need to use `.value` when accessing them. They are also unwrapped in the same way when accessed on `this`.
+[refs](/api/reactivity-core.html#ref) returned from `setup` are [automatically shallow unwrapped](/guide/essentials/reactivity-fundamentals.html#deep-reactivity) when accessed in the template so you do not need to use `.value` when accessing them. They are also unwrapped in the same way when accessed on `this`.
 
-:::tip
 `setup()` itself does not have access to the component instance - `this` will have a value of `undefined` inside `setup()`. You can access Composition-API-exposed values from Options API, but not the other way around.
-:::
 
-:::warning
 `setup()` should return an object _synchronously_. The only case when `async setup()` can be used is when the component is a descendant of a [Suspense](../guide/built-ins/suspense.html) component.
-:::
 
 ## Accessing Props {#accessing-props}
 


### PR DESCRIPTION
## Description of Problem

Currently we don't have any information in the docs regarding the fact that normally, `setup()` should always be called synchronously. This raises questions from users who try to call `async setup()` and fail.

## Proposed Solution

Add a warning to `setup()` docs

## Additional Information

Close #1032
