### PR TITLE
Update v-model.md naming convention

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -22,7 +22,7 @@ When used on a component, `v-model` instead expands to this:
 ```vue-html
 <CustomInput
   :modelValue="searchText"
-  @update:modelValue="newValue => searchText = newValue"
+  @update:model-value="newValue => searchText = newValue"
 />
 ```
 

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -21,7 +21,7 @@ When used on a component, `v-model` instead expands to this:
 
 ```vue-html
 <CustomInput
-  :modelValue="searchText"
+  :model-value="searchText"
   @update:model-value="newValue => searchText = newValue"
 />
 ```


### PR DESCRIPTION
## Description of Problem
camelCase is being used in the example, not following the convention.

## Proposed Solution
kebab-case should be used when event is being listened to inside parent's template.

## Additional Information
#2503 