### PR TITLE
fix: the link address is incorrect after configuring the base URL

### DIFF
--- a/.vitepress/theme/components/Home.vue
+++ b/.vitepress/theme/components/Home.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
+import { withBase } from 'vitepress'
 import SiteMap from './SiteMap.vue'
 // import NewsLetter from './NewsLetter.vue'
 import { load, data, base } from './sponsors'
@@ -24,7 +25,7 @@ onMounted(async () => {
     </p>
     <p class="actions">
       <VueMasteryModal />
-      <a class="get-started" href="/guide/introduction.html">
+      <a class="get-started" :href="withBase('/guide/introduction.html')">
         Get Started
         <svg
           class="icon"
@@ -38,7 +39,7 @@ onMounted(async () => {
           />
         </svg>
       </a>
-      <a class="setup" href="/guide/quick-start.html">Install</a>
+      <a class="setup" :href="withBase('/guide/quick-start.html')">Install</a>
     </p>
   </section>
 

--- a/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/.vitepress/theme/components/PreferenceSwitch.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { VTSwitch, VTIconChevronDown } from '@vue/theme'
-import { useRoute } from 'vitepress'
+import { useRoute, withBase } from 'vitepress'
 import { ref, computed, inject, Ref } from 'vue'
 import {
   preferCompositionKey,
@@ -91,7 +91,7 @@ function useToggleFn(
         <a
           class="switch-link"
           title="About API preference"
-          href="/guide/introduction.html#api-styles"
+          :href="withBase('/guide/introduction.html#api-styles')"
           @click="closeSideBar"
           >?</a
         >
@@ -109,7 +109,7 @@ function useToggleFn(
         <a
           class="switch-link"
           title="About SFC"
-          href="/guide/scaling-up/sfc.html"
+          :href="withBase('/guide/scaling-up/sfc.html')"
           @click="closeSideBar"
           >?</a
         >

--- a/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/.vitepress/theme/components/PreferenceSwitch.vue
@@ -28,12 +28,12 @@ const trimSuffix = (s: string, suffix: string): string => {
   if (s.slice(s.length - suffix.length) === suffix) {
     return s.slice(0, s.length - suffix.length);
   }
-  return s;
+  return s
 }
 
 const { site } = useData()
-const baseWithoutSuffixSlash = trimSuffix(site.value.base, '/');
-const trimBase = (path: string) => trimPrefix(path, baseWithoutSuffixSlash);
+const baseWithoutSuffixSlash = trimSuffix(site.value.base, '/')
+const trimBase = (path: string) => trimPrefix(path, baseWithoutSuffixSlash)
 
 const show = computed(() =>
   /^\/(guide|tutorial|examples|style-guide)\//.test(trimBase(route.path))

--- a/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/.vitepress/theme/components/PreferenceSwitch.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { VTSwitch, VTIconChevronDown } from '@vue/theme'
-import { useRoute, withBase } from 'vitepress'
+import { useRoute, useData, withBase } from 'vitepress'
 import { ref, computed, inject, Ref } from 'vue'
 import {
   preferCompositionKey,
@@ -11,10 +11,34 @@ import {
 import PreferenceTooltip from './PreferenceTooltip.vue'
 
 const route = useRoute()
+
+const trimPrefix = (s: string, prefix: string): string => {
+  if (!prefix || s.length < prefix.length) {
+    return s
+  }
+  if (s.slice(0, prefix.length) === prefix) {
+    return s.slice(prefix.length)
+  }
+  return s
+}
+const trimSuffix = (s: string, suffix: string): string => {
+  if (!suffix || s.length < suffix.length) {
+    return s
+  }
+  if (s.slice(s.length - suffix.length) === suffix) {
+    return s.slice(0, s.length - suffix.length);
+  }
+  return s;
+}
+
+const { site } = useData()
+const baseWithoutSuffixSlash = trimSuffix(site.value.base, '/');
+const trimBase = (path: string) => trimPrefix(path, baseWithoutSuffixSlash);
+
 const show = computed(() =>
-  /^\/(guide|tutorial|examples|style-guide)\//.test(route.path)
+  /^\/(guide|tutorial|examples|style-guide)\//.test(trimBase(route.path))
 )
-const showSFC = computed(() => !/^\/guide|style-guide/.test(route.path))
+const showSFC = computed(() => !/^\/guide|style-guide/.test(trimBase(route.path)))
 
 let isOpen = ref(true)
 

--- a/.vitepress/theme/components/PreferenceTooltip.vue
+++ b/.vitepress/theme/components/PreferenceTooltip.vue
@@ -5,7 +5,7 @@ import {
   preferComposition,
   preferCompositionKey
 } from './preferences'
-import { useData, type Header } from 'vitepress'
+import { useData, withBase, type Header } from 'vitepress'
 
 const show = ref(false)
 const { page } = useData()
@@ -121,7 +121,7 @@ function dismiss() {
         </p>
       </template>
       <p class="actions">
-        <a href="/guide/introduction#api-styles">Learn more</a>
+        <a :href="withBase('/guide/introduction#api-styles')">Learn more</a>
         <button @click="dismiss">Got it</button>
       </p>
       <div class="arrow-top"></div>

--- a/.vitepress/theme/components/SponsorsAside.vue
+++ b/.vitepress/theme/components/SponsorsAside.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import SponsorsGroup from './SponsorsGroup.vue'
-import { useData } from 'vitepress'
+import { useData, withBase } from 'vitepress'
 const { frontmatter } = useData()
 </script>
 
 <template>
   <div v-if="frontmatter.sponsors !== false">
-    <a class="sponsors-aside-text" href="/sponsor/">Sponsors</a>
+    <a class="sponsors-aside-text" :href="withBase('/sponsor/')">Sponsors</a>
     <SponsorsGroup tier="special" />
     <SponsorsGroup tier="platinum" />
   </div>

--- a/.vitepress/theme/components/SponsorsGroup.vue
+++ b/.vitepress/theme/components/SponsorsGroup.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
+import { withBase } from 'vitepress'
 import { SponsorData, data, base, load } from './sponsors'
 
 type Placement = 'aside' | 'page' | 'landing'
@@ -90,7 +91,7 @@ function resolveList(data: SponsorData) {
     </template>
     <a
       v-if="placement !== 'page' && tier !== 'special'"
-      href="/sponsor/"
+      :href="withBase('/sponsor/')"
       class="sponsor-item action"
       @click="track(true)"
       >Become a Sponsor</a

--- a/src/partners/components/PartnerCard.vue
+++ b/src/partners/components/PartnerCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { withBase } from 'vitepress'
 import { Partner } from './type'
 import { normalizeName, getHero, getLogo, track } from './utils'
 import Location from './PartnerLocation.vue'
@@ -19,6 +20,8 @@ const {
   flipLogo,
   website
 } = props.data
+
+const getPartnerLink = withBase('/partners/' + normalizeName(name) + '.html')
 </script>
 
 <template>
@@ -26,7 +29,7 @@ const {
     :is="page ? 'div' : 'a'"
     class="partner-card"
     :class="{ hero, page, flipLogo }"
-    :href="'/partners/' + normalizeName(name) + '.html'"
+    :href="getPartnerLink"
   >
     <div class="info">
       <a :href="website.url" target="_blank" @click="track">

--- a/src/partners/components/PartnerPage.vue
+++ b/src/partners/components/PartnerPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { withBase } from 'vitepress'
 import data from '../partners.json'
 import { Partner } from './type'
 import { normalizeName, track } from './utils'
@@ -23,7 +24,7 @@ function genMailLink(email: string) {
 <template>
   <div class="partner-page">
     <div class="back">
-      <a href="/partners/all.html"
+      <a :href="withBase('/partners/all.html')"
         ><VTIconChevronLeft class="icon" />Back to all partners</a
       >
     </div>


### PR DESCRIPTION
## Description of Problem

Then link address is incorrect after configuring the base URL

When configuring the base URL like below: 
```json
{
    "base": "/base/"
}
```
Correct: `'/base/some-link'`
Incorrect: `'/some-link'`


## Proposed Solution

use `withBase` prepend base URL into the link

## Additional Information
