### PR TITLE
Update docs on usage of external types in defineProps

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -50,7 +50,7 @@ const props = defineProps<Props>()
 </script>
 ```
 
-This also works if `Props` is imported from an external source. This feature requires TypeScript to be a peer dependency of vue.
+This also works if `Props` is imported from an external source. This feature requires TypeScript to be a peer dependency of Vue.
 
 ```vue
 <script setup lang="ts">

--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -50,6 +50,20 @@ const props = defineProps<Props>()
 </script>
 ```
 
+This also works if `Props` is imported from an external source. 
+
+```vue
+<script setup lang="ts">
+import type { Props } from './foo'
+
+const props = defineProps<Props>()
+</script>
+```
+
+:::info
+This feature requires TypeScript to be a peer dependency of vue.
+:::
+
 #### Syntax Limitations {#syntax-limitations}
 
 In version 3.2 and below, the generic type parameter for `defineProps()` were limited to a type literal or a reference to a local interface.

--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -50,7 +50,7 @@ const props = defineProps<Props>()
 </script>
 ```
 
-This also works if `Props` is imported from an external source. 
+This also works if `Props` is imported from an external source. This feature requires TypeScript to be a peer dependency of vue.
 
 ```vue
 <script setup lang="ts">
@@ -59,10 +59,6 @@ import type { Props } from './foo'
 const props = defineProps<Props>()
 </script>
 ```
-
-:::info
-This feature requires TypeScript to be a peer dependency of vue.
-:::
 
 #### Syntax Limitations {#syntax-limitations}
 


### PR DESCRIPTION
## Description of Problem
The documentation currently lacks explicit reference to the capability of `defineProps` to incorporate types from an external file. 
Also, users should be aware that adding `TypeScript` as a peer dependency is necessary for this feature to work.

## Proposed Solution
Add documentation for when types for `defineProps` are coming from an external file


## Additional Information
