### PR TITLE
Add missing defineExpose import

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -222,7 +222,7 @@ An exception here is that components using `<script setup>` are **private by def
 
 ```vue
 <script setup>
-import { ref } from 'vue'
+import { defineExpose, ref } from 'vue'
 
 const a = 1
 const b = ref(2)


### PR DESCRIPTION
## Description of Problem

An example on `guide/essentials/template-refs.md` is missing the import of `defineExpose`.

## Proposed Solution

Add it.
