### PR TITLE
clarify restrictions on where composables can be invoked

### DIFF
--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -277,9 +277,9 @@ It is OK to perform side effects (e.g. adding DOM event listeners or fetching da
 
 ### Usage Restrictions {#usage-restrictions}
 
-Composables should only be called **synchronously** in `<script setup>` or the `setup()` hook. In some cases, you can also call them in lifecycle hooks like `onMounted()`.
+Composables should only be called in `<script setup>` or the `setup()` hook. They should also be called **synchronously** in these contexts. In some cases, you can also call them in lifecycle hooks like `onMounted()`.
 
-These are the contexts where Vue is able to determine the current active component instance. Access to an active component instance is necessary so that:
+These restrictions are important because these are the contexts where Vue is able to determine the current active component instance. Access to an active component instance is necessary so that:
 
 1. Lifecycle hooks can be registered to it.
 


### PR DESCRIPTION
## Description of Problem

I have seen some vue developers interpret the following from the ["Composables -> Usage Restrictions"](https://vuejs.org/guide/reusability/composables.html#usage-restrictions) section: when calling composables in a `<script setup>` or `setup()` context, you must call them synchronously. This is good, however feel like we may need to be clear that composables also should only be called in `<script setup>` or `setup()` regardless of whether they are a/synchronously called, and for the reasons described later in the section.

## Proposed Solution

Change how the section is phrased to emphasise that composables, in all cases, only be called:

1. in `<script setup>` or `setup()` hook
2. synchronously

And/or start discussion about best practices about where composables can be called from.

## Additional Information

We should discuss whether this is in the realm of a hard restriction, simply a "best practice," or clarity on "best practices" for using composables outside of a vue context.  

### Related

- [Vue Chat discussion](https://discord.com/channels/325477692906536972/546534697166045204/1063524833025077278)
- [#7488 Composables usage restrictions][7488]
- [#6114 using composables outside script setup (eg. Pinia action)][6114]  
- [A suggestion that composables are to be only used in a vue context](https://github.com/vuejs/core/discussions/6632#discussioncomment-3695121)
- #1841 
- #1293 
  -  "Reactivity APIs should never be used outside setup, unless we fully understand why and how to use effectScope to collect and clean up side effects."

### Counter examples

Libraries like VueUse have techniques like [`tryOnUnmounted`](https://vueuse.org/shared/tryonunmounted/#tryonunmounted) which seem to imply that their composables could work outside of a vue context. 

Pinia also suggests usage of their `useStore()` composable [outside of the context of a component](https://pinia.vuejs.org/core-concepts/outside-component-usage.html) and other cases where you could use a composable within its framework.

[6114]: https://github.com/vuejs/core/discussions/6114
[7488]: https://github.com/vuejs/core/discussions/7488
  
  