### PR TITLE
docs(essentials): fixed wrong javascript object function in list.md

### DIFF
--- a/src/guide/essentials/list.md
+++ b/src/guide/essentials/list.md
@@ -134,7 +134,7 @@ You can also use `of` as the delimiter instead of `in`, so that it is closer to 
 
 ## `v-for` with an Object {#v-for-with-an-object}
 
-You can also use `v-for` to iterate through the properties of an object. The iteration order will be based on the result of calling `Object.keys()` on the object:
+You can also use `v-for` to iterate through the properties of an object. The iteration order will be based on the result of calling `Object.values()` on the object:
 
 <div class="composition-api">
 


### PR DESCRIPTION
## Description of Problem
Documentation on essentials was specifying a wrong behaviour when talking about how `v-for` works for objects.

## Proposed Solution
I wrote the exact behaviour: in case of a `v-for` inside an object, if we specify only one parameter we are directly accessing the values of the object and not the key. So, the correct function is `Object.values()`.

## Additional Information
 I tested this behaviour with the playground given by the doc itself.
