### PR TITLE
Update template-syntax.md

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -225,7 +225,7 @@ Similarly, you can use dynamic arguments to bind a handler to a dynamic event na
 <a v-on:[eventName]="doSomething"> ... </a>
 
 <!-- shorthand -->
-<a @[eventName]="doSomething">
+<a @[eventName]="doSomething"> ...</a>
 ```
 
 In this example, when `eventName`'s value is `"focus"`, `v-on:[eventName]` will be equivalent to `v-on:focus`.


### PR DESCRIPTION
## Shorthand format of the example code was confusing

## <a @[eventName]="doSomething"> ... </a>

## <a @[eventName]="doSomething"> it seems that in the shorthand format of code, there is no need for a closing tag.
