### PR TITLE
Add translation link to ko.vuejs.org and pt.vuejs.org

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -642,6 +642,11 @@ export default defineConfigWithTheme<ThemeConfig>({
         repo: 'https://github.com/vuejs-translations/docs-ko'
       },
       {
+        link: 'https://pt.vuejs.org',
+        text: 'Português',
+        repo: 'https://github.com/vuejs-translations/docs-pt'
+      },
+      {
         link: '/translations/',
         text: 'Help Us Translate!',
         isTranslationsDesc: true

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -637,6 +637,11 @@ export default defineConfigWithTheme<ThemeConfig>({
         repo: 'https://github.com/vuejs-translations/docs-fr'
       },
       {
+        link: 'https://ko.vuejs.org',
+        text: '한국어',
+        repo: 'https://github.com/vuejs-translations/docs-ko'
+      },
+      {
         link: '/translations/',
         text: 'Help Us Translate!',
         isTranslationsDesc: true

--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -12,6 +12,7 @@ aside: false
 - [Українська / Ukrainian](https://ua.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-uk)]
 - [Français / French](https://fr.vuejs.org) [[source](https://github.com/vuejs-translations/docs-fr)]
 - [한국어 / Korean](https://ko.vuejs.org) [[source](https://github.com/vuejs-translations/docs-ko)]
+- [Português / Portuguese](https://pt.vuejs.org) [[source](https://github.com/vuejs-translations/docs-pt)]
 
 <!-- ## Work in Progress Languages {#work-in-progress-languages} -->
 

--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -11,6 +11,7 @@ aside: false
 - [日本語 / Japanese](https://ja.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-ja)]
 - [Українська / Ukrainian](https://ua.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-uk)]
 - [Français / French](https://fr.vuejs.org) [[source](https://github.com/vuejs-translations/docs-fr)]
+- [한국어 / Korean](https://ko.vuejs.org) [[source](https://github.com/vuejs-translations/docs-ko)]
 
 <!-- ## Work in Progress Languages {#work-in-progress-languages} -->
 


### PR DESCRIPTION
## Description of Problem

Add translation link to ko.vuejs.org and pt.vuejs.org

Notice that pt.vuejs.org hasn't been well-deployed.

## Proposed Solution

## Additional Information

https://github.com/vuejs-translations/guidelines/pull/71
https://github.com/vuejs-translations/guidelines/discussions/26#discussioncomment-6544331