### PR TITLE
Reword type assertions with events

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -299,7 +299,7 @@ function handleChange(event) {
 </template>
 ```
 
-Without type annotation, the `event` argument will implicitly have a type of `any`. This will also result in a TS error if `"strict": true` or `"noImplicitAny": true` are used in `tsconfig.json`. It is therefore recommended to explicitly annotate the argument of event handlers. In addition, you may need to explicitly cast properties on `event`:
+Without type annotation, the `event` argument will implicitly have a type of `any`. This will also result in a TS error if `"strict": true` or `"noImplicitAny": true` are used in `tsconfig.json`. It is therefore recommended to explicitly annotate the argument of event handlers. In addition, you may need to use type assertions when accessing the properties of `event`:
 
 ```ts
 function handleChange(event: Event) {

--- a/src/guide/typescript/options-api.md
+++ b/src/guide/typescript/options-api.md
@@ -199,7 +199,7 @@ export default defineComponent({
 </template>
 ```
 
-Without type annotation, the `event` argument will implicitly have a type of `any`. This will also result in a TS error if `"strict": true` or `"noImplicitAny": true` are used in `tsconfig.json`. It is therefore recommended to explicitly annotate the argument of event handlers. In addition, you may need to explicitly cast properties on `event`:
+Without type annotation, the `event` argument will implicitly have a type of `any`. This will also result in a TS error if `"strict": true` or `"noImplicitAny": true` are used in `tsconfig.json`. It is therefore recommended to explicitly annotate the argument of event handlers. In addition, you may need to use type assertions when accessing the properties of `event`:
 
 ```ts
 import { defineComponent } from 'vue'


### PR DESCRIPTION
This change is inspired by the suggestion in #2174.

The use of the word 'cast' does seem to match how it is commonly used in a TypeScript context. However, it does have a slightly different meaning in other languages, and the TS docs seem to stay clear of using that word.

However, the proposal in #2174 to change it to the word 'assert' seemed less natural to me, even if it could be seen as more technically correct.

Instead, I've tried rewording the whole sentence, aiming to make it sound more like something from the TS docs.

The same sentence appears in both pages about TS usage, so I've applied the same change to both.