### PR TITLE
docs (reactivity-in-depth): improve the implementation of `createSignal`

### DIFF
--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -439,7 +439,7 @@ export function createSignal(value, { equals } = {}) {
 
     if (equals === undefined) return void (r.value = next)
     if (equals === false) return void (r.value = next, triggerRef(r))
-    if (typeof equals === "function") {
+    if (typeof equals === 'function') {
       if (equals(prev, next)) return
 
       r.value = next


### PR DESCRIPTION
## Description of Problem

This document describes how to simulate the `createSignal` API from SolidJS in Vue. I believe it needs to be modified for the following two reasons:

1. The current implementation is **incomplete**: The current implementation differs significantly from the definition of `createSignal`, mainly because it cannot handle the case where `equals` is a function.
2. The current implementation has a **significant flaw**: Even when `equals` is set to `truly`, the current implementation still updates the signal, which should not happen.

> I think the first issue is acceptable, but the second issue needs to be fixed, which is the real reason why I initiated the PR.

## Proposed Solution

Here is my proposed implementation, which conforms to the definition of `createSignal` in SolidJS and addresses the two issues stated above.

You can visit [this Playground](https://play.vuejs.org/#eNqlVU1v2kAQ/SsjqxVGpdDgG8L0I80hPaRVkhuOFNeMjROz6+6unVTI/72za69taIIQuQA7M29m3uzsY+t8zfNxWaAzc+YyEmmuQKIq8kXA0k3OhYItPIUqWl/EMUYKKogF38CAIINeSCQwVHiTJizM2pjxRPIsXX2Uxjx+kIQIWMSZVLCMeMHU2UhXOzc/78DfSeN+Gu4GT7vg6f/BI+oC/xRhJmcQ0ydCtYf3Orx3GO/mAssRMHxWQ/AXoI/g+76xmLwB6w3FdU2UrsUzHGc8ce/fR3C7RsB6ajwmL9WFsxm8o2kZwoSq7kcwiHjGxQwErgZDSn1a4mmXeLqXmIuQJfiG3F6X29vLnafs0WQO2HxS7w9tDh0UbvKMxksngLmkfCln5kDHfNFOY9ufRjWf6MUzMb8LpTiDL1GWRo9+4LR74ubmSuADnA0DZ3HJ9D1KnE9qxNH4jzX+O56G19grDudrPdwdMA2iR/c17nRhlru5sGO4T9/IvcWfyN3ij+X+OntaKcverNQx7L03sm/xJ7K3+OPYzyftE3BGzp4Qktq20inXYZbxp2uMR6BEmiQo6Pee0AakPCY+LpipsKteZZgV2CkYgX3YVkPY6q5qDRRk6krVCHq31p2gooBaE8TYeDsnTUA7S+M1Oa1n2SmlltRlAyUmf3MkAallc2C7HsBnKN0maAgzKO80N50vjcFtuteQgq0wThmuhiSMqhAMSp6uwGKpllHnF7FG/g/i+pN2hdYvm6bpu5eta76Z527F/n+FrWk5gR1lU9Zad4rXxkp/mY+m7SXdiPnDoglVtEFK0sTjNKHt4Yz2x7QSOBHf5GmG4meuW5SBQw+rzhg45rJ/GJsSdCnWHq0xenzB/iCftS1wfgmUKEoMnNanQkEN1e6LmytNpnNu+KrIKPqA8xrpCRS6xzrsG10wtd2LM91emleRsuRWXjwrZNKS0o2aEZn4wKFncX6AeteuN/aa0VZO9Q+X6O5d) to further validate this implementation.

```js
import { shallowRef, triggerRef } from 'vue'

export function createSignal(value, { equals } = {}) {
  const r = shallowRef(value)
  const get = () => r.value
  const set = (v) => {
    const [prev, next] = [r.value, typeof v === 'function' ? v(r.value) : v]

    if (equals === undefined) return void (r.value = next)
    if (equals === false) return void (r.value = next, triggerRef(r))
    if (typeof equals === 'function') {
      if (equals(prev, next)) return

      r.value = next
      triggerRef(r)
    }
  }
  return [get, set]
}
```

## Additional Information
- [SolidJS - createSignal](https://docs.solidjs.com/references/api-reference/basic-reactivity/createSignal)
