### PR TITLE
Fix reference to `defineComponent` type tests

### DIFF
--- a/src/guide/typescript/overview.md
+++ b/src/guide/typescript/overview.md
@@ -130,7 +130,7 @@ export default defineComponent({
 See also:
 
 - [Note on webpack Treeshaking](/api/general.html#note-on-webpack-treeshaking)
-- [type tests for `defineComponent`](https://github.com/vuejs/core/blob/main/test-dts/defineComponent.test-d.tsx)
+- [type tests for `defineComponent`](https://github.com/vuejs/core/blob/main/packages/dts-test/defineComponent.test-d.tsx)
 
 :::tip
 `defineComponent()` also enables type inference for components defined in plain JavaScript.


### PR DESCRIPTION
## Description of Problem
Broken link

## Proposed Solution
Changed link from https://github.com/vuejs/core/blob/main/test-dts/defineComponent.test-d.tsx to https://github.com/vuejs/core/blob/main/packages/dts-test/defineComponent.test-d.tsx