### PR TITLE
re-arrange VueSchoolLink like on other pages

### DIFF
--- a/src/guide/components/registration.md
+++ b/src/guide/components/registration.md
@@ -1,8 +1,8 @@
 # Component Registration {#component-registration}
 
-<VueSchoolLink href="https://vueschool.io/lessons/vue-3-global-vs-local-vue-components" title="Free Vue.js Component Registration Lesson"/>
-
 > This page assumes you've already read the [Components Basics](/guide/essentials/component-basics). Read that first if you are new to components.
+
+<VueSchoolLink href="https://vueschool.io/lessons/vue-3-global-vs-local-vue-components" title="Free Vue.js Component Registration Lesson"/>
 
 A Vue component needs to be "registered" so that Vue knows where to locate its implementation when it is encountered in a template. There are two ways to register components: global and local.
 


### PR DESCRIPTION
## Description of Problem

Other pages in `Guide/Components In-Depth` (props, events and slots) have first the assumption about user knows the basics and then the VueSchoolLink (if it is provided). `Component Registration` is the only one where first comes the link and the assumption after.

## Proposed Solution

Unless it was deliberate for some reason unclear to me, I suggest to re-arrange it to follow the same pattern on all pages.

## Additional Information
