### PR TITLE
chore: update link to ssr-vue playground

### DIFF
--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -194,7 +194,7 @@ customElements.define('my-example', ExampleElement)
 
 If you wish to customize what files should be imported in custom element mode (for example, treating _all_ SFCs as custom elements), you can pass the `customElement` option to the respective build plugins:
 
-- [@vitejs/plugin-vue](https://github.com/vitejs/vite/tree/main/packages/plugin-vue#using-vue-sfcs-as-custom-elements)
+- [@vitejs/plugin-vue](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue#using-vue-sfcs-as-custom-elements)
 - [vue-loader](https://github.com/vuejs/vue-loader/tree/next#v16-only-options)
 
 ### Tips for a Vue Custom Elements Library {#tips-for-a-vue-custom-elements-library}

--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -229,7 +229,7 @@ A complete implementation would be quite complex and depends on the build toolch
 
 Vite provides built-in [support for Vue server-side rendering](https://vitejs.dev/guide/ssr.html), but it is intentionally low-level. If you wish to go directly with Vite, check out [vite-plugin-ssr](https://vite-plugin-ssr.com/), a community plugin that abstracts away many challenging details for you.
 
-You can also find an example Vue + Vite SSR project using manual setup [here](https://github.com/vitejs/vite/tree/main/playground/ssr-vue), which can serve as a base to build upon. Note this is only recommended if you are experienced with SSR / build tools and really want to have complete control over the higher-level architecture.
+You can also find an example Vue + Vite SSR project using manual setup [here](https://github.com/vitejs/vite-plugin-vue/tree/main/playground/ssr-vue), which can serve as a base to build upon. Note this is only recommended if you are experienced with SSR / build tools and really want to have complete control over the higher-level architecture.
 
 ## Writing SSR-friendly Code {#writing-ssr-friendly-code}
 


### PR DESCRIPTION
## Description of Problem

The ssr-vue playground link is still valid, but this may change in the future so it is better to already point to the new plugin-vue repository.

I also missed one link in the prev PR.