### PR TITLE
Fix grammar

### DIFF
--- a/src/tutorial/src/step-5/description.md
+++ b/src/tutorial/src/step-5/description.md
@@ -42,6 +42,6 @@ To simplify two-way bindings, Vue provides a directive, `v-model`, which is esse
 
 `v-model` automatically syncs the `<input>`'s value with the bound state, so we no longer need to use an event handler for that.
 
-`v-model` works not only on text inputs, but also other input types such as checkboxes, radio buttons, and select dropdowns. We cover more details in <a target="_blank" href="/guide/essentials/forms.html">Guide - Form Bindings</a>.
+`v-model` works on not only text inputs, but also other input types such as checkboxes, radio buttons, and select dropdowns. We cover more details in <a target="_blank" href="/guide/essentials/forms.html">Guide - Form Bindings</a>.
 
 Now, try to refactor the code to use `v-model` instead.

--- a/src/tutorial/src/step-5/description.md
+++ b/src/tutorial/src/step-5/description.md
@@ -42,6 +42,6 @@ To simplify two-way bindings, Vue provides a directive, `v-model`, which is esse
 
 `v-model` automatically syncs the `<input>`'s value with the bound state, so we no longer need to use an event handler for that.
 
-`v-model` works on not only text inputs, but also other input types such as checkboxes, radio buttons, and select dropdowns. We cover more details in <a target="_blank" href="/guide/essentials/forms.html">Guide - Form Bindings</a>.
+`v-model` works not only on text inputs, but also on other input types such as checkboxes, radio buttons, and select dropdowns. We cover more details in <a target="_blank" href="/guide/essentials/forms.html">Guide - Form Bindings</a>.
 
 Now, try to refactor the code to use `v-model` instead.


### PR DESCRIPTION
## Description of Problem

The sentence is structured in such a way that it is either missing a word or has words arranged incorrectly.

Current incorrect version:

_`v-model` works not only on text inputs, but also **[missing "on" here]** other input types such as checkboxes, . . ._

Correct version:

_`v-model` works not only on text inputs, but also **on** other input types such as checkboxes,_

## Proposed Solution

The problem could be solved by adding the word "on" before "other input types" as shown above, but I chose to slightly rearrange the words of the sentence without any additions to get the same result and avoid repetition of the word "on".