### PR TITLE
Deprecated warning on Reactivity Transform usage

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -578,6 +578,7 @@ export default {
 
 ## Reactivity Transform <sup class="vt-badge experimental" /> \*\* {#reactivity-transform}
 
+:::danger Deprecated Experimental Feature
 Having to use `.value` with refs is a drawback imposed by the language constraints of JavaScript. However, with compile-time transforms we can improve the ergonomics by automatically appending `.value` in appropriate locations. Vue provides a compile-time transform that allows us to write the earlier "counter" example like this:
 
 ```vue
@@ -595,6 +596,7 @@ function increment() {
 </template>
 ```
 
-You can learn more about [Reactivity Transform](/guide/extras/reactivity-transform.html) in its dedicated section. Do note that it is currently still experimental and may change before being finalized.
+You can learn more about [Reactivity Transform](/guide/extras/reactivity-transform.html) in its dedicated section. However, [it was decided](https://github.com/vuejs/rfcs/discussions/369#discussioncomment-5059028) to be removed from Vue.js core soon.
+:::
 
 </div>

--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -97,6 +97,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 This will be compiled to equivalent runtime props `default` options. In addition, the `withDefaults` helper provides type checks for the default values, and ensures the returned `props` type has the optional flags removed for properties that do have default values declared.
 
+:::danger Deprecated Experimental Feature
 Alternatively, you can use the currently experimental [Reactivity Transform](/guide/extras/reactivity-transform.html):
 
 ```vue
@@ -112,7 +113,8 @@ const { name, count = 100 } = defineProps<Props>()
 </script>
 ```
 
-This behavior currently requires [explicit opt-in](/guide/extras/reactivity-transform.html#explicit-opt-in).
+This behavior currently requires [explicit opt-in](/guide/extras/reactivity-transform.html#explicit-opt-in) and will be removed from Vue.js core soon.
+:::
 
 ### Without `<script setup>` {#without-script-setup}
 


### PR DESCRIPTION
## Description of Problem

Adressing #2248 I wrapped remaining examples of Reactivity Transform into ```:::danger``` block. Not sure if this is the best approach, but it is a simple change and quite expressive outcome.

## Proposed Solution

## Additional Information

This is how it would look:

Reactivity Fundamentals:
![image](https://user-images.githubusercontent.com/7399922/221349295-22d3d444-6aef-46d7-901b-114419afecc1.png)

TypeScript with Composition API:
![image](https://user-images.githubusercontent.com/7399922/221349313-a58c4910-cf6c-4727-8e11-ee22211bf5b0.png)
