### PR TITLE
Document PropType usage with the Composition API

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -131,6 +131,49 @@ export default defineComponent({
 })
 ```
 
+### Complex prop types
+
+With type-based declaration, a prop can use a complex type much like any other type:
+
+```vue
+<script setup lang="ts">
+interface Book {
+  title: string
+  author: string
+  year: number
+}
+
+const props = defineProps<{
+  book: Book
+}>()
+</script>
+```
+
+For runtime declaration, we can use the `PropType` utility type:
+
+```ts
+import type { PropType } from 'vue'
+
+const props = defineProps({
+  book: Object as PropType<Book>
+})
+```
+
+This works in much the same way if we're specifying the `props` option directly:
+
+```ts
+import { defineComponent } from 'vue'
+import type { PropType } from 'vue'
+
+export default defineComponent({
+  props: {
+    book: Object as PropType<Book>
+  }
+})
+```
+
+The `props` option is more commonly used with the Options API, so you'll find more detailed examples in the guide to [TypeScript with Options API](/guide/typescript/options-api.html#typing-component-props). The techniques shown in those examples also apply to runtime declarations using `defineProps()`.
+
 ## Typing Component Emits {#typing-component-emits}
 
 In `<script setup>`, the `emit` function can also be typed using either runtime declaration OR type declaration:


### PR DESCRIPTION
Closes #1621.

Add documentation about working with complex types for props in the Composition API.

Specifically, `PropType` isn't currently mentioned on the page about using TypeScript with the Composition API. It only features on the page about the Options API.

The original suggestion, on #1621, was to document this near the top of the page, before we start discussing type-based prop declaration. That was my original plan, but I felt there were a few problems with that approach:

* The page also mentions the `props` option, which also uses `PropType` for complex types.
* That earlier section seems to be trying to encourage the use of type-based declaration. Runtime declaration is glossed over very quickly. Adding a more detailed explanation would delay mentioning the 'recommended' approach.
* The docs don't currently show how to use complex types with type-based declaration. It may be 'obvious', but without mentioning it explicitly I think someone could get confused and think they need to do something with `PropType`.

I also didn't want to repeat everything that's on the Options API page.

With those considerations in mind, I've added a separate section to the end of the section about props. It documents using complex types with the three different approaches. The examples are based on those in the Options API TS docs, but I haven't gone into the same level of detail as those examples. I've included a link to the Options API TS docs for anyone who wants more examples, but I don't think there's any essential information missing.