### PR TITLE
Add instructions for type-only imports

### DIFF
--- a/src/guide/typescript/overview.md
+++ b/src/guide/typescript/overview.md
@@ -208,6 +208,21 @@ let x: string | number = 1
 If using Vue CLI or a webpack-based setup, TypeScript in template expressions requires `vue-loader@^16.8.0`.
 :::
 
+### Importing Types
+Because [`compilerOptions.isolatedModules`](https://www.typescriptlang.org/tsconfig#isolatedModules) is set to `true` (due to Vite using [esbuild](https://esbuild.github.io/) for transpiling), it is necessary when using [`type only imports`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html) to use the `import type` syntax.
+
+In other words, when importing a type you would typically use:
+
+```vue
+import { Product } from 'product.interface
+```
+
+Instead, you should use:
+
+```vue
+import type { Product } from 'product.interface
+```
+
 ### Usage with TSX
 
 Vue also supports authoring components with JSX / TSX. Details are covered in the [Render Function & JSX](/guide/extras/render-function.html#jsx-tsx) guide.


### PR DESCRIPTION
## Description of Problem
Because Vue uses isolatedModules, it is necessary to use type-only import syntax when importing types. Discovering the resolution for this edge case is difficult when first beginning to work with TypeScript and Vue/Vite.

This is easy to replicate by creating an app with `create-vue` and selectihg the `typescript` option. Then, export an interface from a `.ts` file and import it and try to use it as a type in a component. When you run `npm run type-check` you will see the error. Here is a sample repo that duplicates the problem with a new `create-vue` app: https://github.com/jmcooper/create-vue-ts-repro

## Proposed Solution
Update the documentation as proposed to make it clear this is an expected behavior and how to resolve it.

## Additional Information
Sample repo to replicate the problem: https://github.com/jmcooper/create-vue-ts-repro