### PR TITLE
docs: fix recommended syntax for getters as reactive data sources

### DIFF
--- a/src/api/reactivity-utilities.md
+++ b/src/api/reactivity-utilities.md
@@ -124,9 +124,20 @@ Can also be used to create a ref for a property on a source reactive object. The
   useSomeFeature(toRef(props, 'foo'))
 
   // getter syntax - recommended in 3.3+
-  useSomeFeature(() => props.foo)
+  useSomeFeature(toRef(() => props.foo))
   </script>
   ```
+  When the composable implements accepts a `MaybeRefsOrGetter<T>` through [`toValue`](#tovalue) it is possible to directly use a getter without allocating unnecessary intermediate refs:
+
+  ```vue
+  <script setup>
+  const props = defineProps(/* ... */)
+
+  // more efficient and succinct 
+  useSomeFeature(() => props.foo)
+  </script>
+  ``````
+  
 
   When `toRef` is used with component props, the usual restrictions around mutating the props still apply. Attempting to assign a new value to the ref is equivalent to trying to modify the prop directly and is not allowed. In that scenario you may want to consider using [`computed`](./reactivity-core#computed) with `get` and `set` instead. See the guide to [using `v-model` with components](/guide/components/v-model) for more information.
 
@@ -167,7 +178,12 @@ This can be used in [Composables](/guide/reusability/composables.html) to normal
   useFeature(1)
   useFeature(ref(1))
   useFeature(() => 1)
+
+  // Using props in this composable with a getter function
+  useFeature(() => props.id)
   ```
+
+  
 
 ## toRefs() {#torefs}
 

--- a/src/api/reactivity-utilities.md
+++ b/src/api/reactivity-utilities.md
@@ -124,7 +124,7 @@ Can also be used to create a ref for a property on a source reactive object. The
   useSomeFeature(toRef(props, 'foo'))
 
   // getter syntax - recommended in 3.3+
-  useSomeFeature(toRef(() => props.foo))
+  useSomeFeature(() => props.foo)
   </script>
   ```
 


### PR DESCRIPTION
## Description of Problem

With the addition of `toValue` in vue 3.3, there is a new syntax so we can use getters as reactive data sources.
Here is the announcement. https://blog.vuejs.org/posts/vue-3-3#better-getter-support-with-toref-and-tovalue

The  example used in the this post is :
``` 
// after: more efficient and succinct
useFeature(() => props.foo)
```

In the api docs:
```
// getter syntax - recommended in 3.3+
useSomeFeature(toRef(() => props.foo))
```

Although this section is about `toRef()`, I think users should be guided that there is a new implementation using getters with `toValue`

I think the recommended getter syntax should be `useSomeFeature(() => props.foo)`

## Proposed Solution

Update the docs, please see changes.

Thanks!
