### PR TITLE
Update reactivity-fundamentals.md

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -445,7 +445,7 @@ The `reactive()` API has a few limitations:
    state = reactive({ count: 1 })
    ```
 
-3. **Not destructure-friendly:** when we destructure a reactive object's property into local variables, or when we pass that property into a function, we will lose the reactivity connection:
+3. **Not destructure-friendly:** when we destructure a reactive object's primitive type property into local variables, or when we pass that property into a function, we will lose the reactivity connection:
 
    ```js
    const state = reactive({ count: 0 })


### PR DESCRIPTION
## Description of Problem
doc:  when we destructure a reactive object's property into local variables, or when we pass that property into a function, we will lose the reactivity connection:

but true:  Evidently, the loss of reactivity only occurs when deconstructing properties of primitive types, whereas properties of non-primitive types remain unaffected by this phenomenon.

## Proposed Solution
change out docc
## Additional Information
