### PR TITLE
text goes out from wrapper in multiline text section

### DIFF
--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -87,7 +87,7 @@ For languages that require an [IME](https://en.wikipedia.org/wiki/Input_method) 
 
 <div class="demo">
   <span>Multiline message is:</span>
-  <p style="white-space: pre-line;">{{ multilineText }}</p>
+  <p style="white-space: pre-line, word-break: break-all;">{{ multilineText }}</p>
   <textarea v-model="multilineText" placeholder="add multiple lines"></textarea>
 </div>
 


### PR DESCRIPTION
text goes out from wrapper in multiline text section when do not press enter in textarea and type very letter in it.
for this error we can use css attribute word-break and set this with break-all value;
