### PR TITLE
fix: change redirection link

### DIFF
--- a/src/about/team/members-core.json
+++ b/src/about/team/members-core.json
@@ -326,7 +326,7 @@
       },
       {
         "label": "vuequery",
-        "url": "https://github.com/vuequery"
+        "url": "https://github.com/phanan/vuequery"
       },
       {
         "label": "vue-google-signin-button",


### PR DESCRIPTION
Change redirection link from https://github.com/vuequery to https://github.com/phanan/vuequery