### PR TITLE
Updated Community Guide Link - Line 77

### DIFF
--- a/src/about/faq.md
+++ b/src/about/faq.md
@@ -74,7 +74,7 @@ Yes. Despite a common misconception that Vue is only suitable for simple use cas
 
 ## How do I contribute to Vue? {#how-do-i-contribute-to-vue}
 
-We appreciate your interest! Please check out our [Community Guide](/about/community-guide).
+We appreciate your interest! Please check out our [Community Guide](https://vuejs.org/about/community-guide.html#what-you-can-do).
 
 ## Should I use Options API or Composition API? {#should-i-use-options-api-or-composition-api}
 


### PR DESCRIPTION
Previously it didn't go anywhere, I updated the link to go straight to the vuejs.org Community Guide, "What Can You Do" section!

## Description of Problem
Link doesn't take you anywhere, send you to an error Github Page

## Proposed Solution
Added the link to the correct area, on the official vuejs.org website, Community Guide, section "What Can You Do"

## Additional Information
Line 77