### PR TITLE
missed element in TypeScript interface

### DIFF
--- a/src/about/team/Member.ts
+++ b/src/about/team/Member.ts
@@ -21,5 +21,6 @@ export interface Link {
 export interface Socials {
   github: string
   twitter?: string
+  linkedin?: string
   codepen?: string
 }


### PR DESCRIPTION
## Description of Problem
`src/about/team/Member.ts` is missing `linkedin` property in `Social` interface definition. While the page still works as intended since the data are presented in `.json` files, TypeScript check in Visual Studio points out this error on `TeamMember.vue`, where the property is called.

## Proposed Solution
Add missing element into interface definition.

## Additional Information
