### PR TITLE
docs: remove broken link to focus indicator extension (closes #2530)

### DIFF
--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -518,7 +518,6 @@ W3C's WAI-ARIA provides guidance on how to build dynamic content and advanced us
 - Other Helpful Tools
   - [HeadingMap](https://chrome.google.com/webstore/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi?hl=en…)
   - [Color Oracle](https://colororacle.org)
-  - [Focus Indicator](https://chrome.google.com/webstore/detail/focus-indicator/heeoeadndnhebmfebjccbhmccmaoedlf?hl=en-US…)
   - [NerdeFocus](https://chrome.google.com/webstore/detail/nerdefocus/lpfiljldhgjecfepfljnbjnbjfhennpd?hl=en-US…)
   - [Visual Aria](https://chrome.google.com/webstore/detail/visual-aria/lhbmajchkkmakajkjenkchhnhbadmhmk?hl=en-US)
   - [Silktide Website Accessibility Simulator](https://chrome.google.com/webstore/detail/silktide-website-accessib/okcpiimdfkpkjcbihbmhppldhiebhhaf?hl=en-US)


### PR DESCRIPTION
## Description of Problem
`Other Helpful Tools` : the `Focus Indicator` extension is not valid. In doc we also have a alternative option for this extension. that why we don't need this extension anymore.

![image](https://github.com/vuejs/docs/assets/76747782/80743b1b-203f-415b-af3e-8b5352a21a28)

## Proposed Solution
Focus Indicator: is removed from document 

After merge: it will be like below 

![image](https://github.com/vuejs/docs/assets/76747782/0d716793-d4cd-481c-aef0-0d16cba8e2a7)


## Additional Information
No