### PR TITLE
Add translation link for bn.vuejs.org

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -695,7 +695,7 @@ export default defineConfigWithTheme<ThemeConfig>({
   markdown: {
     config(md) {
       md.use(headerPlugin)
-      // .use(textAdPlugin)
+        // .use(textAdPlugin)
     }
   },
 

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -647,6 +647,11 @@ export default defineConfigWithTheme<ThemeConfig>({
         repo: 'https://github.com/vuejs-translations/docs-pt'
       },
       {
+        link: 'https://bn.vuejs.org',
+        text: 'বাংলা',
+        repo: 'https://github.com/vuejs-translations/docs-bn'
+      },
+      {
         link: '/translations/',
         text: 'Help Us Translate!',
         isTranslationsDesc: true
@@ -690,7 +695,7 @@ export default defineConfigWithTheme<ThemeConfig>({
   markdown: {
     config(md) {
       md.use(headerPlugin)
-        // .use(textAdPlugin)
+      // .use(textAdPlugin)
     }
   },
 

--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -13,6 +13,7 @@ aside: false
 - [Français / French](https://fr.vuejs.org) [[source](https://github.com/vuejs-translations/docs-fr)]
 - [한국어 / Korean](https://ko.vuejs.org) [[source](https://github.com/vuejs-translations/docs-ko)]
 - [Português / Portuguese](https://pt.vuejs.org) [[source](https://github.com/vuejs-translations/docs-pt)]
+- [বাংলা / Bengali](https://bn.vuejs.org) [[source](https://github.com/vuejs-translations/docs-bn)]
 
 <!-- ## Work in Progress Languages {#work-in-progress-languages} -->
 


### PR DESCRIPTION
## Description of Problem
Add translation link for bn.vuejs.org

Note: bn.vuejs.org hasn't deployed in live.

## Proposed Solution

## Additional Information
Repo: https://github.com/vuejs-translations/docs-bn
Discussions: https://github.com/vuejs-translations/guidelines/discussions/66
