### PR TITLE
Fix a grammatical error

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -66,7 +66,7 @@ Attributes that start with `:` may look a bit different from normal HTML, but it
 
 ### Boolean Attributes
 
-[Boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes) are attributes that can indicate true / false values by its presence on an element. For example, [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) is one of the most commonly used boolean attributes.
+[Boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes) are attributes that can indicate true / false values by their presence on an element. For example, [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) is one of the most commonly used boolean attributes.
 
 `v-bind` works a bit differently in this case:
 


### PR DESCRIPTION
## Description of Problem

The singular possessive adjective "its" in the given sentence refers to the plural subject "boolean attributes".

## Proposed Solution

Change "its" to "their" so that it matches "boolean attributes".
