### PR TITLE
onBeforeUnmount to onUnmounted for consistency

### DIFF
--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -94,13 +94,13 @@ For example, we can extract the logic of adding and removing a DOM event listene
 
 ```js
 // event.js
-import { onMounted, onBeforeUnmount } from 'vue'
+import { onMounted, onUnmounted } from 'vue'
 
 export function useEventListener(target, event, callback) {
   // if you want, you can also make this
   // support selector strings as target
   onMounted(() => target.addEventListener(event, callback))
-  onBeforeUnmount(() => target.removeEventListener(event, callback))
+  onUnmounted(() => target.removeEventListener(event, callback))
 }
 ```
 


### PR DESCRIPTION
## Description of Problem

The rest of this documentation page uses `onUnmounted` for removing event listeners, including the example this composable directly references. The API also suggests using `onUnmounted` for this purpose.

## Proposed Solution

Update the example to use `onUnmounted` as well, for consistency with the rest of the page.
