### PR TITLE
docs: update docs to use defineOptions over requesting a second scrip…

### DIFF
--- a/src/api/options-misc.md
+++ b/src/api/options-misc.md
@@ -76,18 +76,15 @@ Controls whether the default component attribute fallthrough behavior should be 
   </div>
   <div class="composition-api">
 
-  When declaring this option in a component that uses `<script setup>`, a separate `<script>` block is necessary:
+  When declaring this option in a component that uses `<script setup>`, you can use the `defineOptions` macro:
 
   ```vue
-  <script>
-  export default {
-    inheritAttrs: false
-  }
-  </script>
-
   <script setup>
   defineProps(['label', 'value'])
   defineEmits(['input'])
+  defineOptions({
+    inheritAttrs: false,
+  })
   </script>
 
   <template>

--- a/src/api/options-misc.md
+++ b/src/api/options-misc.md
@@ -76,14 +76,14 @@ Controls whether the default component attribute fallthrough behavior should be 
   </div>
   <div class="composition-api">
 
-  When declaring this option in a component that uses `<script setup>`, you can use the `defineOptions` macro:
+  When declaring this option in a component that uses `<script setup>`, you can use the [`defineOptions`](/api/sfc-script-setup#defineoptions) macro:
 
   ```vue
   <script setup>
   defineProps(['label', 'value'])
   defineEmits(['input'])
   defineOptions({
-    inheritAttrs: false,
+    inheritAttrs: false
   })
   </script>
 

--- a/src/guide/components/attrs.md
+++ b/src/guide/components/attrs.md
@@ -79,18 +79,13 @@ If you do **not** want a component to automatically inherit attributes, you can 
 
 <div class="composition-api">
 
-If using `<script setup>`, you will need to declare this option using a separate, normal `<script>` block:
+If using `<script setup>`, you can use the `defineOptions` macro:
 
 ```vue
-<script>
-// use normal <script> to declare options
-export default {
-  inheritAttrs: false
-}
-</script>
-
 <script setup>
-// ...setup logic
+defineOptions({
+  inheritAttrs: false,
+})
 </script>
 ```
 

--- a/src/guide/components/attrs.md
+++ b/src/guide/components/attrs.md
@@ -79,12 +79,12 @@ If you do **not** want a component to automatically inherit attributes, you can 
 
 <div class="composition-api">
 
-If using `<script setup>`, you can use the `defineOptions` macro:
+If using `<script setup>`, you can use the [`defineOptions`](/api/sfc-script-setup#defineoptions) macro:
 
 ```vue
 <script setup>
 defineOptions({
-  inheritAttrs: false,
+  inheritAttrs: false
 })
 </script>
 ```

--- a/src/guide/extras/composition-api-faq.md
+++ b/src/guide/extras/composition-api-faq.md
@@ -106,7 +106,7 @@ Options API does allow you to "think less" when writing component code, which is
 
 ### Does Composition API cover all use cases? {#does-composition-api-cover-all-use-cases}
 
-Yes in terms of stateful logic. When using Composition API, there are only a few options that may still be needed: `props`, `emits`, `name`, and `inheritAttrs`. If using `<script setup>`, then `inheritAttrs` is typically the only option that may require a separate normal `<script>` block.
+Yes in terms of stateful logic. When using Composition API, there are only a few options that may still be needed: `props`, `emits`, `name`, and `inheritAttrs`.
 
 If you intend to exclusively use Composition API (along with the options listed above), you can shave a few kbs off your production bundle via a [compile-time flag](https://github.com/vuejs/core/tree/main/packages/vue#bundler-build-feature-flags) that drops Options API related code from Vue. Note this also affects Vue components in your dependencies.
 


### PR DESCRIPTION
…t block

## Description of Problem

Some of the documentation was still recommending the use of a second script block over using the defineOptions macro

## Proposed Solution

Rewrite some of the description to highlight the use of the macro

## Additional Information

I'm not sure what the documentations strategy is... As Vue 3.3 is relatively new, I'm not sure if the strategy is to highlight what would work for "most people", or if it's proposed strategy is to be as up to date with the current core version. 