### PR TITLE
examples (todomvc): change `@vnode-mounted` to `@vue:mounted`

### DIFF
--- a/src/examples/src/todomvc/App/template.html
+++ b/src/examples/src/todomvc/App/template.html
@@ -34,7 +34,7 @@
           class="edit"
           type="text"
           v-model="todo.title"
-          @vnode-mounted="({ el }) => el.focus()"
+          @vue:mounted="({ el }) => el.focus()"
           @blur="doneEdit(todo)"
           @keyup.enter="doneEdit(todo)"
           @keyup.escape="cancelEdit(todo)"


### PR DESCRIPTION
## Description of Problem
This example was using a deprecated API (`@vnode-mounted`), so I updated it.

## Proposed Solution
Change `@vnode-mounted` to `@vue:mounted`.

## Additional Information
