### PR TITLE
fix: #2137 Prefixing urls with "https://" for sponsors.

### DIFF
--- a/.vitepress/theme/components/SponsorsGroup.vue
+++ b/.vitepress/theme/components/SponsorsGroup.vue
@@ -57,7 +57,7 @@ function track(interest?: boolean) {
       <a
         v-for="{ url, img, name } of data[tier]"
         class="sponsor-item"
-        :href="url"
+        :href="url.startsWith('https') ? url : `https://${url}`"
         target="_blank"
         rel="sponsored noopener"
         @click="track()"

--- a/.vitepress/theme/components/SponsorsGroup.vue
+++ b/.vitepress/theme/components/SponsorsGroup.vue
@@ -57,7 +57,7 @@ function track(interest?: boolean) {
       <a
         v-for="{ url, img, name } of data[tier]"
         class="sponsor-item"
-        :href="url.startsWith('https') ? url : `https://${url}`"
+        :href="/^https?:\/\//.test(url) ? url : `https://${url}`"
         target="_blank"
         rel="sponsored noopener"
         @click="track()"


### PR DESCRIPTION
## Description of Problem
Just as described in #2137 
The data coming from the endpoint for the Sentry sponsor doesn't have the proper URL.
![image](https://user-images.githubusercontent.com/601266/232929040-98b20e33-8e49-40f8-afd6-5860b0c206b6.png)

ie. it is missing the protocol part.
See the surrounding sponsor urls:
![image](https://user-images.githubusercontent.com/601266/232929135-b785d610-2787-43ef-9441-765772a7965c.png)

## Proposed Solution
Since we don't have access to update the data (that I am aware of). We can add a quick check and prefix the url with the protocol before rendering it. 

Quick and dirty, but it works 😅 

## Additional Information
Works on my ~machine~ Stackblitz instance!
![sentry fix](https://user-images.githubusercontent.com/601266/232929628-5de2ce49-a164-4349-9d6c-b5e7d98e730a.gif)

