### PR TITLE
API - Built-in Components - unify "See also" links

### DIFF
--- a/src/api/built-in-components.md
+++ b/src/api/built-in-components.md
@@ -126,7 +126,7 @@ Provides animated transition effects to a **single** element or component.
   </Transition>
   ```
 
-- **See also** [`<Transition>` Guide](/guide/built-ins/transition)
+- **See also** [Guide - Transition](/guide/built-ins/transition)
 
 ## `<TransitionGroup>` {#transitiongroup}
 


### PR DESCRIPTION
## Description of Problem

For each of 5 built-in components there is a link to respective "Guide" page.

While four of them are written like "Guide - Component name":
![image](https://github.com/vuejs/docs/assets/7399922/afc21839-a67a-424a-8cea-cb4c4d1f171d)

The first one for `<Transition>` is different:
![image](https://github.com/vuejs/docs/assets/7399922/c4af7c3e-0c36-4eb7-a109-8c0bff7a1d1a)

## Proposed Solution

Change the displayed text to match the others:
![image](https://github.com/vuejs/docs/assets/7399922/b9e124b0-f0b2-444e-bed7-0693d73fd2bf)

## Additional Information

Alternatively we could change the other 4 texts to be the same as for `<Transition>`, but it is more work, and I don't even think it looks better.
