### PR TITLE
use onBeforeUnmount in useEventListener

### DIFF
--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -94,13 +94,13 @@ For example, we can extract the logic of adding and removing a DOM event listene
 
 ```js
 // event.js
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onBeforeUnmount } from 'vue'
 
 export function useEventListener(target, event, callback) {
   // if you want, you can also make this
   // support selector strings as target
   onMounted(() => target.addEventListener(event, callback))
-  onUnmounted(() => target.removeEventListener(event, callback))
+  onBeforeUnmount(() => target.removeEventListener(event, callback))
 }
 ```
 


### PR DESCRIPTION
use `onBeforeUnmount` in `useEventListener` instead of `onUnmounted` since `onUnmounted` will not work if you trying to pass some element ref from the consumer component. Using the  `onUnmounted` the ref will be null since the component is unmounted, so we should use `onBeforeUnmount`

## Description of Problem
using will throw an error:
```
Cannot read properties of null (reading 'removeEventListener')
```
 if you use Element ref

## Proposed Solution
Use `onBeforeUnmount`, no remove the listener just before destroying the component
