### PR TITLE
fix: change a singular noun to plural

### DIFF
--- a/src/guide/scaling-up/state-management.md
+++ b/src/guide/scaling-up/state-management.md
@@ -197,7 +197,7 @@ export const store = reactive({
 </div>
 
 :::tip
-Note the click handler uses `store.increment()` with the parenthesis - this is necessary to call the method with the proper `this` context since it's not a component method.
+Note the click handler uses `store.increment()` with parentheses - this is necessary to call the method with the proper `this` context since it's not a component method.
 :::
 
 Although here we are using a single reactive object as a store, you can also share reactive state created using other [Reactivity APIs](/api/reactivity-core.html) such as `ref()` or `computed()`, or even return global state from a [Composable](/guide/reusability/composables.html):


### PR DESCRIPTION
## Description of Problem

The singular noun "parenthesis" is used in reference to two parentheses that invoke a function.

## Proposed Solution

Change the singular form to plural.
