### PR TITLE
remove unused link for Custom Renderers (#2242)

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -322,7 +322,6 @@ export const sidebar: ThemeConfig['sidebar'] = {
         //   text: 'Building a Library for Vue',
         //   link: '/guide/extras/building-a-library'
         // },
-        // { text: 'Custom Renderers', link: '/guide/extras/custom-renderer' },
         // {
         //   text: 'Vue for React Devs',
         //   link: '/guide/extras/vue-for-react-devs'


### PR DESCRIPTION
## Description of Problem
The Custom Renderers page has been moved to the API section. The link to the Extra Topics section is now useless. 
I don't know about the other two link : `Building a Library for Vue` and `Vue for React Devs`.

## Proposed Solution
Remove the link in `config.ts`.