### PR TITLE
Fix defineOptions secrtion according to vue 3.3

### DIFF
--- a/src/guide/components/attrs.md
+++ b/src/guide/components/attrs.md
@@ -82,15 +82,8 @@ If you do **not** want a component to automatically inherit attributes, you can 
 If using `<script setup>`, you will need to declare this option using a separate, normal `<script>` block:
 
 ```vue
-<script>
-// use normal <script> to declare options
-export default {
-  inheritAttrs: false
-}
-</script>
-
 <script setup>
-// ...setup logic
+defineOptions({ inheritAttrs: false })
 </script>
 ```
 


### PR DESCRIPTION
The new defineOptions macro allows declaring component options directly in <script setup>, without requiring a separate <script> block according to vue 3.3
