### PR TITLE
feat: update composition-api-faq.md

### DIFF
--- a/src/api/options-misc.md
+++ b/src/api/options-misc.md
@@ -102,6 +102,27 @@ Controls whether the default component attribute fallthrough behavior should be 
   </template>
   ```
 
+  Since 3.3 you can also use defineOptions directly in script setup, no longer need normal `<script>` block.
+
+  ```vue
+  <script setup>
+  defineProps(['label', 'value'])
+  defineEmits(['input'])
+  defineOptions({ inheritAttrs: false })
+  </script>
+
+  <template>
+    <label>
+      {{ label }}
+      <input
+        v-bind="$attrs"
+        v-bind:value="value"
+        v-on:input="$emit('input', $event.target.value)"
+      />
+    </label>
+  </template>
+  ```
+
   </div>
 
 - **See also:** [Fallthrough Attributes](/guide/components/attrs)

--- a/src/api/options-misc.md
+++ b/src/api/options-misc.md
@@ -102,7 +102,7 @@ Controls whether the default component attribute fallthrough behavior should be 
   </template>
   ```
 
-  Since 3.3 you can also use defineOptions directly in script setup, no longer need normal `<script>` block.
+  Since 3.3 you can also use `defineOptions` directly in `<script setup>`:
 
   ```vue
   <script setup>

--- a/src/guide/components/attrs.md
+++ b/src/guide/components/attrs.md
@@ -94,7 +94,7 @@ export default {
 </script>
 ```
 
-Since 3.3 you can also use defineOptions directly in script setup, no longer need normal `<script>` block.
+ Since 3.3 you can also use `defineOptions` directly in `<script setup>`:
 
 ```vue
 <script setup>

--- a/src/guide/components/attrs.md
+++ b/src/guide/components/attrs.md
@@ -94,6 +94,17 @@ export default {
 </script>
 ```
 
+Since 3.3 you can also use defineOptions directly in script setup, no longer need normal `<script>` block.
+
+```vue
+<script setup>
+defineOptions({
+  inheritAttrs: false
+})
+// ...setup logic
+</script>
+```
+
 </div>
 
 The common scenario for disabling attribute inheritance is when attributes need to be applied to other elements besides the root node. By setting the `inheritAttrs` option to `false`, you can take full control over where the fallthrough attributes should be applied.

--- a/src/guide/extras/composition-api-faq.md
+++ b/src/guide/extras/composition-api-faq.md
@@ -108,6 +108,12 @@ Options API does allow you to "think less" when writing component code, which is
 
 Yes in terms of stateful logic. When using Composition API, there are only a few options that may still be needed: `props`, `emits`, `name`, and `inheritAttrs`. If using `<script setup>`, then `inheritAttrs` is typically the only option that may require a separate normal `<script>` block.
 
+:::tip
+
+Since 3.3 you can directly use defineOptions in `<script setup>` to set name or inheritAttrs.
+
+:::
+
 If you intend to exclusively use Composition API (along with the options listed above), you can shave a few kbs off your production bundle via a [compile-time flag](https://github.com/vuejs/core/tree/main/packages/vue#bundler-build-feature-flags) that drops Options API related code from Vue. Note this also affects Vue components in your dependencies.
 
 ### Can I use both APIs together? {#can-i-use-both-apis-together}

--- a/src/guide/extras/composition-api-faq.md
+++ b/src/guide/extras/composition-api-faq.md
@@ -110,7 +110,7 @@ Yes in terms of stateful logic. When using Composition API, there are only a few
 
 :::tip
 
-Since 3.3 you can directly use defineOptions in `<script setup>` to set name or inheritAttrs.
+Since 3.3 you can directly use `defineOptions` in `<script setup>` to set the component name or `inheritAttrs` property
 
 :::
 


### PR DESCRIPTION
Reference #2369 added some content.

The new defineOptions macro allows declaring component options directly in <script setup>, without requiring a separate <script> block according to vue 3.3