### PR TITLE
docs: replaces 'Not available' with 'search'

### DIFF
--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -123,7 +123,7 @@ Users can navigate an application through headings. Having descriptive headings 
 | main            | role="main"          | The main or central content of the document.                                                                     |
 | footer          | role="contentinfo"   | Information about the parent document: footnotes/copyrights/links to privacy statement                           |
 | aside           | role="complementary" | Supports the main content, yet is separated and meaningful on its own content                                    |
-| _Not available_ | role="search"        | This section contains the search functionality for the application                                               |
+| search          | role="search"        | This section contains the search functionality for the application                                               |
 | form            | role="form"          | Collection of form-associated elements                                                                           |
 | section         | role="region"        | Content that is relevant and that users will likely want to navigate to. Label must be provided for this element |
 


### PR DESCRIPTION
## Description of Problem

The landmark table showed "Not available" in the HTML column for the search landmark
![image](https://github.com/vuejs/docs/assets/98567681/d63140ec-ed13-41f7-ad89-48d2317a7d15)

## Proposed Solution
I replaced it to show the `<search>` element, as it already defines the search landmark.
![image](https://github.com/vuejs/docs/assets/98567681/5f9512d4-2c4e-4eab-b47c-7c1310a3ffbb)