### PR TITLE
chore: Update newsletters.md

### DIFF
--- a/src/ecosystem/newsletters.md
+++ b/src/ecosystem/newsletters.md
@@ -2,7 +2,6 @@
 
 There are many great newsletters / Vue-dedicated blogs from the community bringing you latest news and happenings in the Vue ecosystem. Here is a non-exhaustive list of active ones that we have come across:
 
-- [Vue.js Feed](https://vuejsfeed.com/)
 - [Michael Thiessen](https://michaelnthiessen.com/newsletter)
 - [Jakub Andrzejewski](https://dev.to/jacobandrewsky)
 - [Weekly Vue News](https://weekly-vue.news/)


### PR DESCRIPTION
## Description of Problem
The Vue.js Feed newsletter seems discontinued.

## Proposed Solution
Remove the link.

## Additional Information

From what I can tell, the Vue.js Feed newsletter is no longer maintained. It used GetRevue, which was axed by Twitter.