### PR TITLE
Update sfc-script-setup.md

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -221,7 +221,7 @@ export interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   msg: 'hello',
-  labels: () => ['one', 'two']
+  labels: ['one', 'two']
 })
 ```
 


### PR DESCRIPTION
Fixed type mismatch
`Type 'string[]' is not assignable to type '(props: Props) => string[]'.`

## Description of Problem
string[] is defined in interface but a function with a returntype of string[] is provided

## Proposed Solution

## Additional Information
