### PR TITLE
Add WebdriverIO as alternative

### DIFF
--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -225,9 +225,9 @@ We recommend using `@testing-library/vue` for testing components in applications
 
 ### Other Options {#other-options-1}
 
-- [WebdriverIO](https://webdriver.io/docs/component-testing/vue) for cross browser component testing that relies on native user interaction based on standardised automation. Can also be used with Testing Library. 
+- [Nightwatch](https://nightwatchjs.org/) is an E2E test runner with Vue Component Testing support. ([Example Project](https://github.com/nightwatchjs-community/todo-vue))
 
-- [Nightwatch](https://v2.nightwatchjs.org/) is an E2E test runner with Vue Component Testing support. ([Example Project](https://github.com/nightwatchjs-community/todo-vue) in Nightwatch v2)
+- [WebdriverIO](https://webdriver.io/docs/component-testing/vue) for cross browser component testing that relies on native user interaction based on standardised automation. Can also be used with Testing Library. 
 
 ## E2E Testing {#e2e-testing}
 
@@ -275,9 +275,9 @@ When end-to-end (E2E) tests are run in continuous integration / deployment pipel
 
 - [Playwright](https://playwright.dev/) is also a great E2E testing solution with a wider range of browser support (mainly WebKit). See [Why Playwright](https://playwright.dev/docs/why-playwright) for more details.
 
-- [WebdriverIO](https://webdriver.io/) is a test automation framework for web and mobile testing based on the WebDriver protocol.
+- [Nightwatch](https://nightwatchjs.org/) is an E2E testing solution based on [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver). This gives it the widest browser support range.
 
-- [Nightwatch v2](https://v2.nightwatchjs.org/) is an E2E testing solution based on [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver). This gives it the widest browser support range.
+- [WebdriverIO](https://webdriver.io/) is a test automation framework for web and mobile testing based on the WebDriver protocol.
 
 ## Recipes {#recipes}
 

--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -225,6 +225,8 @@ We recommend using `@testing-library/vue` for testing components in applications
 
 ### Other Options {#other-options-1}
 
+- [WebdriverIO](https://webdriver.io/docs/component-testing/vue) for cross browser component testing that relies on native user interaction based on standardised automation. Can also be used with Testing Library. 
+
 - [Nightwatch](https://v2.nightwatchjs.org/) is an E2E test runner with Vue Component Testing support. ([Example Project](https://github.com/nightwatchjs-community/todo-vue) in Nightwatch v2)
 
 ## E2E Testing {#e2e-testing}
@@ -272,6 +274,8 @@ When end-to-end (E2E) tests are run in continuous integration / deployment pipel
 ### Other Options {#other-options-2}
 
 - [Playwright](https://playwright.dev/) is also a great E2E testing solution with a wider range of browser support (mainly WebKit). See [Why Playwright](https://playwright.dev/docs/why-playwright) for more details.
+
+- [WebdriverIO](https://webdriver.io/) is a test automation framework for web and mobile testing based on the WebDriver protocol.
 
 - [Nightwatch v2](https://v2.nightwatchjs.org/) is an E2E testing solution based on [Selenium WebDriver](https://www.npmjs.com/package/selenium-webdriver). This gives it the widest browser support range.
 


### PR DESCRIPTION
## Description of Problem

Current testing docs only offer PW and NW as alternative solutions. WebdriverIO has released v8 which includes component testing and has dedicated docs how to get up and running when using Vue as framework.

Using JSDOM and JavaScript click events do not seem like a viable approach for testing component these days as they don't mimic user behavior at all. For example, clicks through `fireEvent` of `@testing-library/vue` do not recognise whether another element is blocking the access to an element. I've done a [whole set of experiments](https://github.com/webdriverio/component-testing-examples/tree/main/framework-comparisons) showing that using WebDriver which is a W3C web standard as automation protocol to mimic user behavior prevents stupid errors to pass through and also offers much more capabilities, e.g. user gestures.

 For pure component tests I personally would not advice to use JSDOM at all given that:

- it lacks in certain features (e.g. triggering pseudo states) and has some [known caveats](https://github.com/jsdom/jsdom#caveats)
- it completely ignores the interactivity state of elements, e.g. if my component hides a button or an input is disabled, many user interactions are still possible within JSDOM and non-organic interactions via JS clicks
- mounting and rendering components in an actual browser allows the use of common developer debugging tools like DevTools rather than using e.g. `screen.debug()` to print the DOM tree providing a much better DX
- speed advancements are just minimal, starting a headless browser is almost as fast

## Proposed Solution

As WebdriverIO as viable alternative.

## Additional Information

n/a