### PR TITLE
docs: change `@vnode-mounted` to `@vue:mounted`

### DIFF
--- a/src/examples/src/cells/Cell/template.html
+++ b/src/examples/src/cells/Cell/template.html
@@ -4,7 +4,7 @@
     :value="cells[c][r]"
     @change="update"
     @blur="update"
-    @vnode-mounted="({ el }) => el.focus()"
+    @vue:mounted="({ el }) => el.focus()"
   >
   <span v-else>{{ evalCell(cells[c][r]) }}</span>
 </div>

--- a/src/guide/extras/demos/SpreadSheetCell.vue
+++ b/src/guide/extras/demos/SpreadSheetCell.vue
@@ -22,7 +22,7 @@ function update(e) {
       :value="cells[c][r]"
       @change="update"
       @blur="update"
-      @vnode-mounted="({ el }) => el.focus()"
+      @vue:mounted="({ el }) => el.focus()"
     />
     <span v-else>{{ evalCell(cells[c][r]) }}</span>
   </div>


### PR DESCRIPTION
## Description of Problem

![image](https://github.com/vuejs/docs/assets/61787903/f4ea627e-eb03-4ea0-b032-d65910ead85f)

`@vnode-*` hooks in templates are deprecated. Use the `vue:` prefix instead.

For example, `@vnode-mounted` should be changed to `@vue:mounted`. 

`@vnode-*` hooks support will be removed in 3.4.

## Proposed Solution

Replace `@vnode-mounted` with `@vue:mounted`



## Additional Information
