### PR TITLE
fix(expose): change 'to the parent' to 'to the access component'

### DIFF
--- a/src/api/options-state.md
+++ b/src/api/options-state.md
@@ -439,7 +439,7 @@ Declare the custom events emitted by the component.
 
 ## expose {#expose}
 
-Declare exposed public properties when the component instance is accessed by a parent via template refs.
+Declare exposed public properties when the component instance is accessed by the other component via template refs.
 
 - **Type**
 

--- a/src/api/options-state.md
+++ b/src/api/options-state.md
@@ -451,7 +451,7 @@ Declare exposed public properties when the component instance is accessed by a p
 
 - **Details**
 
-  By default, a component instance exposes all instance properties to the parent when accessed via `$parent`, `$root`, or template refs. This can be undesirable, since a component most likely has internal state or methods that should be kept private to avoid tight coupling.
+  By default, a component instance exposes all instance properties to the access component when accessed via `$parent`, `$root`, or template refs. This can be undesirable, since a component most likely has internal state or methods that should be kept private to avoid tight coupling.
 
   The `expose` option expects a list of property name strings. When `expose` is used, only the properties explicitly listed will be exposed on the component's public instance.
 


### PR DESCRIPTION
## Description of Problem

![image](https://user-images.githubusercontent.com/12869626/224648612-00ae4a48-5557-40bc-82ca-e95f44bb3aaf.png)

"To the parent" parent component description is not accurate

a component instance exposes all instance properties to the child when accessed via $parent, $root.

