### PR TITLE
Update Infinite Re-computation Issue in useFetch Composable Example

### DIFF
--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -216,15 +216,16 @@ export function useFetch(url) {
   const data = ref(null)
   const error = ref(null)
 
-  watchEffect(() => {
-    // reset state before fetching..
-    data.value = null
-    error.value = null
-    // toValue() unwraps potential refs or getters
-    fetch(toValue(url))
+	const fetchData = (dt) => {
+			fetch(toValue(url))
       .then((res) => res.json())
       .then((json) => (data.value = json))
       .catch((err) => (error.value = err))
+	}
+
+  watchEffect(() => {
+    // reset state before fetching..
+    fetchData(url)
   })
 
   return { data, error }


### PR DESCRIPTION
## Description of Problem
https://vuejs.org/guide/reusability/composables.html#accepting-reactive-state

The watchEffect should not modify data.value and error.value used in this example to avoid infinite re-computations.
