### PR TITLE
fix: typing component refs

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -401,14 +401,15 @@ defineExpose({
 </script>
 ```
 
-In order to get the instance type of `MyModal`, we need to first get its type via `typeof`, then use TypeScript's built-in `InstanceType` utility to extract its instance type:
+In order to get the instance type of `MyModal`, we need to first get its type via `typeof`, then use Vue's `ComponentPublicInstance` utility to extract its instance type:
 
 ```vue{5}
 <!-- App.vue -->
 <script setup lang="ts">
+import { ComponentPublicInstance } from 'vue';
 import MyModal from './MyModal.vue'
 
-const modal = ref<InstanceType<typeof MyModal> | null>(null)
+const modal = ref<ComponentPublicInstance<typeof MyModal> | null>(null)
 
 const openModal = () => {
   modal.value?.open()


### PR DESCRIPTION
## Description of Problem

Typescript and Intellij cannot find exposed methods when using `InstanceType` for typed template refs:

![Screenshot at Feb 06 09-52-17](https://user-images.githubusercontent.com/15201748/216930759-5adb7dd6-8c46-4c1f-a539-4dc49edc4d47.png)

The methods are exposed inside the Modal like so:

```
setup(props, { expose }) {
  expose({
    open: () => {},
  });
  // ...
}
```

## Proposed Solution

Use Vue's `ComponentPublicInstance` instead of `InstanceType`:

```
import { ref, ComponentPublicInstance } from 'vue';
const modal = ref<ComponentPublicInstance<typeof MyModal> | null>(null);
```
