### PR TITLE
Improve description of "disconnected" property caveat to reactive obj…

### DIFF
--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -104,7 +104,7 @@ Code snippets here and below are meant to explain the core concepts in the simpl
 
 This explains a few [limitations of reactive objects](/guide/essentials/reactivity-fundamentals.html#limitations-of-reactive) that we have discussed in the fundamentals section:
 
-- When you assign or destructure a reactive object's property to a local variable, the local variable's reactivity is "disconnected" from the parent object because access to the local variable no longer triggers the get / set proxy traps on the parent object.
+- When you assign or destructure a reactive object's property to a local variable, the local variable's reactivity is "disconnected" from the source object because access to the local variable no longer triggers the get / set proxy traps on the source object.
 
 - The returned proxy from `reactive()`, although behaving just like the original, has a different identity if we compare it to the original using the `===` operator.
 

--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -104,7 +104,7 @@ Code snippets here and below are meant to explain the core concepts in the simpl
 
 This explains a few [limitations of reactive objects](/guide/essentials/reactivity-fundamentals.html#limitations-of-reactive) that we have discussed in the fundamentals section:
 
-- When you assign or destructure a reactive object's property to a local variable, the local variable's reactivity is "disconnected" from the source object because access to the local variable no longer triggers the get / set proxy traps on the source object.
+- When you assign or destructure a reactive object's property to a local variable, accessing or assigning to that variable is non-reactive because it no longer triggers the get / set proxy traps on the source object. Note this "disconnect" only affects the variable binding - if the variable points to a non-primitive value such as an object, mutating the object would still be reactive.
 
 - The returned proxy from `reactive()`, although behaving just like the original, has a different identity if we compare it to the original using the `===` operator.
 

--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -104,7 +104,7 @@ Code snippets here and below are meant to explain the core concepts in the simpl
 
 This explains a few [limitations of reactive objects](/guide/essentials/reactivity-fundamentals.html#limitations-of-reactive) that we have discussed in the fundamentals section:
 
-- When you assign or destructure a reactive object's property to a local variable, the reactivity is "disconnected" because access to the local variable no longer triggers the get / set proxy traps.
+- When you assign or destructure a reactive object's property to a local variable, the local variable's reactivity is "disconnected" from the parent object because access to the local variable no longer triggers the get / set proxy traps on the parent object.
 
 - The returned proxy from `reactive()`, although behaving just like the original, has a different identity if we compare it to the original using the `===` operator.
 


### PR DESCRIPTION
…ects.

Try and make more clear what happens when you create a new reference to a reactive object property. Just saying "disconnected" is ambiguous and confusing because as stated else where in the docs, reactivity is "deep", so the property your referencing is actually still a proxy object. It's just "disconnected" from the parent to subscribers to the parent will not get notified. At least that is my understanding of what is going on (it's strange because it seems like have a parent reference would be a simple fix to this issue, but that has not been done for some unexplained reason).

## Description of Problem

## Proposed Solution

## Additional Information
