### PR TITLE
Update project initialization steps in quick-start.md file

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -22,7 +22,7 @@ footer: false
 
 In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vitejs.dev) and allow us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).
 
-Make sure you have an up-to-date version of [Node.js](https://nodejs.org/) installed, then run the following command in your command line (without the `>` sign):
+Make sure you have an up-to-date version of [Node.js](https://nodejs.org/) installed, then run the following command in your command line with the project root folder as the current working directory (without the `>` sign):
 
 <div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">&gt;</span> <span style="color:#A6ACCD;">npm init vue@latest</span></span></code></pre></div>
 

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -22,7 +22,7 @@ footer: false
 
 In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vitejs.dev) and allow us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).
 
-Make sure you have an up-to-date version of [Node.js](https://nodejs.org/) installed, then run the following command in your command line with the project root folder as the current working directory (without the `>` sign):
+Make sure you have an up-to-date version of [Node.js](https://nodejs.org/) installed, then run the following command in your command line with the current working directory as the folder in which you intend to create the project (without the `>` sign):
 
 <div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">&gt;</span> <span style="color:#A6ACCD;">npm init vue@latest</span></span></code></pre></div>
 


### PR DESCRIPTION
## Description of Problem
Ambiguity in creating a new vue application.
In line number 25 of vuejs/docs/src/guide/quick-start.md, the directory in which the npm init command is to be run is not mentioned.
Front-end beginners might run the command in some directory and get confused.

## Proposed Solution
To resolve this ambiguity, I propose we mention that the command be run in the folder in which the developer intends to create the project. running the command will then scaffold i.e create the project folder in the set current working directory.

## Additional Information
little things like this make the documentation more beginner-friendly and encourage them
