### PR TITLE
Reword the section on in-DOM root templates

### DIFF
--- a/src/guide/essentials/application.md
+++ b/src/guide/essentials/application.md
@@ -59,7 +59,7 @@ The `.mount()` method should always be called after all app configurations and a
 
 ### In-DOM Root Component Template {#in-dom-root-component-template}
 
-When using Vue without a build step, we can write our root component's template directly inside the mount container:
+The template for the root component is usually part of the component itself, but it is also possible to provide the template separately by writing it directly inside the mount container:
 
 ```html
 <div id="app">
@@ -82,6 +82,8 @@ app.mount('#app')
 ```
 
 Vue will automatically use the container's `innerHTML` as the template if the root component does not already have a `template` option.
+
+In-DOM templates are often used in applications that are [using Vue without a build step](/guide/quick-start.html#using-vue-from-cdn). They can also be used in conjunction with server-side frameworks, where the root template might be generated dynamically by the server.
 
 ## App Configurations {#app-configurations}
 


### PR DESCRIPTION
This change was motivated by #1864.

The section on using an in-DOM template begins by introducing it as a feature used without a build step. That is one use case, but it is also commonly used with server-side frameworks that generate the template HTML dynamically.

While `import { createApp } from 'vue'` can be used 'without a build step', it does seem less natural in that context. This was the problem originally raised in #1864. The idea of using import maps is discussed earlier in the docs, but this specific example leans on that knowledge more heavily than the rest of the docs.

Instead, I've started by introducing the feature without explicit motivation, contrasting it with the more common approach. I've then mentioned the use cases at the end, including a link back to the section about using Vue without build tools.