### PR TITLE
docs: remove duplicate defineOptions script setup example

### DIFF
--- a/src/guide/components/attrs.md
+++ b/src/guide/components/attrs.md
@@ -79,17 +79,7 @@ If you do **not** want a component to automatically inherit attributes, you can 
 
 <div class="composition-api">
 
-If using `<script setup>`, you can use the [`defineOptions`](/api/sfc-script-setup#defineoptions) macro:
-
-```vue
-<script setup>
-defineOptions({
-  inheritAttrs: false
-})
-</script>
-```
-
- Since 3.3 you can also use `defineOptions` directly in `<script setup>`:
+ Since 3.3 you can also use [`defineOptions`](/api/sfc-script-setup#defineoptions) directly in `<script setup>`:
 
 ```vue
 <script setup>


### PR DESCRIPTION
removes an old example that used to document using defineOptions without a setup but now says the same thing twice

## Description of Problem

The docs recommend using the defineOptions macro twice. Looks like it was changed in [PR #2384](https://github.com/vuejs/docs/pull/2384) to always suggest always using `<script setup>` but it didn't remove the second example. 

## Proposed Solution

Remove the first example. (Could remove the other too though 🤷‍♀️ )