### PR TITLE
docs: consist usage of in-DOM template 

### DIFF
--- a/src/style-guide/rules-strongly-recommended.md
+++ b/src/style-guide/rules-strongly-recommended.md
@@ -352,7 +352,7 @@ Unfortunately, HTML doesn't allow custom elements to be self-closing - only [off
 ```
 
 ```vue-html
-<!-- In DOM templates -->
+<!-- In in-DOM templates -->
 <my-component/>
 ```
 
@@ -367,7 +367,7 @@ Unfortunately, HTML doesn't allow custom elements to be self-closing - only [off
 ```
 
 ```vue-html
-<!-- In DOM templates -->
+<!-- In in-DOM templates -->
 <my-component></my-component>
 ```
 


### PR DESCRIPTION
## Description of Problem

There is an inconsistency in naming. Sometimes it is called "In DOM", sometimes "In in-DOM"

## Proposed Solution

Change "In Dom" to "In in-DOM" in two places as used in the rest of the document

## Additional Information
