### PR TITLE
docs: add copying versions of the sort and reverse methods

### DIFF
--- a/src/guide/essentials/list.md
+++ b/src/guide/essentials/list.md
@@ -432,3 +432,9 @@ Be careful with `reverse()` and `sort()` in a computed property! These two metho
 - return numbers.reverse()
 + return [...numbers].reverse()
 ```
+
+Or use copying versions of these methods `toReversed()` and `toSorted()`:
+```diff
+- return numbers.reverse()
++ return numbers.toReversed()
+```


### PR DESCRIPTION
## Description of Problem
Currently we're proposing to create a copy of array but modern browsers (except FireFox) are already support ES2023 new array methods that returns new array instead of mutating existing

## Proposed Solution
We can propose to the users to use new copying methods instead of creating array copy. 

## Additional Information
[Can I use](https://caniuse.com/mdn-javascript_builtins_array_tosorted)
