### PR TITLE
Update built-in-components.md. Rename <teleport> to <Teleport>

### DIFF
--- a/src/api/built-in-components.md
+++ b/src/api/built-in-components.md
@@ -294,17 +294,17 @@ Renders its slot content to another part of the DOM.
   Specifying target container:
 
   ```vue-html
-  <teleport to="#some-id" />
-  <teleport to=".some-class" />
-  <teleport to="[data-teleport]" />
+  <Teleport to="#some-id" />
+  <Teleport to=".some-class" />
+  <Teleport to="[data-teleport]" />
   ```
 
   Conditionally disabling:
 
   ```vue-html
-  <teleport to="#popup" :disabled="displayVideoInline">
+  <Teleport to="#popup" :disabled="displayVideoInline">
     <video src="./my-movie.mp4">
-  </teleport>
+  </Teleport>
   ```
 
 - **See also** [Guide - Teleport](/guide/built-ins/teleport)


### PR DESCRIPTION
## Description of Problem
I think teleport component name should be capitalized on this page. Sincere sorry if I'm wrong.
## Proposed Solution
Renaming <teleport... into <Teleport...