### PR TITLE
Add a comment about not importing defineExpose

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -227,6 +227,7 @@ import { ref } from 'vue'
 const a = 1
 const b = ref(2)
 
+// Compiler macros, such as defineExpose, don't need to be imported
 defineExpose({
   a,
   b


### PR DESCRIPTION
As mentioned in #2126, the example that introduces `defineExpose` doesn't currently mention that it shouldn't be imported. I've added a comment to try to address that.

From what I can tell, this is the first point in the guides that the concept of compiler macros is mentioned. We haven't yet introduced `defineProps` or `defineEmits`. I imagine a lot of people won't be clear what a 'macro' is in this context. This PR doesn't attempt to address that problem directly, though I have used the term 'compiler macro' rather than just 'macro' in the comment.