### PR TITLE
Add TypeScript With Slots section

### DIFF
--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -510,6 +510,6 @@ While an interesting pattern, most of what can be achieved with Renderless Compo
 That said, scoped slots are still useful in cases where we need to both encapsulate logic **and** compose visual output, like in the `<FancyList>` example.
 
 
-## Typing Slots
+## TypeScript With Slots <sup class="vt-badge ts"/>
 
-Slots can be typed with `defineSlots()` to give hints to your IDE for slot name and prop type checking. Learn more about the `defineSlots()` macro [here](https://vuejs.org/api/sfc-script-setup.html#defineslots) 
+Slots can be typed with `defineSlots()` to give hints to your IDE for slot name and prop type checking. [Learn more about the `defineSlots()` macro](https://vuejs.org/api/sfc-script-setup.html#defineslots) 

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -508,3 +508,8 @@ An example renderless component could be one that encapsulates the logic of trac
 While an interesting pattern, most of what can be achieved with Renderless Components can be achieved in a more efficient fashion with Composition API, without incurring the overhead of extra component nesting. Later, we will see how we can implement the same mouse tracking functionality as a [Composable](/guide/reusability/composables).
 
 That said, scoped slots are still useful in cases where we need to both encapsulate logic **and** compose visual output, like in the `<FancyList>` example.
+
+
+## Typing Slots
+
+Slots can be typed with `defineSlots()` to give hints to your IDE for slot name and prop type checking. Learn more about the `defineSlots()` macro [here](https://vuejs.org/api/sfc-script-setup.html#defineslots) 


### PR DESCRIPTION
## Description of Problem

Missing a typing slots section in Vue slots doc. This section is relevant to Typescript users who are looking to type their slots.

## Proposed Solution

Add the missing section with a link to the defineSlots() docs
