### PR TITLE
Fix broken portal-vue link

### DIFF
--- a/src/about/team/members-core.json
+++ b/src/about/team/members-core.json
@@ -215,7 +215,7 @@
       },
       {
         "label": "portal-vue*",
-        "url": "https://github.com/LinusBorg/portal-vue*"
+        "url": "https://github.com/LinusBorg/portal-vue"
       }
     ],
     "reposPersonal": ["portal-vue"],


### PR DESCRIPTION
## Description of Problem

The issue found is the portal-vue URL under Linusborg leading to a 404 page.

## Proposed Solution

The proposed solution - remove the * at the end of the URL.

Thanks!