### PR TITLE
Missing import for mounted

### DIFF
--- a/src/api/composition-api-setup.md
+++ b/src/api/composition-api-setup.md
@@ -15,7 +15,7 @@ We can declare reactive state using [Reactivity APIs](./reactivity-core.html) an
 
 ```vue
 <script>
-import { ref } from 'vue'
+import { ref, mounted } from 'vue'
 
 export default {
   setup() {


### PR DESCRIPTION
## Description of Problem
In the first coding example, it supposes to import mounted and then use it in the setup

## Proposed Solution
Simply import it from vue 
