### PR TITLE
Add missing heading anchors

### DIFF
--- a/src/api/ssr.md
+++ b/src/api/ssr.md
@@ -30,7 +30,7 @@
   })()
   ```
 
-  ### SSR Context
+  ### SSR Context {#ssr-context}
 
   You can pass an optional context object, which can be used to record additional data during the render, for example [accessing content of Teleports](/guide/scaling-up/ssr.html#teleports):
 

--- a/src/guide/essentials/class-and-style.md
+++ b/src/guide/essentials/class-and-style.md
@@ -247,7 +247,7 @@ You can learn more about component attribute inheritance in [Fallthrough Attribu
 
 ## Binding Inline Styles {#binding-inline-styles}
 
-### Binding to Objects
+### Binding to Objects {#binding-to-objects-1}
 
 `:style` supports binding to JavaScript object values - it corresponds to an [HTML element's `style` property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style):
 
@@ -317,7 +317,7 @@ data() {
 
 Again, object style binding is often used in conjunction with computed properties that return objects.
 
-### Binding to Arrays
+### Binding to Arrays {#binding-to-arrays-1}
 
 We can bind `:style` to an array of multiple style objects. These objects will be merged and applied to the same element:
 

--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -379,7 +379,7 @@ For radio, checkbox and select options, the `v-model` binding values are usually
 
 But sometimes we may want to bind the value to a dynamic property on the current active instance. We can use `v-bind` to achieve that. In addition, using `v-bind` allows us to bind the input value to non-string values.
 
-### Checkbox
+### Checkbox {#checkbox-1}
 
 ```vue-html
 <input
@@ -403,7 +403,7 @@ But sometimes we may want to bind the value to a dynamic property on the current
 The `true-value` and `false-value` attributes don't affect the input's `value` attribute, because browsers don't include unchecked boxes in form submissions. To guarantee that one of two values is submitted in a form (e.g. "yes" or "no"), use radio inputs instead.
 :::
 
-### Radio
+### Radio {#radio-1}
 
 ```vue-html
 <input type="radio" v-model="pick" :value="first" />


### PR DESCRIPTION
A few more headings without anchors.

I think the SSR heading was missed because of the indentation. The others are duplicate headers within the same file, so they need a `-1` suffix.