### PR TITLE
docs: recommend to use new ES2023 Array method

### DIFF
--- a/src/guide/essentials/list.md
+++ b/src/guide/essentials/list.md
@@ -432,3 +432,10 @@ Be careful with `reverse()` and `sort()` in a computed property! These two metho
 - return numbers.reverse()
 + return [...numbers].reverse()
 ```
+
+Or you can use the copying counterpart of the method such as `toReversed()` and `toSorted()` from the latest ECMAScript 2023:
+
+```diff
+- return numbers.reverse()
++ return numbers.toReversed()
+```


### PR DESCRIPTION
## Description of Problem

The new ES2023 has new array method to modify the array without mutating the original value. Here, we are still showing the traditional method to copy the original array before running the array method like `sort` or `reverse`.

## Proposed Solution

The new method has 12% higher performance: https://jsperf.app/yipiqe

Thus, we can introduce and encourage user to use the newer array method as well.

## Additional Information

Question: Shall we put more information that this method may not work if the user is using older browser and their scripts are not compiled to support latest browser? ex: Typescript >v5.2