### PR TITLE
fix: missing \ before second star

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -67,9 +67,9 @@ When you access `this.someObject` after assigning it, the value is a reactive pr
 
 <div class="composition-api">
 
-## Declaring Reactive State \** {#declaring-reactive-state-1}
+## Declaring Reactive State \*\* {#declaring-reactive-state-1}
 
-### `ref()` \** {#ref}
+### `ref()` \*\* {#ref}
 
 In Composition API, the recommended way to declare reactive state is using the [`ref()`](/api/reactivity-core#ref) function:
 
@@ -372,7 +372,7 @@ export default {
 
 <div class="composition-api">
 
-## `reactive()` \** {#reactive}
+## `reactive()` \*\* {#reactive}
 
 There is another way to declare reactive state, with the `reactive()` API. Unlike a ref which wraps the inner value in a special object, `reactive()` makes an object itself reactive:
 
@@ -496,7 +496,7 @@ console.log(count.value) // 1
 
 Ref unwrapping only happens when nested inside a deep reactive object. It does not apply when it is accessed as a property of a [shallow reactive object](/api/reactivity-advanced#shallowreactive).
 
-### Caveat in Arrays and Collections \** {#caveat-in-arrays-and-collections}
+### Caveat in Arrays and Collections \*\* {#caveat-in-arrays-and-collections}
 
 Unlike reactive objects, there is **no** unwrapping performed when the ref is accessed as an element of a reactive array or a native collection type like `Map`:
 


### PR DESCRIPTION
There is few situation where it miss the `\` symbol before the second star