### PR TITLE
Reactivity Fundamentals: Use third person singular for "Vue performs"

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -198,7 +198,7 @@ When you use a ref in the template, and changes the ref's value later, Vue autom
 
 In standard JavaScript, there is no way to detect the access or mutation of plain variables. But we can intercept a property's get and set operations.
 
-The `.value` property gives Vue the opportunity to detect when a ref has been accessed or mutated. Under the hood, Vue perform the tracking in its getter, and performs triggering in its setter. Conceptually, you can think of a ref as an object that looks like this:
+The `.value` property gives Vue the opportunity to detect when a ref has been accessed or mutated. Under the hood, Vue performs the tracking in its getter, and performs triggering in its setter. Conceptually, you can think of a ref as an object that looks like this:
 
 ```js
 // pseudo code, not actual implementation


### PR DESCRIPTION
## Description of Problem
The Reactivity Fundamentals section of the Essentials Guide includes a grammatical error, namely `Vue perform`

## Proposed Solution
Change phrasing into `Vue performs`

## Additional Information
Since this is my first contribution, I would like to receive feedback on the format of this PR, so if you have any remarks, please feel free to tell me. Moreover, I would like to know whether these type of minimal PRs are appreciated or should best be avoided for future PRs. Thanks in advance for the invested time.