### PR TITLE
fix: non-case sensitive filtering

### DIFF
--- a/src/guide/built-ins/transition-demos/ListStagger.vue
+++ b/src/guide/built-ins/transition-demos/ListStagger.vue
@@ -13,7 +13,7 @@ const list = [
 const query = ref('')
 
 const computedList = computed(() => {
-  return list.filter((item) => item.msg.toLowerCase().includes(query.value))
+  return list.filter((item) => item.msg.toLowerCase().includes(query.value.toLowerCase()))
 })
 
 function onBeforeEnter(el) {


### PR DESCRIPTION
## Description of Problem
List staggering example only filters on lowercase inputs.

https://vuejs.org/guide/built-ins/transition-group.html#staggering-list-transitions

## Proposed Solution
Make the query value also toLowerCase.