### PR TITLE
Replace the variable `p` with `pElementRef`

### DIFF
--- a/src/tutorial/src/step-9/App/composition.js
+++ b/src/tutorial/src/step-9/App/composition.js
@@ -2,10 +2,10 @@ import { ref } from 'vue'
 
 export default {
   setup() {
-    const p = ref(null)
+    const pElementRef = ref(null)
 
     return {
-      p
+      pElementRef
     }
   }
 }

--- a/src/tutorial/src/step-9/App/template.html
+++ b/src/tutorial/src/step-9/App/template.html
@@ -1,1 +1,1 @@
-<p ref="p">hello</p>
+<p ref="pElementRef">hello</p>

--- a/src/tutorial/src/step-9/_hint/App/composition.js
+++ b/src/tutorial/src/step-9/_hint/App/composition.js
@@ -2,14 +2,14 @@ import { ref, onMounted } from 'vue'
 
 export default {
   setup() {
-    const p = ref(null)
+    const pElementRef = ref(null)
 
     onMounted(() => {
-      p.value.textContent = 'mounted!'
+      pElementRef.value.textContent = 'mounted!'
     })
 
     return {
-      p
+      pElementRef
     }
   }
 }

--- a/src/tutorial/src/step-9/_hint/App/options.js
+++ b/src/tutorial/src/step-9/_hint/App/options.js
@@ -1,5 +1,5 @@
 export default {
   mounted() {
-    this.$refs.p.textContent = 'mounted!'
+    this.$refs.pElementRef.textContent = 'mounted!'
   }
 }

--- a/src/tutorial/src/step-9/description.md
+++ b/src/tutorial/src/step-9/description.md
@@ -5,7 +5,7 @@ So far, Vue has been handling all the DOM updates for us, thanks to reactivity a
 We can request a **template ref** - i.e. a reference to an element in the template - using the <a target="_blank" href="/api/built-in-special-attributes.html#ref">special `ref` attribute</a>:
 
 ```vue-html
-<p ref="p">hello</p>
+<p ref="pElementRef">hello</p>
 ```
 
 <div class="composition-api">
@@ -15,7 +15,7 @@ To access the ref, we need to declare<span class="html"> and expose</span> a ref
 <div class="sfc">
 
 ```js
-const p = ref(null)
+const pElementRef = ref(null)
 ```
 
 </div>
@@ -23,10 +23,10 @@ const p = ref(null)
 
 ```js
 setup() {
-  const p = ref(null)
+  const pElementRef = ref(null)
 
   return {
-    p
+    pElementRef
   }
 }
 ```
@@ -67,7 +67,7 @@ createApp({
 
 <div class="options-api">
 
-The element will be exposed on `this.$refs` as `this.$refs.p`. However, you can only access it after the component is **mounted**.
+The element will be exposed on `this.$refs` as `this.$refs.pElementRef`. However, you can only access it after the component is **mounted**.
 
 To run code after mount, we can use the `mounted` option:
 
@@ -97,4 +97,4 @@ createApp({
 
 This is called a **lifecycle hook** - it allows us to register a callback to be called at certain times of the component's lifecycle. There are other hooks such as <span class="options-api">`created` and `updated`</span><span class="composition-api">`onUpdated` and `onUnmounted`</span>. Check out the <a target="_blank" href="/guide/essentials/lifecycle.html#lifecycle-diagram">Lifecycle Diagram</a> for more details.
 
-Now, try to add <span class="options-api">a `mounted`</span><span class="composition-api">an `onMounted`</span> hook, access the `<p>` via <span class="options-api">`this.$refs.p`</span><span class="composition-api">`p.value`</span>, and perform some direct DOM operations on it (e.g. changing its `textContent`).
+Now, try to add <span class="options-api">a `mounted`</span><span class="composition-api">an `onMounted`</span> hook, access the `<p>` via <span class="options-api">`this.$refs.pElementRef`</span><span class="composition-api">`pElementRef.value`</span>, and perform some direct DOM operations on it (e.g. changing its `textContent`).


### PR DESCRIPTION
## Description of Problem

The use of `p` as the variable name of a `<p>` element was a little confusing.

See https://github.com/vuejs/docs/pull/2270 for a justification for renaming this variable to remove ambiguity

## Proposed Solution

This PR proposes `pElementRef` as the variable name and then this style can be used in other parts of the documentation, for example: [Template Refs](https://vuejs.org/guide/essentials/template-refs.html) for `<input>`, we could use `inputElementRef`
