### PR TITLE
Explain how extends works with composition API

### DIFF
--- a/src/api/options-composition.md
+++ b/src/api/options-composition.md
@@ -232,6 +232,8 @@ A "base class" component to extend from.
   However, `extends` and `mixins` express different intents. The `mixins` option is primarily used to compose chunks of functionality, whereas `extends` is primarily concerned with inheritance.
 
   As with `mixins`, any options will be merged using the relevant merge strategy.
+  
+  **Note:** The `setup` option will not be extended when using `extends`. If you need to extending a compontent build with the composition API you would need to manually merge the setup method: `const Component = {extends: SomeComponent, setup: SomeComponent.setup}`
 
 - **Example:**
 
@@ -243,3 +245,4 @@ A "base class" component to extend from.
     ...
   }
   ```
+  

--- a/src/api/options-composition.md
+++ b/src/api/options-composition.md
@@ -233,7 +233,7 @@ A "base class" component to extend from.
 
   As with `mixins`, any options will be merged using the relevant merge strategy.
   
-  **Note:** The `setup` option will not be extended when using `extends`. If you need to extending a compontent build with the composition API you would need to manually merge the setup method: `const Component = {extends: SomeComponent, setup: SomeComponent.setup}`
+  **Note:** The `setup` option will not be extended when using `extends` so extending a component built with the composition API may have unexpected functionality. In such cases you would need to manually merge the setup method into your component: `const MyComponent = {extends: CompComponent, setup: ComeComponent.setup}`
 
 - **Example:**
 


### PR DESCRIPTION
It is possible to extend any component, whether or not it is a component that was built with options API. We should mention how the option works with the setup option and/or a composition component.

## Description of Problem

No explanation of how extends works with composition API, although components themselves are not obviously 'composition' or 'options' components when importing them. Using `extends` on a component will have unexpected effect if that component is built with a setup option.

## Proposed Solution

Add explanation


