### PR TITLE
Disable VueJobs widget

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -4,7 +4,6 @@ import { defineConfigWithTheme } from 'vitepress'
 import type { Config as ThemeConfig } from '@vue/theme'
 import baseConfig from '@vue/theme/config'
 import { headerPlugin } from './headerMdPlugin'
-import { jobsPlugin } from './jobsMdPlugin'
 
 const nav: ThemeConfig['nav'] = [
   {
@@ -662,7 +661,7 @@ export default defineConfigWithTheme<ThemeConfig>({
 
   markdown: {
     config(md) {
-      md.use(headerPlugin).use(jobsPlugin)
+      md.use(headerPlugin)
     }
   },
 

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -8,7 +8,6 @@ import {
   filterHeadersByPreference
 } from './components/preferences'
 import SponsorsAside from './components/SponsorsAside.vue'
-import VueJobs from './components/VueJobs.vue'
 import VueSchoolLink from './components/VueSchoolLink.vue'
 // import Banner from './components/Banner.vue'
 
@@ -26,6 +25,5 @@ export default Object.assign({}, VPTheme, {
     app.provide('prefer-sfc', preferSFC)
     app.provide('filter-headers', filterHeadersByPreference)
     app.component('VueSchoolLink', VueSchoolLink)
-    app.component('VueJobs', VueJobs)
   }
 })


### PR DESCRIPTION
As discussed with @yyx990803 this PR will disable the Jobs widget in the header of the documentation pages.