### PR TITLE
Reword the opening sentence about declaring events

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -100,7 +100,7 @@ All extra arguments passed to `$emit()` after the event name will be forwarded t
 
 ## Declaring Emitted Events {#declaring-emitted-events}
 
-Emitted events can be explicitly declared on the component via the <span class="composition-api">[`defineEmits()`](/api/sfc-script-setup.html#defineprops-defineemits) macro</span><span class="options-api">[`emits`](/api/options-state.html#emits) option</span>:
+A component can explicitly declare the events it will emit using the <span class="composition-api">[`defineEmits()`](/api/sfc-script-setup.html#defineprops-defineemits) macro</span><span class="options-api">[`emits`](/api/options-state.html#emits) option</span>:
 
 <div class="composition-api">
 


### PR DESCRIPTION
Closes #1888.

The current wording is a little ambiguous. On first reading, it isn't necessarily clear which component (parent or child) is being referenced by the words 'the component'. Further, the words 'emitted events' could be interpreted as 'events that have been emitted', rather than 'events that will be emitted'.

This rewording attempts to remove the potential for misinterpretation.