### PR TITLE
Fix broken link in docs

### DIFF
--- a/src/guide/typescript/options-api.md
+++ b/src/guide/typescript/options-api.md
@@ -230,7 +230,7 @@ declare module 'vue' {
 
 See also:
 
-- [TypeScript unit tests for component type extensions](https://github.com/vuejs/core/blob/main/test-dts/componentTypeExtensions.test-d.tsx)
+- [TypeScript unit tests for component type extensions](https://github.com/vuejs/core/blob/main/packages/dts-test/componentTypeExtensions.test-d.tsx)
 
 ### Type Augmentation Placement {#type-augmentation-placement}
 
@@ -290,4 +290,4 @@ The placement of this augmentation is subject the [same restrictions](#type-augm
 
 See also:
 
-- [TypeScript unit tests for component type extensions](https://github.com/vuejs/core/blob/main/test-dts/componentTypeExtensions.test-d.tsx)
+- [TypeScript unit tests for component type extensions](https://github.com/vuejs/core/blob/main/packages/dts-test/componentTypeExtensions.test-d.tsx)


### PR DESCRIPTION
Fixing https://github.com/vuejs/docs/issues/2206

## Description of Problem

Link was broken

## Proposed Solution

Changing link destination from
https://github.com/vuejs/core/blob/main/test-dts/componentTypeExtensions.test-d.tsx (404)
to https://github.com/vuejs/core/blob/main/packages/dts-test/componentTypeExtensions.test-d.tsx

## Additional Information
