### PR TITLE
feat: forms.md added docs references in tip note

### DIFF
--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -44,7 +44,7 @@ In addition, `v-model` can be used on inputs of different types, `<textarea>`, a
 - `<select>` use `value` as a prop and `change` as an event.
 
 ::: tip Note
-`v-model` will ignore the initial `value`, `checked` or `selected` attributes found on any form elements. It will always treat the current bound JavaScript state as the source of truth. You should declare the initial value on the JavaScript side, using <span class="options-api">the `data` option</span><span class="composition-api">reactivity APIs</span>.
+`v-model` will ignore the initial `value`, `checked` or `selected` attributes found on any form elements. It will always treat the current bound JavaScript state as the source of truth. You should declare the initial value on the JavaScript side, using <span class="options-api">the [`data`](https://vuejs.org/api/options-state.html#data) option</span><span class="composition-api">[reactivity APIs](https://vuejs.org/api/reactivity-core.html#reactivity-api-core)</span>.
 :::
 
 ## Basic Usage {#basic-usage}

--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -44,7 +44,7 @@ In addition, `v-model` can be used on inputs of different types, `<textarea>`, a
 - `<select>` use `value` as a prop and `change` as an event.
 
 ::: tip Note
-`v-model` will ignore the initial `value`, `checked` or `selected` attributes found on any form elements. It will always treat the current bound JavaScript state as the source of truth. You should declare the initial value on the JavaScript side, using <span class="options-api">the [`data`](https://vuejs.org/api/options-state.html#data) option</span><span class="composition-api">[reactivity APIs](https://vuejs.org/api/reactivity-core.html#reactivity-api-core)</span>.
+`v-model` will ignore the initial `value`, `checked` or `selected` attributes found on any form elements. It will always treat the current bound JavaScript state as the source of truth. You should declare the initial value on the JavaScript side, using <span class="options-api">the [`data`](/api/options-state.html#data) option</span><span class="composition-api">[reactivity APIs](/api/reactivity-core.html#reactivity-api-core)</span>.
 :::
 
 ## Basic Usage {#basic-usage}


### PR DESCRIPTION
## Description of Problem

Highlighted references for both Options/Composition api styles missing links to corresponding docs sections in tip note

## Proposed Solution

Added links:
- https://vuejs.org/api/options-state.html#data
- https://vuejs.org/api/reactivity-core.html#reactivity-api-core

## Additional Information

![Options](https://i.imgur.com/aFS9Ety.png)
![Options-fix](https://i.imgur.com/pHFRufN.png)


![Composition](https://i.imgur.com/8R9UCC1.png)
![Composition-fix](https://i.imgur.com/YI4aKly.png)
