### PR TITLE
add DOM interface info to Typing Template Refs

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -352,6 +352,8 @@ onMounted(() => {
 </template>
 ```
 
+To get the right DOM interface you can check pages like [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#technical_summary).
+
 Note that for strict type safety, it is necessary to use optional chaining or type guards when accessing `el.value`. This is because the initial ref value is `null` until the component is mounted, and it can also be set to `null` if the referenced element is unmounted by `v-if`.
 
 ## Typing Component Template Refs {#typing-component-template-refs}


### PR DESCRIPTION
Provide information and a place to find the right dom interface for a HTML element.

## Description of Problem
Always stumple about the point HTMLInputElement for two reason

- It's not mention what it is (DOM interface), i can't search when i doesn't had the name
- Where to look into to get this information so that i can look for other HTML elements

## Proposed Solution
Solve the problem by calling it by it's name (i hope the right one) and
provide a example for Input element to provide a source and the place in the source.

## Additional Information
