### PR TITLE
Remove custom-renderer.md from extra topics section (#2238)

### DIFF
--- a/src/guide/extras/custom-renderer.md
+++ b/src/guide/extras/custom-renderer.md
@@ -1,1 +1,0 @@
-# Custom Renderers {#custom-renderers}


### PR DESCRIPTION
## Description of Problem

The page custom renderers is empty.

Link: https://vuejs.org/guide/extras/custom-renderer.html

## Proposed Solution
The file `src/guide/extras/custom-renderer.md` should be deleted.