### PR TITLE
docs: recommend `petite-vue` for no build approaches

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -365,6 +365,8 @@ Import Maps is a relatively new browser feature. Make sure to use a browser with
 
 :::warning Notes on Production Use
 The examples so far are using the development build of Vue - if you intend to use Vue from a CDN in production, make sure to check out the [Production Deployment Guide](/guide/best-practices/production-deployment#without-build-tools).
+
+While it is possible to use Vue without a build system, we consider it to be a little too much for minimalist approaches, so we recommend giving a chance to the [`vuejs/petite-vue`](https://github.com/vuejs/petite-vue) that could suit better on the context where [`jquery/jquery`](https://github.com/jquery/jquery) (in the past) or [`alpinejs/alpine`](https://github.com/alpinejs/alpine) (in the present) would be more indicated.
 :::
 
 ### Splitting Up the Modules {#splitting-up-the-modules}

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -366,7 +366,7 @@ Import Maps is a relatively new browser feature. Make sure to use a browser with
 :::warning Notes on Production Use
 The examples so far are using the development build of Vue - if you intend to use Vue from a CDN in production, make sure to check out the [Production Deployment Guide](/guide/best-practices/production-deployment#without-build-tools).
 
-While it is possible to use Vue without a build system, we consider it to be a little too much for minimalist approaches, so we recommend giving a chance to the [`vuejs/petite-vue`](https://github.com/vuejs/petite-vue) that could suit better on the context where [`jquery/jquery`](https://github.com/jquery/jquery) (in the past) or [`alpinejs/alpine`](https://github.com/alpinejs/alpine) (in the present) would be more indicated.
+While it is possible to use Vue without a build system, an alternative approach to consider is using [`vuejs/petite-vue`](https://github.com/vuejs/petite-vue) that could better suit the context where [`jquery/jquery`](https://github.com/jquery/jquery) (in the past) or [`alpinejs/alpine`](https://github.com/alpinejs/alpine) (in the present) might be used instead.
 :::
 
 ### Splitting Up the Modules {#splitting-up-the-modules}


### PR DESCRIPTION
## Description of Problem

The mainstream bundle of Vue.js is too big or not the best for setups that do not have a build system or are too minimalist, so while I was reviewing the documentation, I found one possible enhancement for the documentation.

## Proposed Solution

So, I added a note recommending users give a chance to the `petite-vue`  for no-build setups and minimalist approaches.

## How This Look Like?

![petite-vue-recommendation](https://github.com/vuejs/docs/assets/31008635/d5c54705-ff3f-4dc9-a677-6fa24e82790c)

