### PR TITLE
Revert "Fix bad error inducing documentation"

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -40,14 +40,12 @@ You can use either type-based declaration OR runtime declaration, but you cannot
 We can also move the props types into a separate interface:
 
 ```vue
-<script lang="ts">
+<script setup lang="ts">
 interface Props {
   foo: string
   bar?: number
 }
-</script>
 
-<script setup lang="ts">
 const props = defineProps<Props>()
 </script>
 ```


### PR DESCRIPTION
Reverts vuejs/docs#2191

My apologies for the confusion in this. While this does fix the issue at hand, we're trying work at a long term solution that would not require users to use two separate script blocks in order to resolve the error being raised. 