### PR TITLE
Add more API examples for `watch()`

### DIFF
--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -453,7 +453,31 @@ Watches one or more reactive data sources and invokes a callback function when t
     flush: 'post',
     onTrack(e) {
       debugger
+    },
+    onTrigger(e) {
+      debugger
     }
+  })
+  ```
+
+  Stopping the watcher:
+
+  ```js
+  const stop = watch(source, callback)
+
+  // when the watcher is no longer needed:
+  stop()
+  ```
+
+  Side effect cleanup:
+
+  ```js
+  watch(id, async (newId, oldId, onCleanup) => {
+    const { response, cancel } = doAsyncWork(newId)
+    // `cancel` will be called if `id` changes, cancelling
+    // the previous request if it hasn't completed yet
+    onCleanup(cancel)
+    data.value = await response
   })
   ```
 


### PR DESCRIPTION
This PR adds some extra examples for `watch()`. They are very similar to the equivalent examples for `watchEffect()`.

The inspiration for adding these examples comes from #2102. There were some consistency problems that made it difficult to merge that PR, but I believe the changes here should address the same gap in the examples.