### PR TITLE
Update compositon-api.md

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -316,7 +316,7 @@ function handleChange(event) {
 </template>
 ```
 
-Without type annotation, the `event` argument will implicitly have a type of `any`. This will also result in a TS error if `"strict": true` or `"noImplicitAny": true` are used in `tsconfig.json`. It is therefore recommended to explicitly annotate the argument of event handlers. In addition, you may need to explicitly cast properties on `event`:
+Without type annotation, the `event` argument will implicitly have a type of `any`. This will also result in a TS error if `"strict": true` or `"noImplicitAny": true` are used in `tsconfig.json`. It is therefore recommended to explicitly annotate the argument of event handlers. In addition, you may need to explicitly assert properties on `event`:
 
 ```ts
 function handleChange(event: Event) {


### PR DESCRIPTION
## Description of Problem
There is no such thing as casting in typescript, but asserting. There are no actual types during runtime. You are able to trick the compiler into thinking that the left-hand side of the `as` keyword has the shape of the specified type on the right-hand side.

https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions

## Proposed Solution
Use `as` instead of `cast` in the docs.

## Additional Information
