### PR TITLE
API style switch enhancements

### DIFF
--- a/.vitepress/inlined-scripts/restorePreference.js
+++ b/.vitepress/inlined-scripts/restorePreference.js
@@ -5,7 +5,7 @@
       document.documentElement.classList.add(cls)
     }
   }
-  restore('vue-docs-prefer-composition', 'prefer-composition')
+  restore('vue-docs-prefer-composition', 'prefer-composition', true)
   restore('vue-docs-prefer-sfc', 'prefer-sfc', true)
 
   // window.__VUE_BANNER_ID__ = ''

--- a/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/.vitepress/theme/components/PreferenceSwitch.vue
@@ -8,6 +8,7 @@ import {
   preferSFCKey,
   preferSFC
 } from './preferences'
+import PreferenceTooltip from './PreferenceTooltip.vue'
 
 const route = useRoute()
 const show = computed(() =>
@@ -94,6 +95,7 @@ function useToggleFn(
           @click="closeSideBar"
           >?</a
         >
+        <PreferenceTooltip />
       </div>
       <div class="switch-container" v-if="showSFC">
         <label class="no-sfc-label" @click="toggleSFC(false)">HTML</label>
@@ -168,7 +170,7 @@ function useToggleFn(
 
 .switch-container {
   display: flex;
-  align-items: center;  
+  align-items: center;
 }
 
 @media(max-width: 959px){

--- a/.vitepress/theme/components/PreferenceTooltip.vue
+++ b/.vitepress/theme/components/PreferenceTooltip.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { preferComposition, preferCompositionKey } from './preferences'
+import { useData } from 'vitepress'
+
+const show = ref(false)
+const { page } = useData()
+
+onMounted(() => {
+  show.value =
+    !page.value.relativePath.startsWith('tutorial/') &&
+    localStorage.getItem(preferCompositionKey) === null
+})
+
+function dismiss() {
+  show.value = false
+  localStorage.setItem(
+    preferCompositionKey,
+    String(preferComposition.value)
+  )
+}
+</script>
+
+<template>
+  <Transition name="fly-in">
+    <div class="preference-tooltip" v-if="show">
+      <p>API style now defaults to Composition API.</p>
+      <p>
+        Some pages contain different content based on the API style chosen.
+        Use this switch to toggle between APIs styles.
+      </p>
+      <p class="actions">
+        <a href="/guide/introduction#api-styles">Learn more</a>
+        <button @click="dismiss">Got it</button>
+      </p>
+      <div class="arrow-top"></div>
+      <div class="arrow-top inner"></div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.preference-tooltip {
+  font-weight: 500;
+  line-height: 1.6;
+  position: absolute;
+  padding: 12px 20px 12px 36px;
+  width: 100%;
+  background-color: var(--vt-c-bg-soft);
+  top: 7.5em;
+  border: 1px solid var(--vt-c-green);
+  border-radius: 8px;
+  box-shadow: var(--vt-shadow-3);
+  z-index: 10;
+}
+
+.preference-tooltip:before {
+  content: 'ⓘ';
+  position: absolute;
+  font-weight: 600;
+  font-size: 14px;
+  top: 9px;
+  left: 13px;
+}
+
+.dark .preference-tooltip {
+  box-shadow: var(--vt-shadow-1);
+}
+
+p {
+  margin-bottom: 8px;
+}
+
+.arrow-top {
+  width: 0;
+  height: 0;
+  border: 6px solid transparent;
+  border-bottom: 9px solid var(--vt-c-green);
+  position: absolute;
+  top: -16px;
+  left: 130px;
+}
+
+.arrow-top.inner {
+  border-bottom-color: var(--vt-c-bg-soft);
+  top: -14px;
+}
+
+.actions {
+  text-align: right;
+  margin-top: 14px;
+  margin-bottom: 0;
+}
+
+a {
+  color: var(--vt-c-green);
+  text-decoration: underline;
+  margin-right: 1.5em;
+}
+
+button {
+  color: var(--vt-c-bg-soft);
+  font-weight: 500;
+  box-shadow: var(--vt-shadow-2);
+  padding: 2px 8px;
+  border-radius: 6px;
+  background-color: var(--vt-c-green);
+}
+
+@media (max-width: 1439px) {
+  .arrow-top {
+    left: 136px;
+  }
+}
+
+.fly-in-enter-active {
+  transition: all 0.2s ease-out;
+}
+
+.fly-in-leave-active {
+  transition: all 0.15s ease-in;
+}
+
+.fly-in-enter-from,
+.fly-in-leave-to {
+  opacity: 0;
+  transform: translateY(16px);
+}
+</style>

--- a/.vitepress/theme/components/preferences.ts
+++ b/.vitepress/theme/components/preferences.ts
@@ -1,14 +1,14 @@
 import { ref } from 'vue'
 import { AugmentedHeader } from '../../headerMdPlugin'
 
-const hasStorage = typeof localStorage !== 'undefined'
+export const hasStorage = typeof localStorage !== 'undefined'
 const get = (key: string, defaultValue = false): boolean =>
   hasStorage
     ? JSON.parse(localStorage.getItem(key) || String(defaultValue))
     : defaultValue
 
 export const preferCompositionKey = 'vue-docs-prefer-composition'
-export const preferComposition = ref(get(preferCompositionKey))
+export const preferComposition = ref(get(preferCompositionKey, true))
 
 export const preferSFCKey = 'vue-docs-prefer-sfc'
 export const preferSFC = ref(get(preferSFCKey, true))

--- a/.vitepress/theme/components/preferences.ts
+++ b/.vitepress/theme/components/preferences.ts
@@ -1,9 +1,9 @@
 import { ref } from 'vue'
 import { AugmentedHeader } from '../../headerMdPlugin'
 
-export const hasStorage = typeof localStorage !== 'undefined'
+export const inBrowser = typeof window !== 'undefined'
 const get = (key: string, defaultValue = false): boolean =>
-  hasStorage
+  inBrowser
     ? JSON.parse(localStorage.getItem(key) || String(defaultValue))
     : defaultValue
 

--- a/src/guide/introduction.md
+++ b/src/guide/introduction.md
@@ -30,6 +30,8 @@ Vue (pronounced /vjuː/, like **view**) is a JavaScript framework for building u
 
 Here is a minimal example:
 
+<div class="options-api">
+
 ```js
 import { createApp } from 'vue'
 
@@ -41,6 +43,23 @@ createApp({
   }
 }).mount('#app')
 ```
+
+</div>
+<div class="composition-api">
+
+```js
+import { createApp, ref } from 'vue'
+
+createApp({
+  setup() {
+    return {
+      count: ref(0)
+    }
+  }
+}).mount('#app')
+```
+
+</div>
 
 ```vue-html
 <div id="app">
@@ -96,6 +115,8 @@ Despite the flexibility, the core knowledge about how Vue works is shared across
 
 In most build-tool-enabled Vue projects, we author Vue components using an HTML-like file format called **Single-File Component** (also known as `*.vue` files, abbreviated as **SFC**). A Vue SFC, as the name suggests, encapsulates the component's logic (JavaScript), template (HTML), and styles (CSS) in a single file. Here's the previous example, written in SFC format:
 
+<div class="options-api">
+
 ```vue
 <script>
 export default {
@@ -117,6 +138,28 @@ button {
 }
 </style>
 ```
+
+</div>
+<div class="composition-api">
+
+```vue
+<script setup>
+import { ref } from 'vue'
+const count = ref(0)
+</script>
+
+<template>
+  <button @click="count++">Count is: {{ count }}</button>
+</template>
+
+<style scoped>
+button {
+  font-weight: bold;
+}
+</style>
+```
+
+</div>
 
 SFC is a defining feature of Vue and is the recommended way to author Vue components **if** your use case warrants a build setup. You can learn more about the [how and why of SFC](/guide/scaling-up/sfc) in its dedicated section - but for now, just know that Vue will handle all the build tools setup for you.
 


### PR DESCRIPTION
- Default style to Composition API. First-time users without a saved preference will see a tooltip (see screenshot below).

- Support specifying desired style via URL with `?api=composition` or `?api=options`

- Auto switch to proper API style if URL's target header is only available for a given API style. For example, when visiting `/guide/essentials/reactivity-fundamentals.html#ref` with saved preference set to Options API, the page will be displayed in Composition API. A tooltip will also be displayed to let the user be aware that the displayed style is different from their saved preference.

- API style choice enforced via URL persists for that session. This means:
  - If the user navigates to another page without reloading, the API choice remains the same as what was specified by the initial URL.
  - If the user reloads the page, the API choice is reset to the saved preference from localStorage. 

<img width="682" alt="Screenshot 2023-06-11 at 5 27 32 PM" src="https://github.com/vuejs/docs/assets/499550/520527e7-d1c6-4fe9-a601-1a062b30f7e4">