### PR TITLE
Update events.md - Diff between Options API and Composition API text

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -176,7 +176,7 @@ export default {
 
 </div>
 
-The <span class="composition-api">`defineEmits()` macro</span><span class="options-api">`emits` option</span> also supports an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
+The `emits` option and `defineEmits()` macro also support an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
 
 <div class="composition-api">
 

--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -176,7 +176,7 @@ export default {
 
 </div>
 
-The <span class="composition-api">`defineEmits()` macro</span><span class="composition-api">`emits` option</span> also supports an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
+The <span class="composition-api">`defineEmits()` macro</span><span class="options-api">`emits` option</span> also supports an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
 
 <div class="composition-api">
 

--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -176,9 +176,9 @@ export default {
 
 </div>
 
-The `emits` option also supports an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
-
 <div class="composition-api">
+
+The `defineEmits()` macro also supports an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
 
 ```vue
 <script setup>
@@ -206,6 +206,8 @@ More details: [Typing Component Emits](/guide/typescript/composition-api#typing-
 
 </div>
 <div class="options-api">
+
+The `emits` option also supports an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
 
 ```js
 export default {

--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -176,9 +176,9 @@ export default {
 
 </div>
 
-<div class="composition-api">
+The <span class="composition-api">`defineEmits()` macro</span><span class="composition-api">`emits` option</span> also supports an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
 
-The `defineEmits()` macro also supports an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
+<div class="composition-api">
 
 ```vue
 <script setup>
@@ -206,8 +206,6 @@ More details: [Typing Component Emits](/guide/typescript/composition-api#typing-
 
 </div>
 <div class="options-api">
-
-The `emits` option also supports an object syntax, which allows us to perform runtime validation of the payload of the emitted events:
 
 ```js
 export default {


### PR DESCRIPTION
The `emits` object sintax support for Options API text was displayed for both, Options and Composition API.

## Description of Problem
It talks about `emits` options and the script shows the `defineEmits()` macro

## Proposed Solution
Add spans with `options-api` and  `composition-api` class to display properly `emits` options or `defineEmits()` macro

## Additional Information
