### PR TITLE
docs: use semantically correct tag for date

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -151,9 +151,9 @@ Therefore, the following will **NOT** work:
 It is possible to call a component-exposed method inside a binding expression:
 
 ```vue-html
-<span :title="toTitleDate(date)">
+<time :title="toTitleDate(date)" :datetime="date">
   {{ formatDate(date) }}
-</span>
+</time>
 ```
 
 :::tip


### PR DESCRIPTION
## Description of Problem

It's more semantically correct to use `<time>` tag instead of `<span>` for dates.

## Proposed Solution

Let's use `<time>` tag.

## Additional Information
