### PR TITLE
Correct minor grammatical mistake

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -6,7 +6,7 @@ Components allow us to split the UI into independent and reusable pieces, and th
 
 <!-- https://www.figma.com/file/qa7WHDQRWuEZNRs7iZRZSI/components -->
 
-This is very similar to how we nest native HTML elements, but Vue implements its own component model that allow us to encapsulate custom content and logic in each component. Vue also plays nicely with native Web Components. If you are curious about the relationship between Vue Components and native Web Components, [read more here](/guide/extras/web-components).
+This is very similar to how we nest native HTML elements, but Vue implements its own component model that allows us to encapsulate custom content and logic in each component. Vue also plays nicely with native Web Components. If you are curious about the relationship between Vue Components and native Web Components, [read more here](/guide/extras/web-components).
 
 ## Defining a Component {#defining-a-component}
 


### PR DESCRIPTION
## Description of Problem
The sentence contains a grammatical error as it uses "allow" instead of "allows," causing subject-verb agreement issues.

## Proposed Solution
Replace "allow" with "allows" to maintain proper subject-verb agreement.

## Additional Information
