### PR TITLE
Add caveats around mixing `<script setup>` and `<script>`

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -239,6 +239,13 @@ export default {
 </script>
 ```
 
+Support for combining `<script setup>` and `<script>` in the same component is limited to the scenarios described above. Specifically:
+
+- Do **NOT** use a separate `<script>` section for options that can already be defined using `<script setup>`, such as `props` and `emits`.
+- Variables created inside `<script setup>` are not added as properties to the component instance, making them inaccessible from the Options API. Mixing APIs in this way is strongly discouraged.
+
+If you find yourself in one of the scenarios that is not supported then you should consider switching to an explicit [`setup()`](/api/composition-api-setup.html) function, instead of using `<script setup>`.
+
 ## Top-level `await` {#top-level-await}
 
 Top-level `await` can be used inside `<script setup>`. The resulting code will be compiled as `async setup()`:


### PR DESCRIPTION
This PR is based on the conversation on <https://github.com/vuejs/core/issues/6242>.

Using `<script setup>` alongside a separate `<script>` tag was intended as an escape hatch for some specific use cases, as described in the docs. But in practice it has been used in various other ways that were not really intended. However, the tone of the docs does not currently discourage that kind of usage.

This PR makes some of the caveats more explicit.