### PR TITLE
docs: convert vs. to vs

### DIFF
--- a/src/examples/ExampleRepl.vue
+++ b/src/examples/ExampleRepl.vue
@@ -18,8 +18,8 @@ onHashChange(updateExample)
 /**
  * We perform some runtime logic to transform source files into different
  * API / format combinations:
- * - Options vs. Composition
- * - plain HTML vs. SFCs
+ * - Options vs Composition
+ * - plain HTML vs SFCs
  */
 function updateExample() {
   let hash = location.hash.slice(1)

--- a/src/guide/best-practices/production-deployment.md
+++ b/src/guide/best-practices/production-deployment.md
@@ -1,6 +1,6 @@
 # Production Deployment {#production-deployment}
 
-## Development vs. Production {#development-vs-production}
+## Development vs Production {#development-vs-production}
 
 During development, Vue provides a number of features to improve the development experience:
 

--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -156,7 +156,7 @@ Technically, you can also use camelCase when passing props to a child component 
 
 We use [PascalCase for component tags](/guide/components/registration.html#component-name-casing) when possible because it improves template readability by differentiating Vue components from native elements. However, there isn't as much practical benefit in using camelCase when passing props, so we choose to follow each language's conventions.
 
-### Static vs. Dynamic Props {#static-vs-dynamic-props}
+### Static vs Dynamic Props {#static-vs-dynamic-props}
 
 So far, you've seen props passed as static values, like in:
 

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -330,7 +330,7 @@ In fact, we can do exactly that - we can pass attributes to a slot outlet just l
 </div>
 ```
 
-Receiving the slot props is a bit different when using a single default slot vs. using named slots. We are going to show how to receive props using a single default slot first, by using `v-slot` directly on the child component tag:
+Receiving the slot props is a bit different when using a single default slot vs using named slots. We are going to show how to receive props using a single default slot first, by using `v-slot` directly on the child component tag:
 
 ```vue-html
 <MyComponent v-slot="slotProps">

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -138,7 +138,7 @@ With `<script setup>`, imported components are automatically made available to t
 
 </div>
 
-It's also possible to globally register a component, making it available to all components in a given app without having to import it. The pros and cons of global vs. local registration is discussed in the dedicated [Component Registration](/guide/components/registration.html) section.
+It's also possible to globally register a component, making it available to all components in a given app without having to import it. The pros and cons of global vs local registration is discussed in the dedicated [Component Registration](/guide/components/registration.html) section.
 
 Components can be reused as many times as you want:
 

--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -138,7 +138,7 @@ See also: [Typing Computed](/guide/typescript/composition-api.html#typing-comput
 
 </div>
 
-## Computed Caching vs. Methods {#computed-caching-vs-methods}
+## Computed Caching vs Methods {#computed-caching-vs-methods}
 
 You may have noticed we can achieve the same result by invoking a method in the expression:
 

--- a/src/guide/essentials/conditional.md
+++ b/src/guide/essentials/conditional.md
@@ -98,7 +98,7 @@ The difference is that an element with `v-show` will always be rendered and rema
 
 `v-show` doesn't support the `<template>` element, nor does it work with `v-else`.
 
-## `v-if` vs. `v-show` {#v-if-vs-v-show}
+## `v-if` vs `v-show` {#v-if-vs-v-show}
 
 `v-if` is "real" conditional rendering because it ensures that event listeners and child components inside the conditional block are properly destroyed and re-created during toggles.
 

--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -129,7 +129,7 @@ See also: [Typing Event Handlers](/guide/typescript/options-api.html#typing-even
 
 </div>
 
-### Method vs. Inline Detection {#method-vs-inline-detection}
+### Method vs Inline Detection {#method-vs-inline-detection}
 
 The template compiler detects method handlers by checking whether the `v-on` value string is a valid JavaScript identifier or property access path. For example, `foo`, `foo.bar` and `foo['bar']` are treated as method handlers, while `foo()` and `count++` are treated as inline handlers.
 

--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -41,7 +41,7 @@ It is possible to add a new property directly to `this` without including it in 
 
 Vue uses a `$` prefix when exposing its own built-in APIs via the component instance. It also reserves the prefix `_` for internal properties. You should avoid using names for top-level `data` properties that start with either of these characters.
 
-### Reactive Proxy vs. Original \* {#reactive-proxy-vs-original}
+### Reactive Proxy vs Original \* {#reactive-proxy-vs-original}
 
 In Vue 3, data is made reactive by leveraging [JavaScript Proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy). Users coming from Vue 2 should be aware of the following edge case:
 
@@ -302,7 +302,7 @@ It is also possible to explicitly create [shallow reactive objects](/api/reactiv
 
 <div class="composition-api">
 
-### Reactive Proxy vs. Original \*\* {#reactive-proxy-vs-original-1}
+### Reactive Proxy vs Original \*\* {#reactive-proxy-vs-original-1}
 
 It is important to note that the returned value from `reactive()` is a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) of the original object, which is not equal to the original object:
 

--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -301,7 +301,7 @@ For examples like these, with only one dependency, the benefit of `watchEffect()
 `watchEffect` only tracks dependencies during its **synchronous** execution. When using it with an async callback, only properties accessed before the first `await` tick will be tracked.
 :::
 
-### `watch` vs. `watchEffect` {#watch-vs-watcheffect}
+### `watch` vs `watchEffect` {#watch-vs-watcheffect}
 
 `watch` and `watchEffect` both allow us to reactively perform side effects. Their main difference is the way they track their reactive dependencies:
 

--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -206,7 +206,7 @@ The `ref()`, `computed()` and `watchEffect()` APIs are all part of the Compositi
 
 </div>
 
-## Runtime vs. Compile-time Reactivity {#runtime-vs-compile-time-reactivity}
+## Runtime vs Compile-time Reactivity {#runtime-vs-compile-time-reactivity}
 
 Vue's reactivity system is primarily runtime-based: the tracking and triggering are all performed while the code is running directly in the browser. The pros of runtime reactivity are that it can work without a build step, and there are fewer edge cases. On the other hand, this makes it constrained by the syntax limitations of JavaScript.
 

--- a/src/guide/extras/reactivity-transform.md
+++ b/src/guide/extras/reactivity-transform.md
@@ -8,9 +8,9 @@ Reactivity Transform is currently an experimental feature. It is disabled by def
 Reactivity Transform is a Composition-API-specific feature and requires a build step.
 :::
 
-## Refs vs. Reactive Variables {#refs-vs-reactive-variables}
+## Refs vs Reactive Variables {#refs-vs-reactive-variables}
 
-Ever since the introduction of the Composition API, one of the primary unresolved questions is the use of refs vs. reactive objects. It's easy to lose reactivity when destructuring reactive objects, while it can be cumbersome to use `.value` everywhere when using refs. Also, `.value` is easy to miss if not using a type system.
+Ever since the introduction of the Composition API, one of the primary unresolved questions is the use of refs vs reactive objects. It's easy to lose reactivity when destructuring reactive objects, while it can be cumbersome to use `.value` everywhere when using refs. Also, `.value` is easy to miss if not using a type system.
 
 [Vue Reactivity Transform](https://github.com/vuejs/core/tree/main/packages/reactivity-transform) is a compile-time transform that allows us to write code like this:
 

--- a/src/guide/extras/rendering-mechanism.md
+++ b/src/guide/extras/rendering-mechanism.md
@@ -48,7 +48,7 @@ At the high level, this is what happens when a Vue component is mounted:
 
 <!-- https://www.figma.com/file/elViLsnxGJ9lsQVsuhwqxM/Rendering-Mechanism -->
 
-## Templates vs. Render Functions {#templates-vs-render-functions}
+## Templates vs Render Functions {#templates-vs-render-functions}
 
 Vue templates are compiled into virtual DOM render functions. Vue also provides APIs that allow us to skip the template compilation step and directly author render functions. Render functions are more flexible than templates when dealing with highly dynamic logic, because you can work with vnodes using the full power of JavaScript.
 

--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -224,7 +224,7 @@ export function register() {
 
 If you have many components, you can also leverage build tool features such as Vite's [glob import](https://vitejs.dev/guide/features.html#glob-import) or webpack's [`require.context`](https://webpack.js.org/guides/dependency-management/#requirecontext) to load all components from a directory.
 
-## Web Components vs. Vue Components {#web-components-vs-vue-components}
+## Web Components vs Vue Components {#web-components-vs-vue-components}
 
 Some developers believe that framework-proprietary component models should be avoided, and that exclusively using Custom Elements makes an application "future-proof". Here we will try to explain why we believe that this is an overly simplistic take on the problem.
 

--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -331,7 +331,7 @@ export default {
 
 ## Comparisons with Other Techniques {#comparisons-with-other-techniques}
 
-### vs. Mixins {#vs-mixins}
+### vs Mixins {#vs-mixins}
 
 Users coming from Vue 2 may be familiar with the [mixins](/api/options-composition.html#mixins) option, which also allows us to extract component logic into reusable units. There are three primary drawbacks to mixins:
 
@@ -343,7 +343,7 @@ Users coming from Vue 2 may be familiar with the [mixins](/api/options-compositi
 
 For the above reasons, we no longer recommend using mixins in Vue 3. The feature is kept only for migration and familiarity reasons.
 
-### vs. Renderless Components {#vs-renderless-components}
+### vs Renderless Components {#vs-renderless-components}
 
 In the component slots chapter, we discussed the [Renderless Component](/guide/components/slots.html#renderless-components) pattern based on scoped slots. We even implemented the same mouse tracking demo using renderless components.
 
@@ -351,7 +351,7 @@ The main advantage of composables over renderless components is that composables
 
 The recommendation is to use composables when reusing pure logic, and use components when reusing both logic and visual layout.
 
-### vs. React Hooks {#vs-react-hooks}
+### vs React Hooks {#vs-react-hooks}
 
 If you have experience with React, you may notice that this looks very similar to custom React hooks. Composition API was in part inspired by React hooks, and Vue composables are indeed similar to React hooks in terms of logic composition capabilities. However, Vue composables are based on Vue's fine-grained reactivity system, which is fundamentally different from React hooks' execution model. This is discussed in more detail in the [Composition API FAQ](/guide/extras/composition-api-faq#comparison-with-react-hooks).
 

--- a/src/guide/scaling-up/routing.md
+++ b/src/guide/scaling-up/routing.md
@@ -1,6 +1,6 @@
 # Routing {#routing}
 
-## Client-Side vs. Server-Side Routing {#client-side-vs-server-side-routing}
+## Client-Side vs Server-Side Routing {#client-side-vs-server-side-routing}
 
 Routing on the server side means the server sending a response based on the URL path that the user is visiting. When we click on a link in a traditional server-rendered web app, the browser receives an HTML response from the server and reloads the entire page with the new HTML.
 

--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -36,7 +36,7 @@ There are also some trade-offs to consider when using SSR:
 
 Before using SSR for your app, the first question you should ask is whether you actually need it. It mostly depends on how important time-to-content is for your app. For example, if you are building an internal dashboard where an extra few hundred milliseconds on initial load doesn't matter that much, SSR would be an overkill. However, in cases where time-to-content is absolutely critical, SSR can help you achieve the best possible initial load performance.
 
-### SSR vs. SSG {#ssr-vs-ssg}
+### SSR vs SSG {#ssr-vs-ssg}
 
 **Static Site Generation (SSG)**, also referred to as pre-rendering, is another popular technique for building fast websites. If the data needed to server-render a page is the same for every user, then instead of rendering the page every time a request comes in, we can render it only once, ahead of time, during the build process. Pre-rendered pages are generated and served as static HTML files.
 


### PR DESCRIPTION
## Description of Problem

The documentation uses `vs.` instead of `vs` in many places, which seems like a low-level mistake?

![image](https://user-images.githubusercontent.com/24560368/217286852-ad904882-8ea0-4995-98d6-f68aa615f366.png)

## Proposed Solution

Replace all occurrences of `vs.` with `vs`

![image](https://user-images.githubusercontent.com/24560368/217287184-1ae360a5-31a8-41b0-a377-39d09953edde.png)

## Additional Information
