### PR TITLE
fix: Update broken link in accessibility.md

### DIFF
--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -503,7 +503,7 @@ W3C's WAI-ARIA provides guidance on how to build dynamic content and advanced us
   - [ChromeVox](https://chrome.google.com/webstore/detail/chromevox-classic-extensi/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en)
 - Zooming Tools
   - [MAGic](https://www.freedomscientific.com/products/software/magic/)
-  - [ZoomText](https://www.zoomtext.com/)
+  - [ZoomText](https://www.freedomscientific.com/products/software/zoomtext/)
   - [Magnifier](https://support.microsoft.com/en-us/help/11542/windows-use-magnifier-to-make-things-easier-to-see)
 
 ### Testing {#testing}


### PR DESCRIPTION
## Description of Problem
Previous link had a redirect to a privacy error, which could be confusing for users.

## Proposed Solution
This adds in the URL that the previous URL was trying to redirect to, which bypasses the privacy error