### PR TITLE
Update SponsorsGroup.vue

### DIFF
--- a/.vitepress/theme/components/SponsorsGroup.vue
+++ b/.vitepress/theme/components/SponsorsGroup.vue
@@ -77,7 +77,7 @@ function track(interest?: boolean) {
       href="/sponsor/"
       class="sponsor-item action"
       @click="track(true)"
-      >Your logo</a
+      >Become a Sponsor</a
     >
   </div>
 </template>


### PR DESCRIPTION
Change your logo to become a sponsor do that people who want to join the vue sponsorship program can get it easy

## Description of Problem
On the side you get your logo after all sponsor logo has been display 
## Proposed Solution
I changed to to Become a sponsor because that's is what the link is about when you click
## Additional Information
To avoid misleading and also make it easy for sponsor to join