### PR TITLE
Add shorthand usages with object for `v-bind` and `v-on`

### DIFF
--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -313,7 +313,7 @@ Dynamically bind one or more attributes, or a component prop to an expression.
   <div v-bind="{ id: someProp, 'other-attr': otherProp }"></div>
 
   <!-- shorthand binding an object of attributes -->
-  <div v-bind="{ id: someProp, 'other-attr': otherProp }"></div>
+  <div :="{ id: someProp, 'other-attr': otherProp }"></div>
 
   <!-- prop binding. "prop" must be declared in the child component. -->
   <MyComponent :prop="someThing" />

--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -238,6 +238,9 @@ Attach an event listener to the element.
 
   <!-- object syntax -->
   <button v-on="{ mousedown: doThis, mouseup: doThat }"></button>
+
+  <!-- shorthand object syntax -->
+  <button @="{ mousedown: doThis, mouseup: doThat }"></button>
   ```
 
   Listening to custom events on a child component (the handler is called when "my-event" is emitted on the child):
@@ -307,6 +310,9 @@ Dynamically bind one or more attributes, or a component prop to an expression.
   <div :style="[styleObjectA, styleObjectB]"></div>
 
   <!-- binding an object of attributes -->
+  <div v-bind="{ id: someProp, 'other-attr': otherProp }"></div>
+
+  <!-- shorthand binding an object of attributes -->
   <div v-bind="{ id: someProp, 'other-attr': otherProp }"></div>
 
   <!-- prop binding. "prop" must be declared in the child component. -->


### PR DESCRIPTION
## Description of Problem

Examples of of `v-bind` and `v-on` have no shorthand object usage.

## Proposed Solution

Add usage to the example.

## Additional Information

I don't sure if this is a valid usage. But I think it also need to explain similarly if this isn't valid usage.

If it's valid usage I think it should be added to example.

Another dispute is about `v-slot` shorthand. Is the following usage valid?

```html
<MyComp>
  <template #="params">
    {{ params }}
  </template>
</MyComp>
```
