### PR TITLE
Events as Props: more details added

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -293,14 +293,14 @@ export default {
 
 You may also declare and pass `events` as `props`, by prefixing the capitalized event name with `on`.
 
-Using `$props.onEvent` has a different behaviour than using `$emit('event')`, as `$props.onEvent` gets the callback function declared as a listener in the parent (either `@event` or `:onEvent`).
+Using `props.onEvent` has a different behaviour than using `emit('event')`, as `props.onEvent` gets the callback function declared as a listener in the parent (either `@event` or `:onEvent`).
 
 :::warning
-If both `:onEvent` and `@event` are passed `$props.onEvent` might be an array of `functions` instead of `function`, this behavior is not stable and might change in the future.
+If both `:onEvent` and `@event` are passed `props.onEvent` might be an array of `functions` instead of `function`, this behavior is not stable and might change in the future.
 
-If no handler is defined, attempting to use `$props.onEvent()` as an emitter will result in a console error.
+If no handler is defined, attempting to use `props.onEvent()` as an emitter will result in a console error.
 
-When passing an event handler as a prop and kebab-case is used (ie: `:on-event`), the handler won't be interpreted when using the `$emit('event')` emitter.
+When passing an event handler as a prop and kebab-case is used (ie: `:on-event`), the handler won't be interpreted when using the `emit('event')` emitter.
 :::
 
-Because of this, it is recommended to use `$emit('event')` instead of `$props.onEvent` when emitting events and declare event listener using event directives as `@event` instead of `:onEvent`.
+Because of this, it is recommended to use `emit('event')` instead of `props.onEvent` when emitting events and declare event listener using event directives as `@event` instead of `:onEvent`.

--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -291,11 +291,16 @@ export default {
 
 ## Events as Props {#events-props}
 
-You may also declare and pass `events` as `props`, by prefixing the capitalized event name with `on`
-Using `props.onEvent` has a different behaviour than using `emit('event')`, as the former will pass only handle the property based listener (either `@event` or `:on-event`)
+You may also declare and pass `events` as `props`, by prefixing the capitalized event name with `on`.
+
+Using `$props.onEvent` has a different behaviour than using `$emit('event')`, as `$props.onEvent` gets the callback function declared as a listener in the parent (either `@event` or `:onEvent`).
 
 :::warning
-If both `:onEvent` and `@event` are passed `props.onEvent` might be an array of `functions` instead of `function`, this behavior is not stable and might change in the future.
+If both `:onEvent` and `@event` are passed `$props.onEvent` might be an array of `functions` instead of `function`, this behavior is not stable and might change in the future.
+
+If no handler is defined, attempting to use `$props.onEvent()` as an emitter will result in a console error.
+
+When passing an event handler as a prop and kebab-case is used (ie: `:on-event`), the handler won't be interpreted when using the `$emit('event')` emitter.
 :::
 
-Because of this, it is recommended to use `emit('event')` instead of `props.onEvent` when emitting events.
+Because of this, it is recommended to use `$emit('event')` instead of `$props.onEvent` when emitting events and declare event listener using event directives as `@event` instead of `:onEvent`.

--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -293,14 +293,14 @@ export default {
 
 You may also declare and pass `events` as `props`, by prefixing the capitalized event name with `on`.
 
-Using `props.onEvent` has a different behaviour than using `emit('event')`, as `props.onEvent` gets the callback function declared as a listener in the parent (either `@event` or `:onEvent`).
+Using `props.onSomeEvent` has a different behaviour than using `emit('someEvent')`, as `props.onSomeEvent` gets the callback function declared as a listener in the parent (either `@someEvent` or `:onSomeEvent`).
 
 :::warning
-If both `:onEvent` and `@event` are passed `props.onEvent` might be an array of `functions` instead of `function`, this behavior is not stable and might change in the future.
+If both `:onSomeEvent` and `@someEvent` are passed, `props.onSomeEvent` might be an array of functions instead of a function, this behavior is not stable and might change in the future.
 
-If no handler is defined, attempting to use `props.onEvent()` as an emitter will result in a console error.
+If no handler is defined, attempting to use `props.onSomeEvent()` as an emitter, will result in a console error.
 
-When passing an event handler as a prop and kebab-case is used (ie: `:on-event`), the handler won't be interpreted when using the `emit('event')` emitter.
+When passing an event handler as a prop, and kebab-case is used (ie: `:on-some-event`), the handler won't be interpreted when using the `emit('someEvent')` emitter.
 :::
 
-Because of this, it is recommended to use `emit('event')` instead of `props.onEvent` when emitting events and declare event listener using event directives as `@event` instead of `:onEvent`.
+Because of this, it is recommended to use `emit('someEvent')` instead of `props.onSomeEvent` when emitting events, and declare event listeners using the event directives as `@someEvent` instead of `:onSomeEvent`.


### PR DESCRIPTION
I wrote different cases [In the Playground](https://play.vuejs.org/#eNqdVcFu2zAM/RXCGOYUTe0BvaVu0HUIsO6wFmuHHeYdHIdJ3NqSIclJiyDfsPtO+4x9z35gvzBKslyncdJ1lyAmH6lHPkpceW/LMlhU6A28SKYiKxVIVFU5jFlWlFwoWIHAKaxhKngBPkH9k8b3jhdl7QhC/aFT+TGLWcqZVDDNBE7gVGfovTmgOGsuBS/lJbvmBY4WyNTNQ4k1yvc1LGbTiqUq4wxQA94nbJKj6JmPvo3XQQermIGFBCoRM1SBVA85BinPuaCU/kwgMs0Y4PDQ0AkWSV6hsXTxsG4KbQ4h6DpmUWjbQ42hD4VFmScK6QugZgdpkudUbjQerlZ16et1FI6HoLICZTQWBm6q5VN4ZU4I+OP5gzq2sz82lU4QzY+HjMO8Pvb3j59/fn2PQrIarxEltP+xGF5MoQXOJExwmjGc9CFRugyVsRkoDpVEiFI+weE2sd5BFBoXJBISEqXIKFbAMstzkk1WuYKMQQJaX54joBBcBFFI5zvGZ9Jlc2SeUH4EnMZeW/bYc+W4NEfGvS+PRexLNGjVtyNTG/JMqqNtWt3CbGJ3ZqXGfZkjgzKRUgukm76RnCZFa2FmxcwY2bXxDsfJ+ChNJBor6U3Ckthqjk3skjNfwRhJM1KxFKhoVJf6uMocprGUqp4GLXYtv0lZi79T3dcbfXOHyp3t2NPifxiJmgP92zG7bnKpE4wr6ph7Wk4gU74Z50SI5IGGWc1hzOnH9ckh5cDdXYAjOO+EUBJ0L0CrlTvbGLRTfn6C3X0BrdQvuYSmS1aqKGy9W17fU5Kg02wW3ErOaAOY1zT2UhImo+Iu6W2gVLE3AOPRPiqQLz8YmxIV9p09nWN612G/lffaFntXxBDFAmOv8dkX27pH1x/xnv43zoJPqpzQe5yfkMqsNEcLO6/q2Whwhu2F2VXU4Bs5ulfIpCtKE9XItcHHHu0uPZO7Sn+kexwcmzhaDNRFt/c6Vqhdd1ooWij23R3Rh+zBV/Cb2fbhGzxZjg38Sn8ZeGsaXED3kqwfiud3IxcJm5l1vn+/RZNs4S7ZuFKKDjxL8yy9o0tpzfU5DYNXNQWzZY2bqu61S+7XGHqYaLnRNtwa+SY69oYmvBV94IafroMh1NBzd+p/iW7fvJfw7Li3nUyj0LZ080Ku/wJ8e0W5) to understand the Events as Props

## Description of Problem
1- It was missing a dot and new line
2- _as the former will pass only handle the property based listener_ sentence was not clear for me
3- _(either `@event` or `:on-event`)_ is using `:kebab-case` instead of `:camelCase`, and it could lend into an issue when using `$emit`(explained in the new warning sentences).

## Proposed Solution
1- Dot and new line added
2- I've tried to rewrite the sentence, maybe you can suggest a better one.
3- `:on-event` replaced with `:onEvent`

## Additional Information
I've found more warings to add