### PR TITLE
docs(script-setup): updated outdated tip

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -304,7 +304,7 @@ const attrs = useAttrs()
 
 `<script setup>` can be used alongside normal `<script>`. A normal `<script>` may be needed in cases where we need to:
 
-- Declare options that cannot be expressed in `<script setup>` (prior to 3.3, supported by [`defineOptions`](https://vuejs.org/api/sfc-script-setup.html#defineoptions) in 3.3+), for example `inheritAttrs` or custom options enabled via plugins.
+- Declare options that cannot be expressed in `<script setup>`, for example `inheritAttrs` or custom options enabled via plugins (Can be replaced by [`defineOptions`](/api/sfc-script-setup#defineoptions) in 3.3+).
 - Declaring named exports.
 - Run side effects or create objects that should only execute once.
 

--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -304,7 +304,7 @@ const attrs = useAttrs()
 
 `<script setup>` can be used alongside normal `<script>`. A normal `<script>` may be needed in cases where we need to:
 
-- Declare options that cannot be expressed in `<script setup>`, for example `inheritAttrs` or custom options enabled via plugins.
+- Declare options that cannot be expressed in `<script setup>` (prior to 3.3, supported by [`defineOptions`](https://vuejs.org/api/sfc-script-setup.html#defineoptions) in 3.3+), for example `inheritAttrs` or custom options enabled via plugins.
 - Declaring named exports.
 - Run side effects or create objects that should only execute once.
 


### PR DESCRIPTION
With vue 3.3+, you can use `defineOptions` to define `name` etc.
