### PR TITLE
docs(pinia): use stronger language

### DIFF
--- a/src/guide/scaling-up/state-management.md
+++ b/src/guide/scaling-up/state-management.md
@@ -240,4 +240,4 @@ Existing users may be familiar with [Vuex](https://vuex.vuejs.org/), the previou
 
 Pinia started out as an exploration of what the next iteration of Vuex could look like, incorporating many ideas from core team discussions for Vuex 5. Eventually, we realized that Pinia already implements most of what we wanted in Vuex 5, and decided to make it the new recommendation instead.
 
-Compared to Vuex, Pinia provides a simpler API with less ceremony, offers Composition-API-style APIs, and most importantly, has solid type inference support when used with TypeScript.
+Compared to Vuex, Pinia provides a simpler API with less ceremony, offers Composition-API-style APIs, and most importantly, has robust type inference support when used with TypeScript.


### PR DESCRIPTION
## Description of Problem

The word '_solid_' has a neutral-positive connotation: calling a feature '_solid_' implies it might is not the best feature in the system. For example, saying 'I have _solid_ social skills' implies I have other skills that are better, like making substantial contributions to the open-source community by making PRs about language choices in documentation.

## Proposed Solution

Use a strictly positive word: '**robust**'. A system that is **robust** is implied to be complete and even battle-tested.

## Additional Information

When we sell our products, our language should not only reflect the confidence we have in them, but also guide it. That's how we'll make truly robust systems.
