### PR TITLE
Example for new defineEmit with types syntax.md

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -148,22 +148,21 @@ const emit = defineEmits<{
   (e: 'change', id: number): void
   (e: 'update', value: string): void
 }>()
-</script>
-```
 
-A cleaner way to define emits with types, introduced in Vue 3.3:
-```vue
-<script setup lang="ts">
-
+// 3.3+: alternative, more succinct syntax
 const emit = defineEmits<{
   change: [id: number]
   update: [value: string]
 }>()
-
 </script>
 ```
 
-The type argument should be a type literal with [Call Signatures](https://www.typescriptlang.org/docs/handbook/2/functions.html#call-signatures). The type literal will be used as the type of the returned `emit` function. As we can see, the type declaration gives us much finer-grained control over the type constraints of emitted events.
+The type argument can be one of the following:
+
+1. A callable function type, but written as a type literal with [Call Signatures](https://www.typescriptlang.org/docs/handbook/2/functions.html#call-signatures). It will be used as the type of the returned `emit` function.
+2. A type literal where the keys are the event names, and values are array / tuple types representing the additional accepted parameters for the event. The example above is using named tuples so each argument can have an explicit name.
+
+As we can see, the type declaration gives us much finer-grained control over the type constraints of emitted events.
 
 When not using `<script setup>`, `defineComponent()` is able to infer the allowed events for the `emit` function exposed on the setup context:
 

--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -151,6 +151,18 @@ const emit = defineEmits<{
 </script>
 ```
 
+A cleaner way to define emits with types, introduced in Vue 3.3:
+```vue
+<script setup lang="ts">
+
+const emit = defineEmits<{
+  change: [id: number]
+  update: [value: string]
+}>()
+
+</script>
+```
+
 The type argument should be a type literal with [Call Signatures](https://www.typescriptlang.org/docs/handbook/2/functions.html#call-signatures). The type literal will be used as the type of the returned `emit` function. As we can see, the type declaration gives us much finer-grained control over the type constraints of emitted events.
 
 When not using `<script setup>`, `defineComponent()` is able to infer the allowed events for the `emit` function exposed on the setup context:


### PR DESCRIPTION
Added an example showcasing the new way to define emits with types, that was introduced in Vue 3.3

## Description of Problem
Vue 3.3 introduced a new way to define emits with types, this was not documented in the docs.

## Proposed Solution
Added an example for it in the docs.

## Additional Information
