### PR TITLE
docs: add `watchEffect` notes

### DIFF
--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -231,6 +231,9 @@ Takes an object (reactive or plain) or a [ref](#ref) and returns a readonly prox
 
 Runs a function immediately while reactively tracking its dependencies and re-runs it whenever the dependencies are changed.
 
+:::info Usage Note
+`watchEffect` can only observe dependencies that are accessed during its initial execution. If you access reactive states within asynchronous operations, these states will not be collected as dependencies. Similarly, if you access these variables within an `if` statement and the condition is false during the initial execution, these variables will also not be collected as dependencies.
+:::
 - **Type**
 
   ```ts


### PR DESCRIPTION
## Description of Problem

I have observed that users often make some mistakes when using `watchEffect`, such as asynchronously accessing reactive variables, resulting in dependencies not being collected, or having an `if` statement with a false condition during the initial execution, leading to uncollected dependencies. These errors can cause `watchEffect` to malfunction. In this pull request, I have added some notes to help users avoid these mistakes.

## Proposed Solution

## Additional Information

My English is not very good. You can correct my grammar or inaccurate wording at will. I hope it can improve the documentation. Thank you.