### PR TITLE
docs(inject/provide): add example for usage in setup context

### DIFF
--- a/src/guide/components/provide-inject.md
+++ b/src/guide/components/provide-inject.md
@@ -264,13 +264,18 @@ provide('location', {
 ```vue{5}
 <!-- in injector component -->
 <script setup>
-import { inject } from 'vue'
+import { inject, computed } from 'vue'
 
 const { location, updateLocation } = inject('location')
+
+const emoji = computed(() => {
+  // locaion is a ref
+  return location.value === 'North Pole' ? '🎅' : '⬇️'
+})
 </script>
 
 <template>
-  <button @click="updateLocation">{{ location }}</button>
+  <button @click="updateLocation">{{ location }} {{emoji}}</button>
 </template>
 ```
 


### PR DESCRIPTION
# Update provide-inject.md

## Description of Problem

inject and provide are not well documented in the setup context. I struggled for a long time to figure out that when I provide a ref it is also injected as a ref. 

## Proposed Solution

added one example.

## Additional Information

If this is accepted, it might be advisable to add examples for defaults and typescript. Especially also concerning BP.
