### PR TITLE
refactor: use `@vue:mounted` inside `SpreadSheetCell.vue`

### DIFF
--- a/src/guide/extras/demos/SpreadSheetCell.vue
+++ b/src/guide/extras/demos/SpreadSheetCell.vue
@@ -22,7 +22,7 @@ function update(e) {
       :value="cells[c][r]"
       @change="update"
       @blur="update"
-      @vnode-mounted="({ el }) => el.focus()"
+      @vue:mounted="({ el }) => el.focus()"
     />
     <span v-else>{{ evalCell(cells[c][r]) }}</span>
   </div>


### PR DESCRIPTION
replace `@vnode-mounted` with `@vue:mounted` because it will be removed in version 3.4, so this way we will not receive the deprecation warning.

## Description of Problem

`SpreadSheatCell.vue` component was warning about the deprecated usage of the `@vnode-mounted` hook.

## Proposed Solution

Replace `@vnode-mounted` with `@vue:mounted`

## Additional Information

`@vnode-*` hooks support will be removed in version 3.4.

Every usage of `@vnode-*` hooks should be replaced by `vue:` prefix in the place of `@vnode` then after the colon, we should write the hook name.