### PR TITLE
Fix bad error inducing documentation

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -40,12 +40,14 @@ You can use either type-based declaration OR runtime declaration, but you cannot
 We can also move the props types into a separate interface:
 
 ```vue
-<script setup lang="ts">
+<script lang="ts">
 interface Props {
   foo: string
   bar?: number
 }
+</script>
 
+<script setup lang="ts">
 const props = defineProps<Props>()
 </script>
 ```


### PR DESCRIPTION
Existing code snippet gives this error:

    Default export of the module has or is using private name 'Props'.ts (4082)

Error fixed thanks to:
https://github.com/johnsoncodehk/volar/issues/1232#issue-1213615569

![image](https://user-images.githubusercontent.com/27283110/215162678-daedb18c-8fa6-435f-8e25-59bed2b51a0f.png)