### PR TITLE
Add script to show the Free Weekend banner from Vue School

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -594,6 +594,13 @@ export default defineConfigWithTheme<ThemeConfig>({
         'data-spa': 'auto',
         defer: ''
       }
+    ],
+    [
+      'script',
+      {
+        src: 'https://vueschool.io/banner.js?affiliate=vuejs&type=top',
+        async: true
+      }
     ]
   ],
 


### PR DESCRIPTION
This PR adds a banner fixed top banner to vuejs.org, to inform users about Vue School’s upcoming _free weekend_.

The banner opens Vue School's free weekend landing page in a new tab. The banner will not reappear if a user has closed it (a key is stored in localStorage).

This implementation uses an external script to render the banner. This file is hosted on the Vue School server. If you prefer to host the file on own your server, use this PR instead: https://github.com/vuejs/docs/pull/2275

For more info about how the script works, please check the documentation here: https://vueschool.io/affiliates/banner

[Click here to see screenshots of the banner](https://imgur.com/a/mO0TpsZ)

