### PR TITLE
Links to TS docs from the API section

### DIFF
--- a/src/api/built-in-special-attributes.md
+++ b/src/api/built-in-special-attributes.md
@@ -80,7 +80,10 @@ Denotes a [template ref](/guide/essentials/template-refs.html).
 
   `this.$refs` is also non-reactive, therefore you should not attempt to use it in templates for data-binding.
 
-- **See also:** [Template Refs](/guide/essentials/template-refs.html)
+- **See also:**
+  - [Guide - Template Refs](/guide/essentials/template-refs.html)
+  - [Guide - Typing Template Refs](/guide/typescript/composition-api.html#typing-template-refs) <sup class="vt-badge ts" />
+  - [Guide - Typing Component Template Refs](/guide/typescript/composition-api.html#typing-component-template-refs) <sup class="vt-badge ts" />
 
 ## is {#is}
 

--- a/src/api/composition-api-dependency-injection.md
+++ b/src/api/composition-api-dependency-injection.md
@@ -39,7 +39,7 @@ Provides a value that can be injected by descendant components.
 
 - **See also**:
   - [Guide - Provide / Inject](/guide/components/provide-inject.html)
-  - [Guide - Typing Provide / Inject](/guide/typescript/composition-api.html#typing-provide-inject)
+  - [Guide - Typing Provide / Inject](/guide/typescript/composition-api.html#typing-provide-inject) <sup class="vt-badge ts" />
 
 ## inject() {#inject}
 
@@ -103,4 +103,4 @@ Injects a value provided by an ancestor component or the application (via `app.p
 
 - **See also**:
   - [Guide - Provide / Inject](/guide/components/provide-inject.html)
-  - [Guide - Typing Provide / Inject](/guide/typescript/composition-api.html#typing-provide-inject)
+  - [Guide - Typing Provide / Inject](/guide/typescript/composition-api.html#typing-provide-inject) <sup class="vt-badge ts" />

--- a/src/api/options-state.md
+++ b/src/api/options-state.md
@@ -125,7 +125,9 @@ Declare the props of a component.
   }
   ```
 
-- **See also:** [Props](/guide/components/props.html)
+- **See also:**
+  - [Guide - Props](/guide/components/props.html)
+  - [Guide - Typing Component Props](/guide/typescript/options-api.html#typing-component-props) <sup class="vt-badge ts" />
 
 ## computed {#computed}
 
@@ -205,7 +207,9 @@ Declare computed properties to be exposed on the component instance.
   }
   ```
 
-- **See also:** [Computed Properties](/guide/essentials/computed.html)
+- **See also:**
+  - [Guide - Computed Properties](/guide/essentials/computed.html)
+  - [Guide - Typing Computed Properties](/guide/typescript/options-api.html#typing-computed-properties) <sup class="vt-badge ts" />
 
 ## methods {#methods}
 
@@ -429,7 +433,9 @@ Declare the custom events emitted by the component.
   }
   ```
 
-* **See also:** [Fallthrough Attributes](/guide/components/attrs.html)
+- **See also:**
+  - [Guide - Fallthrough Attributes](/guide/components/attrs.html)
+  - [Guide - Typing Component Emits](/guide/typescript/options-api.html#typing-component-emits) <sup class="vt-badge ts" />
 
 ## expose {#expose}
 

--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -41,7 +41,7 @@ Takes an inner value and returns a reactive and mutable ref object, which has a 
 
 - **See also:**
   - [Guide - Reactive Variables with `ref()`](/guide/essentials/reactivity-fundamentals.html#reactive-variables-with-ref)
-  - [Guide - Typing `ref()`](/guide/typescript/composition-api.html#typing-ref)
+  - [Guide - Typing `ref()`](/guide/typescript/composition-api.html#typing-ref) <sup class="vt-badge ts" />
 
 ## computed() {#computed}
 
@@ -111,7 +111,7 @@ Takes a getter function and returns a readonly reactive [ref](#ref) object for t
 - **See also:**
   - [Guide - Computed Properties](/guide/essentials/computed.html)
   - [Guide - Computed Debugging](/guide/extras/reactivity-in-depth.html#computed-debugging)
-  - [Guide - Typing `computed()`](/guide/typescript/composition-api.html#typing-computed)
+  - [Guide - Typing `computed()`](/guide/typescript/composition-api.html#typing-computed) <sup class="vt-badge ts" />
 
 ## reactive() {#reactive}
 
@@ -188,7 +188,7 @@ Returns a reactive proxy of the object.
 
 - **See also:**
   - [Guide - Reactivity Fundamentals](/guide/essentials/reactivity-fundamentals.html)
-  - [Guide - Typing `reactive()`](/guide/typescript/composition-api.html#typing-reactive)
+  - [Guide - Typing `reactive()`](/guide/typescript/composition-api.html#typing-reactive) <sup class="vt-badge ts" />
 
 ## readonly() {#readonly}
 


### PR DESCRIPTION
Inspired by #2138.

I've added or updated entries in the **See also** sections in the API docs that link to the relevant TS guides. In each case I've included the TS badge and prefixed the link text with **'Guide -'**.

In some cases I've also added the **'Guide -'** prefix to other (non-TS) links in the same list, to ensure consistency within the list.

The file `utility-types.md` is also missing the TS badge from its **See also** links, but given that whole page is TS I didn't think it was worth adding it.