### PR TITLE
chore: remove outdated warning for reactive provide

### DIFF
--- a/src/guide/components/provide-inject.md
+++ b/src/guide/components/provide-inject.md
@@ -315,10 +315,6 @@ export default {
 
 The `computed()` function is typically used in Composition API components, but can also be used to complement certain use cases in Options API. You can learn more about its usage by reading the [Reactivity Fundamentals](/guide/essentials/reactivity-fundamentals) and [Computed Properties](/guide/essentials/computed) with the API Preference set to Composition API.
 
-:::warning Temporary Config Required
-The above usage requires setting `app.config.unwrapInjectedRef = true` to make injections automatically unwrap computed refs. This will become the default behavior in Vue 3.3 and this config is introduced temporarily to avoid breakage. It will no longer be required after 3.3.
-:::
-
 </div>
 
 ## Working with Symbol Keys {#working-with-symbol-keys}


### PR DESCRIPTION
## Description of Problem

The docs still include a warning for temporary config prior Vue 3.3

## Proposed Solution

Remove it

## Additional Information
