### PR TITLE
Tools: Link to Microsoft Edge extension page

### DIFF
--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -80,6 +80,7 @@ The Vue browser devtools extension allows you to explore a Vue app's component t
 - [Documentation](https://devtools.vuejs.org/)
 - [Chrome Extension](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
 - [Firefox Addon](https://addons.mozilla.org/en-US/firefox/addon/vue-js-devtools/)
+- [Edge Extension](https://microsoftedge.microsoft.com/addons/detail/vuejs-devtools/olofadcdnkkjdfgjcmjaadnlehnnihnl)
 - [Standalone Electron app](https://devtools.vuejs.org/guide/installation.html#standalone)
 
 ## TypeScript {#typescript}


### PR DESCRIPTION
## Description of Problem
Currently the guide links to the Chrome extension, the Firefox addon, and the standalone app, but not to the Microsoft Edge extension.

## Proposed Solution
Also link to the Edge extension, with the ordering of the different varieties consistent with that of https://devtools.vuejs.org/guide/installation.html

## Additional Information
