### PR TITLE
docs: fix aria-labelledby example.

### DIFF
--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -97,13 +97,13 @@ Users can navigate an application through headings. Having descriptive headings 
 ```vue-html
 <main role="main" aria-labelledby="main-title">
   <h1 id="main-title">Main title</h1>
-  <section aria-labelledby="section-title">
-    <h2 id="section-title"> Section Title </h2>
+  <section aria-labelledby="section-title-1">
+    <h2 id="section-title-1"> Section Title </h2>
     <h3>Section Subtitle</h3>
     <!-- Content -->
   </section>
-  <section aria-labelledby="section-title">
-    <h2 id="section-title"> Section Title </h2>
+  <section aria-labelledby="section-title-2">
+    <h2 id="section-title-2"> Section Title </h2>
     <h3>Section Subtitle</h3>
     <!-- Content -->
     <h3>Section Subtitle</h3>


### PR DESCRIPTION
## Description of Problem

The `id` used in the aria-labelledby attribute is duplicated.

## Proposed Solution

Change the `id`'s to make them unique.