### PR TITLE
Fix terminology and grammar

### DIFF
--- a/src/tutorial/src/step-5/description.md
+++ b/src/tutorial/src/step-5/description.md
@@ -34,7 +34,7 @@ function onInput(e) {
 
 Try typing in the input box - you should see the text in `<p>` updating as you type.
 
-To simplify two-way bindings, Vue provides a directive, `v-model`, which is essentially a syntax sugar for the above:
+To simplify two-way bindings, Vue provides a directive, `v-model`, which is essentially syntactic sugar for the above:
 
 ```vue-html
 <input v-model="text">


### PR DESCRIPTION
## Description of Problem
In Step 5 of the tutorial, the verbiage "a syntax sugar" is used when referring to `v-model`.

## Proposed Solution
This can be simplified to "syntactic sugar" to make it more grammatically correct, using the correct terminology.

## Additional Information
