### PR TITLE
Change <p> tag to <h2> tag to remove ambiguity

### DIFF
--- a/src/tutorial/src/step-9/App/template.html
+++ b/src/tutorial/src/step-9/App/template.html
@@ -1,1 +1,1 @@
-<p ref="p">hello</p>
+<h2 ref="p">hello</h2>

--- a/src/tutorial/src/step-9/description.md
+++ b/src/tutorial/src/step-9/description.md
@@ -5,7 +5,7 @@ So far, Vue has been handling all the DOM updates for us, thanks to reactivity a
 We can request a **template ref** - i.e. a reference to an element in the template - using the <a target="_blank" href="/api/built-in-special-attributes.html#ref">special `ref` attribute</a>:
 
 ```vue-html
-<p ref="p">hello</p>
+<h2 ref="p">hello</h2>
 ```
 
 <div class="composition-api">
@@ -97,4 +97,4 @@ createApp({
 
 This is called a **lifecycle hook** - it allows us to register a callback to be called at certain times of the component's lifecycle. There are other hooks such as <span class="options-api">`created` and `updated`</span><span class="composition-api">`onUpdated` and `onUnmounted`</span>. Check out the <a target="_blank" href="/guide/essentials/lifecycle.html#lifecycle-diagram">Lifecycle Diagram</a> for more details.
 
-Now, try to add <span class="options-api">a `mounted`</span><span class="composition-api">an `onMounted`</span> hook, access the `<p>` via <span class="options-api">`this.$refs.p`</span><span class="composition-api">`p.value`</span>, and perform some direct DOM operations on it (e.g. changing its `textContent`).
+Now, try to add <span class="options-api">a `mounted`</span><span class="composition-api">an `onMounted`</span> hook, access the `<h2>` via <span class="options-api">`this.$refs.p`</span><span class="composition-api">`p.value`</span>, and perform some direct DOM operations on it (e.g. changing its `textContent`).


### PR DESCRIPTION
## Description of Problem

A `<p>` tag is used in the tutorial and the name of the `ref()` in this tutorial is also "p". Using a tag and a variable with the same name can be little confusing. 

I thought of changing the variable name from "p" to "q", for example, but that would involve making changes to more files in this tutorial.

## Proposed Solution

Change `<p>` tag to `<h2>` tag to remove ambiguity
