### PR TITLE
Fix wording

### DIFF
--- a/src/guide/components/provide-inject.md
+++ b/src/guide/components/provide-inject.md
@@ -274,7 +274,7 @@ const { location, updateLocation } = inject('location')
 </template>
 ```
 
-Finally, you can wrap the provided value with [`readonly()`](/api/reactivity-core.html#readonly) if you want to ensure that the data passed through `provide` cannot be mutated by the injected component.
+Finally, you can wrap the provided value with [`readonly()`](/api/reactivity-core.html#readonly) if you want to ensure that the data passed through `provide` cannot be mutated by the injector component.
 
 ```vue
 <script setup>


### PR DESCRIPTION
## Description of Problem

An injector component is called "injected component".

## Proposed Solution

Change "injected" to "injector".

## Additional Information

This is the only instance on the page where this expression is used instead of "injector component".
