### PR TITLE
Remove the app constant name from the method name

### DIFF
--- a/src/guide/components/registration.md
+++ b/src/guide/components/registration.md
@@ -8,7 +8,7 @@ A Vue component needs to be "registered" so that Vue knows where to locate its i
 
 ## Global Registration {#global-registration}
 
-We can make components available globally in the current [Vue application](/guide/essentials/application) using the `app.component()` method:
+We can make components available globally in the current [Vue application](/guide/essentials/application) using the `.component()` method:
 
 ```js
 import { createApp } from 'vue'

--- a/src/guide/components/registration.md
+++ b/src/guide/components/registration.md
@@ -33,7 +33,7 @@ import MyComponent from './App.vue'
 app.component('MyComponent', MyComponent)
 ```
 
-The `app.component()` method can be chained:
+The `.component()` method can be chained:
 
 ```js
 app


### PR DESCRIPTION
To be consitent with the rest of the guide, it should be displayed the method call (with the dot accessor) i.e.: https://vuejs.org/guide/essentials/application.html#mounting-the-app

## Description of Problem
In other parts of the guide, when application methods are described, the `.methodName()` is used instead of `app.methodName()`

## Proposed Solution
remove the constant `app` from the method call

## Additional Information
