### PR TITLE
fix: wrong stable version

### DIFF
--- a/src/about/releases.md
+++ b/src/about/releases.md
@@ -8,8 +8,8 @@ import { ref, onMounted } from 'vue'
 const version = ref()
 
 onMounted(async () => {
-  const res = await fetch('https://api.github.com/repos/vuejs/core/releases?per_page=1')
-  version.value = (await res.json())[0].name
+  const res = await fetch('https://api.github.com/repos/vuejs/core/releases/latest')
+  version.value = (await res.json()).name
 })
 </script>
 


### PR DESCRIPTION
## Description of Problem

![image](https://user-images.githubusercontent.com/16233697/227832614-e217c374-7c3f-492e-ab36-7b7afde4507b.png)

Previous code was pointing to the last release on github including prerelease, so was showing v3.3.0-alpha.5 for instance

## Proposed Solution

The `/latest` endpoint should point to the correct version.

> The latest release is the most recent non-prerelease, non-draft release, sorted by the created_at attribute. The created_at attribute is the date of the commit used for the release, and not the date when the release was drafted or published.

[Docs](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release)

## Additional Information
