### PR TITLE
List transition example fix

### DIFF
--- a/src/examples/src/list-transition/App/composition.js
+++ b/src/examples/src/list-transition/App/composition.js
@@ -14,7 +14,7 @@ export default {
 
     function reset() {
       items.value = getInitialItems()
-      id = getInitialItems().length + 1
+      id = items.value.length + 1
     }
 
     function shuffle() {

--- a/src/examples/src/list-transition/App/composition.js
+++ b/src/examples/src/list-transition/App/composition.js
@@ -14,6 +14,7 @@ export default {
 
     function reset() {
       items.value = getInitialItems()
+      id = getInitialItems().length + 1
     }
 
     function shuffle() {

--- a/src/examples/src/list-transition/App/options.js
+++ b/src/examples/src/list-transition/App/options.js
@@ -16,6 +16,7 @@ export default {
     },
     reset() {
       this.items = getInitialItems()
+      id = getInitialItems().length + 1
     },
     shuffle() {
       this.items = shuffle(this.items)


### PR DESCRIPTION
## Description of Problem
In the [List with transitions example](https://vuejs.org/examples/#list-transition), when you hit `button`, the array will revert to original `[1, 2, 3, 4, 5]`, but the `id` for newly inserted items remains.

So then 7 is inserted instead of logical 6 and so on. You can end up with stuff like that:
![image](https://github.com/vuejs/docs/assets/7399922/23a474d5-0dfd-4bc3-9480-cd25c900f4af)

## Proposed Solution
Would be more logical to reset the `id` value as well.

I added the command to do it in each API variant.

## Additional Information