### PR TITLE
Fix a grammatical mistake

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -101,7 +101,7 @@ export default {
 <div>{{ state.count }}</div>
 ```
 
-Similarly, we can declare functions that mutate reactive state in the same scope and expose it as a method alongside the state:
+Similarly, we can declare functions that mutate reactive state in the same scope and expose them as methods alongside the state:
 
 ```js{7-9,14}
 import { reactive } from 'vue'


### PR DESCRIPTION
## Description of Problem

Singular pronoun is used to refer to the plural "functions".

## Proposed Solution

Change singular "it" to plural "them" so that it correctly matches "functions".
