### PR TITLE
docs: fix link to vue tsc package

### DIFF
--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -89,7 +89,7 @@ Main article: [Using Vue with TypeScript](/guide/typescript/overview).
 
 - [Volar](https://github.com/johnsoncodehk/volar) provides type checking for SFCs using `<script lang="ts">` blocks, including template expressions and cross-component props validation.
 
-- Use [`vue-tsc`](https://github.com/vuejs/language-tools/tree/master/packages/vue-tsc) for performing the same type checking from the command line, or for generating `d.ts` files for SFCs.
+- Use [`vue-tsc`](https://github.com/vuejs/language-tools/tree/master/packages/tsc) for performing the same type checking from the command line, or for generating `d.ts` files for SFCs.
 
 ## Testing {#testing}
 


### PR DESCRIPTION
## Description of Problem
https://github.com/vuejs/language-tools/tree/master/packages/vue-tsc – returns 404 page

## Proposed Solution
https://github.com/vuejs/language-tools/tree/master/packages/tsc – Updated link

## Additional Information
N/A