### PR TITLE
Update forms.md

### DIFF
--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -341,7 +341,7 @@ export default {
 
 ```vue-html
 <select v-model="selected">
-  <option v-for="option in options" :value="option.value">
+  <option v-for="option in options" :key="option.value" :value="option.value">
     {{ option.text }}
   </option>
 </select>


### PR DESCRIPTION
Added a key property to line 344 on the select option dynamic rendering.

## Description of Problem
Missing `key` property when using a `v-for` directive in the dynamic rendering of a `select` with `option`.

## Proposed Solution
Added a `key` property to line 344.

## Additional Information
- Needs to be updated in the options API section as well.
- Playground code also needs to be updated by adding the `key` property in both the options API and Composition API.
