### PR TITLE
Changed recommendation for testing library

### DIFF
--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -40,7 +40,7 @@ Take for example this `increment` function:
 
 ```js
 // helpers.js
-export function increment(current, max = 10) {
+export function increment (current, max = 10) {
   if (current < max) {
     return current + 1
   }
@@ -186,13 +186,9 @@ mount(Stepper, {
   }
 })
 
-cy.get(valueSelector)
-  .should('be.visible')
-  .and('contain.text', '0')
-  .get(buttonSelector)
-  .click()
-  .get(valueSelector)
-  .should('contain.text', '1')
+cy.get(valueSelector).should('be.visible').and('contain.text', '0')
+  .get(buttonSelector).click()
+  .get(valueSelector).should('contain.text', '1')
 ```
 
 </div>
@@ -223,9 +219,9 @@ Component testing often involves mounting the component being tested in isolatio
 
 - [`@vue/test-utils`](https://github.com/vuejs/test-utils) is the official low-level component testing library that was written to provide users access to Vue specific APIs. It's also the lower-level library `@testing-library/vue` is built on top of.
 
-- [`@testing-library/vue`](https://github.com/testing-library/vue-testing-library) is a Vue testing library focused on testing components without relying on implementation details. Built with accessibility in mind, its approach also makes refactoring a breeze. Its guiding principle is that the more tests resemble the way software is used, the more confidence they can provide.
+- [`@testing-library/vue`](https://github.com/testing-library/vue-testing-library) is a Vue testing library focused on testing components without relying on implementation details. Its guiding principle is that the more tests resemble the way software is used, the more confidence they can provide.
 
-We recommend using `@vue/test-utils` for testing components in applications, as its focus aligns better with the testing priorities of applications. `@testing-library/vue` has issues with testing asynchronous component with Suspense, so it should be used with caution.
+We recommend using `@vue/test-utils` for testing components in applications. `@testing-library/vue` has issues with testing asynchronous component with Suspense, so it should be used with caution.
 
 ### Other Options {#other-options-1}
 

--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -40,7 +40,7 @@ Take for example this `increment` function:
 
 ```js
 // helpers.js
-export function increment (current, max = 10) {
+export function increment(current, max = 10) {
   if (current < max) {
     return current + 1
   }
@@ -130,29 +130,6 @@ Component tests should focus on the component's public interfaces rather than in
 
 <TestingApiSwitcher>
 
-<div class="testing-library-api">
-
-```js
-const { getByText } = render(Stepper, {
-  props: {
-    max: 1
-  }
-})
-
-getByText('0') // Implicit assertion that "0" is within the component
-
-const button = getByText('increment')
-
-// Dispatch a click event to our increment button.
-await fireEvent.click(button)
-
-getByText('1')
-
-await fireEvent.click(button)
-```
-
-</div>
-
 <div class="vtu-api">
 
 ```js
@@ -186,9 +163,13 @@ mount(Stepper, {
   }
 })
 
-cy.get(valueSelector).should('be.visible').and('contain.text', '0')
-  .get(buttonSelector).click()
-  .get(valueSelector).should('contain.text', '1')
+cy.get(valueSelector)
+  .should('be.visible')
+  .and('contain.text', '0')
+  .get(buttonSelector)
+  .click()
+  .get(valueSelector)
+  .should('contain.text', '1')
 ```
 
 </div>
@@ -207,21 +188,21 @@ cy.get(valueSelector).should('be.visible').and('contain.text', '0')
 
 ### Recommendation {#recommendation-1}
 
-- [Vitest](https://vitest.dev/) for components or composables that render headlessly (e.g. the [`useFavicon`](https://vueuse.org/core/useFavicon/#usefavicon) function in VueUse). Components and DOM can be tested using [@testing-library/vue](https://testing-library.com/docs/vue-testing-library/intro).
+- [Vitest](https://vitest.dev/) for components or composables that render headlessly (e.g. the [`useFavicon`](https://vueuse.org/core/useFavicon/#usefavicon) function in VueUse). Components and DOM can be tested using [`@vue/test-utils`](https://github.com/vuejs/test-utils).
 
 - [Cypress Component Testing](https://on.cypress.io/component) for components whose expected behavior depends on properly rendering styles or triggering native DOM events. Can be used with Testing Library via [@testing-library/cypress](https://testing-library.com/docs/cypress-testing-library/intro).
 
-The main differences between Vitest and browser-based runners are speed and execution context. In short, browser-based runners, like Cypress, can catch issues that node-based runners, like Vitest, cannot (e.g. style issues, real native DOM events, cookies, local storage, and network failures), but browser-based runners are *orders of magnitude slower than Vitest* because they do open a browser, compile your stylesheets, and more. Cypress is a browser-based runner that supports component testing. Please read [Vitest's comparison page](https://vitest.dev/guide/comparisons.html#cypress) for the latest information comparing Vitest and Cypress.
+The main differences between Vitest and browser-based runners are speed and execution context. In short, browser-based runners, like Cypress, can catch issues that node-based runners, like Vitest, cannot (e.g. style issues, real native DOM events, cookies, local storage, and network failures), but browser-based runners are _orders of magnitude slower than Vitest_ because they do open a browser, compile your stylesheets, and more. Cypress is a browser-based runner that supports component testing. Please read [Vitest's comparison page](https://vitest.dev/guide/comparisons.html#cypress) for the latest information comparing Vitest and Cypress.
 
 ### Mounting Libraries {#mounting-libraries}
 
 Component testing often involves mounting the component being tested in isolation, triggering simulated user input events, and asserting on the rendered DOM output. There are dedicated utility libraries that make these tasks simpler.
 
-- [`@testing-library/vue`](https://github.com/testing-library/vue-testing-library) is a Vue testing library focused on testing components without relying on implementation details. Built with accessibility in mind, its approach also makes refactoring a breeze. Its guiding principle is that the more tests resemble the way software is used, the more confidence they can provide.
-
 - [`@vue/test-utils`](https://github.com/vuejs/test-utils) is the official low-level component testing library that was written to provide users access to Vue specific APIs. It's also the lower-level library `@testing-library/vue` is built on top of.
 
-We recommend using `@testing-library/vue` for testing components in applications, as its focus aligns better with the testing priorities of applications. Use `@vue/test-utils` only if you are building advanced components that require testing Vue-specific internals.
+- [`@testing-library/vue`](https://github.com/testing-library/vue-testing-library) is a Vue testing library focused on testing components without relying on implementation details. Built with accessibility in mind, its approach also makes refactoring a breeze. Its guiding principle is that the more tests resemble the way software is used, the more confidence they can provide.
+
+We recommend using `@vue/test-utils` for testing components in applications, as its focus aligns better with the testing priorities of applications. `@testing-library/vue` has issues with testing asynchronous component with Suspense, so it should be used with caution.
 
 ### Other Options {#other-options-1}
 
@@ -310,11 +291,12 @@ If you are using TypeScript, add `vitest/globals` to the `types` field in your `
 // tsconfig.json
 
 {
- "compilerOptions": {
+  "compilerOptions": {
     "types": ["vitest/globals"]
   }
 }
 ```
+
 :::
 
 Then create a file ending in `*.test.js` in your project. You can place all test files in a test directory in project root, or in test directories next to your source files. Vitest will automatically search for them using the naming convention.
@@ -413,6 +395,7 @@ export function withSetup(composable) {
   return [result, app]
 }
 ```
+
 ```js
 import { withSetup } from './test-utils'
 import { useFoo } from './foo'

--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -130,6 +130,29 @@ Component tests should focus on the component's public interfaces rather than in
 
 <TestingApiSwitcher>
 
+<div class="testing-library-api">
+
+```js
+const { getByText } = render(Stepper, {
+  props: {
+    max: 1
+  }
+})
+
+getByText('0') // Implicit assertion that "0" is within the component
+
+const button = getByText('increment')
+
+// Dispatch a click event to our increment button.
+await fireEvent.click(button)
+
+getByText('1')
+
+await fireEvent.click(button)
+```
+
+</div>
+
 <div class="vtu-api">
 
 ```js


### PR DESCRIPTION
## Description of Problem

As described in https://github.com/vuejs/docs/issues/2295, vue-testing-library has issued with testing async components with Suspense. We cannot recommend it over Vue Test Utils that deal with Suspense fine

## Proposed Solution

Recommend VTU over testing library

## Additional Information

Close https://github.com/vuejs/docs/issues/2295
