### PR TITLE
Make SiteMap.vue compatible with translations

### DIFF
--- a/.vitepress/theme/components/SiteMap.vue
+++ b/.vitepress/theme/components/SiteMap.vue
@@ -4,7 +4,7 @@ import { useData } from 'vitepress'
 
 const data = useData()
 const nav = data.site.value.themeConfig.nav
-const ecosystem = nav.find((i: any) => i.text === 'Ecosystem')
+const ecosystem = nav.find((i: any) => i.activeMatch?.includes('ecosystem'))
 const items = nav
   .filter((i: any) => i !== ecosystem && i.items)
   .concat(ecosystem.items)


### PR DESCRIPTION
`SiteMap.vue` is currently causing errors in the translations because it relies on detecting the English text 'Ecosystem'. See #2209 and #2211 for details.

This PR changes the logic to detect the URL path rather than the text label. This should be stable across translations.