### PR TITLE
docs: missing exclamation marks in examples

### DIFF
--- a/src/guide/essentials/class-and-style.md
+++ b/src/guide/essentials/class-and-style.md
@@ -209,7 +209,7 @@ Then add some classes when using it:
 The rendered HTML will be:
 
 ```vue-html
-<p class="foo bar baz boo">Hi</p>
+<p class="foo bar baz boo">Hi!</p>
 ```
 
 The same is true for class bindings:
@@ -221,7 +221,7 @@ The same is true for class bindings:
 When `isActive` is truthy, the rendered HTML will be:
 
 ```vue-html
-<p class="foo bar active">Hi</p>
+<p class="foo bar active">Hi!</p>
 ```
 
 If your component has multiple root elements, you would need to define which element will receive this class. You can do this using the `$attrs` component property:


### PR DESCRIPTION
## Description of Problem
Some code examples on [Class and Style Bindings](https://vuejs.org/guide/essentials/class-and-style.html#class-and-style-bindings) page use text `Hi!`, while others only `Hi`. Not a big deal, but since they are meant to render the same output, it should be corrected.

## Proposed Solution
Added missing ones (2 of 5 occurences)

## Additional Information
