### PR TITLE
fix: get rid of `++` operator in ref example

### DIFF
--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -35,7 +35,7 @@ Takes an inner value and returns a reactive and mutable ref object, which has a 
   const count = ref(0)
   console.log(count.value) // 0
 
-  count.value++
+  count.value = 1
   console.log(count.value) // 1
   ```
 


### PR DESCRIPTION
## Description of Problem

Example showing ref's value update uses `++` operator, I think that assigning new value is more common and personally i think that using `++` operator should be avoided in this kind of examples (unless you want to show that you can use this specific operator in some specific cases)

## Proposed Solution

```diff
- count.value++
+ count.value = 1
```

## Alternative solution

```diff
- count.value++
+ count.value = count.value + 1
```

## Additional comments

There could be also example with objects, like

```js
const data = ref(null)

data.value = { name: 'John Doe' }
```

Let me know if this should be added as well to this PR