### PR TITLE
fix(tutorial): race condition on step-10

### DIFF
--- a/src/tutorial/src/step-10/App/template.html
+++ b/src/tutorial/src/step-10/App/template.html
@@ -1,4 +1,4 @@
 <p>Todo id: {{ todoId }}</p>
-<button @click="todoId++">Fetch next todo</button>
+<button @click="todoId++" :disabled="!todoData">Fetch next todo</button>
 <p v-if="!todoData">Loading...</p>
 <pre v-else>{{ todoData }}</pre>


### PR DESCRIPTION
## Description of Problem

In the code for [step 10 of the tutorial](https://vuejs.org/tutorial/#step-10), there is an issue where rapidly clicking the button can result in the results not matching the id.

<img width="400" alt="スクリーンショット 2023-11-13 23 44 36" src="https://github.com/vuejs/docs/assets/71201308/9dca4a51-f966-48d2-8c31-1ee2401af770">


## Proposed Solution

There are several possible solutions.
- Disable the button during loading
- Hide the button while loading
- Add a cleanup process.

As referred to in https://github.com/vuejs/docs/pull/2537, adding a cleanup process would require explaining more, which I'm concerned might deviate from the original purpose. 
Therefore, I believe one of the first two options mentioned would be preferable. 

In this PR, I tried fixing it in the direction of disabling the button, as initially suggested!

Behavior after the correction:

https://github.com/vuejs/docs/assets/71201308/bdc1b2bb-d2c3-47d7-9e11-4d54a700f702



## Additional Information

If you have any better suggestions for the fix, please feel free to propose them! 😄 