### PR TITLE
Update utility-types.md

### DIFF
--- a/src/api/utility-types.md
+++ b/src/api/utility-types.md
@@ -11,7 +11,7 @@ Used to annotate a prop with more advanced types when using runtime props declar
 - **Example**
 
   ```ts
-  import { PropType } from 'vue'
+  import type { PropType } from 'vue'
 
   interface Book {
     title: string


### PR DESCRIPTION
## Description of Problem
When running the current code in the docs, the user may see the error:
`The requested module ‘/node_modules/.vite/deps/vue.js’ does not provide an export named ‘PropType’`

## Proposed Solution
Explicitly import PropTypes as a `type` 

