### PR TITLE
Fix:Error when there is no ecosystem field in the theme configuration…

### DIFF
--- a/.vitepress/theme/components/SiteMap.vue
+++ b/.vitepress/theme/components/SiteMap.vue
@@ -5,9 +5,8 @@ import { useData } from 'vitepress'
 const data = useData()
 const nav = data.site.value.themeConfig.nav
 const ecosystem = nav.find((i: any) => i.text === 'Ecosystem')
-const items = nav
-  .filter((i: any) => i !== ecosystem && i.items)
-  .concat(ecosystem.items)
+let items = nav.filter((i: any) => i !== ecosystem && i.items)
+items = ecosystem?.items ?  items.concat(ecosystem.items) : items
 </script>
 
 <template>


### PR DESCRIPTION
… navigation

## Description of Problem

In the local launch of the Chinese version of the document when the white screen problem can not be loaded, through the error message found in the document `.vitepress/config.ts` file in the `ThemeConfig` object missing `Ecosystem ` This object will throw an error.

![](https://github.com/zhoujiahua/picture/blob/master/2023/er-1.png?raw=true)



By debug code in the `.vitepress/theme/components/SiteMap.vue` file we when the object `Ecosystem` is missing we use find method return value is `undefined` type; when we finally merge the data in the 'undefined' type to get the property value when the error.

![](https://github.com/zhoujiahua/picture/blob/master/2023/er-3.png?raw=true)



## Proposed Solution

Add null detection when using the return value `ecosystem`.

![](https://github.com/zhoujiahua/picture/blob/master/2023/su-1.png?raw=true)



## Additional Information

Chinese document error.

![](https://github.com/zhoujiahua/picture/blob/master/2023/cn-1.png?raw=true)

Japanese documentation reports an error.

![](https://github.com/zhoujiahua/picture/blob/master/2023/jp-1.png?raw=true)

