### PR TITLE
docs: hyphenate 'real world' when used as an adjective

### DIFF
--- a/src/about/releases.md
+++ b/src/about/releases.md
@@ -72,6 +72,6 @@ The RFC process is conducted in the [vuejs/rfcs](https://github.com/vuejs/rfcs) 
 
 ## Experimental Features {#experimental-features}
 
-Some features are shipped and documented in a stable version of Vue, but marked as experimental. Experimental features are typically features that have an associated RFC discussion with most of the design problems resolved on paper, but still lacking feedback from real world usage.
+Some features are shipped and documented in a stable version of Vue, but marked as experimental. Experimental features are typically features that have an associated RFC discussion with most of the design problems resolved on paper, but still lacking feedback from real-world usage.
 
 The goal of experimental features is to allow users to provide feedback for them by testing them in a production setting, without having to use an unstable version of Vue. Experimental features themselves are considered unstable, and should only be used in a controlled manner, with the expectation that the feature may change between any release types.

--- a/src/ecosystem/themes/ThemePage.vue
+++ b/src/ecosystem/themes/ThemePage.vue
@@ -8,7 +8,7 @@ import ThemeContact from './ThemeContact.vue'
   <div class="ThemePage">
     <ThemeHero>
       <template #title>Themes</template>
-      <template #lead>Check out the themes, UI Kits, and plugins. You can see how a real world application is built with Vue by our partners.</template>
+      <template #lead>Check out the themes, UI Kits, and plugins. You can see how a real-world application is built with Vue by our partners.</template>
     </ThemeHero>
 
     <ThemeList />

--- a/src/ecosystem/themes/themes.json
+++ b/src/ecosystem/themes/themes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Creative Tim",
-    "description": "With the examples below built by our partners from [Creative Tim](https://creative-tim.com?affiliate_id=116187) you can see how a real world application is built, the technology stack behind it and how most of the concepts you've learned so far apply in a real world application.",
+    "description": "With the examples below built by our partners from [Creative Tim](https://creative-tim.com?affiliate_id=116187) you can see how a real-world application is built, the technology stack behind it and how most of the concepts you've learned so far apply in a real-world application.",
     "seeMoreUrl": "https://www.creative-tim.com/bootstrap-themes/vuejs-themes?affiliate_id=116187",
     "products": [
       {

--- a/src/guide/best-practices/performance.md
+++ b/src/guide/best-practices/performance.md
@@ -55,7 +55,7 @@ One of the most effective ways to improve page load performance is shipping smal
 
   - When using a build step, templates are pre-compiled so we don't need to ship the Vue compiler to the browser. This saves **14kb** min+gzipped JavaScript and avoids the runtime compilation cost.
 
-- Be cautious of size when introducing new dependencies! In real world applications, bloated bundles are most often a result of introducing heavy dependencies without realizing it.
+- Be cautious of size when introducing new dependencies! In real-world applications, bloated bundles are most often a result of introducing heavy dependencies without realizing it.
 
   - If using a build step, prefer dependencies that offer ES module formats and are tree-shaking friendly. For example, prefer `lodash-es` over `lodash`.
 

--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -15,7 +15,7 @@ In the context of Vue applications, a "composable" is a function that leverages 
 
 When building frontend applications, we often need to reuse logic for common tasks. For example, we may need to format dates in many places, so we extract a reusable function for that. This formatter function encapsulates **stateless logic**: it takes some input and immediately returns expected output. There are many libraries out there for reusing stateless logic - for example [lodash](https://lodash.com/) and [date-fns](https://date-fns.org/), which you may have heard of.
 
-By contrast, stateful logic involves managing state that changes over time. A simple example would be tracking the current position of the mouse on a page. In real world scenarios, it could also be more complex logic such as touch gestures or connection status to a database.
+By contrast, stateful logic involves managing state that changes over time. A simple example would be tracking the current position of the mouse on a page. In real-world scenarios, it could also be more complex logic such as touch gestures or connection status to a database.
 
 ## Mouse Tracker Example {#mouse-tracker-example}
 


### PR DESCRIPTION
## Description of Problem

The expression 'real world' should have a hyphen when it is used as an adjective.

## Proposed Solution

real world -> real-world
