### PR TITLE
Side note about HTML-mode in Tutorial

### DIFF
--- a/src/tutorial/src/step-1/description.md
+++ b/src/tutorial/src/step-1/description.md
@@ -24,10 +24,10 @@ If you are an experienced developer coming from Vue 2 or other frameworks, there
 <div class="html">
 
 :::tip
-If you're about to use HTML-mode without a build step in your own applications, make sure you either change imports to 
+If you're about to use HTML-mode without a build step in your own applications, make sure you either change imports to:
 
 ```js
-import { * } from vue/dist/vue.esm-bundler.js
+import { ... } from 'vue/dist/vue.esm-bundler.js'
 ```
 
 inside your scripts or configure your build tool to resolve `vue` accordingly. Sample config for [Vite](https://vitejs.dev/):

--- a/src/tutorial/src/step-1/description.md
+++ b/src/tutorial/src/step-1/description.md
@@ -21,6 +21,29 @@ If you are an experienced developer coming from Vue 2 or other frameworks, there
 
 - You can also switch between SFC-mode or HTML-mode. The former will show code examples in <a target="_blank" href="/guide/introduction.html#single-file-components">Single-File Component</a> (SFC) format, which is what most developers use when they use Vue with a build step. HTML-mode shows usage without a build step.
 
+:::tip
+If you're about to use HTML-mode without a build step in your own applications, make sure you either change imports to 
+
+```js
+import { * } from vue/dist/vue.esm-bundler.js
+```
+
+inside your scripts or configure your build tool to resolve `vue` accordingly. Sample config for [Vite](https://vitejs.dev/):
+
+```js
+// vite.config.js
+export default {
+  resolve: {
+      alias: {
+        vue: 'vue/dist/vue.esm-bundler.js'
+      }
+    }
+}
+```
+
+See the respective [section in Tooling guide](/guide/scaling-up/tooling.html#note-on-in-browser-template-compilation) for more information.
+:::
+
 </details>
 
 Ready? Click "Next" to get started.

--- a/src/tutorial/src/step-1/description.md
+++ b/src/tutorial/src/step-1/description.md
@@ -21,6 +21,8 @@ If you are an experienced developer coming from Vue 2 or other frameworks, there
 
 - You can also switch between SFC-mode or HTML-mode. The former will show code examples in <a target="_blank" href="/guide/introduction.html#single-file-components">Single-File Component</a> (SFC) format, which is what most developers use when they use Vue with a build step. HTML-mode shows usage without a build step.
 
+<div class="html">
+
 :::tip
 If you're about to use HTML-mode without a build step in your own applications, make sure you either change imports to 
 
@@ -43,6 +45,8 @@ export default {
 
 See the respective [section in Tooling guide](/guide/scaling-up/tooling.html#note-on-in-browser-template-compilation) for more information.
 :::
+
+</div>
 
 </details>
 

--- a/src/tutorial/src/step-1/description.md
+++ b/src/tutorial/src/step-1/description.md
@@ -34,10 +34,10 @@ inside your scripts or configure your build tool to resolve `vue` accordingly. S
 // vite.config.js
 export default {
   resolve: {
-      alias: {
-        vue: 'vue/dist/vue.esm-bundler.js'
-      }
+    alias: {
+      vue: 'vue/dist/vue.esm-bundler.js'
     }
+  }
 }
 ```
 


### PR DESCRIPTION
## Description of Problem

A follow-up to #2627

As a newcommer (and then me as well) got confused about using Vue directly in HTML without a build step, I think there should be more info about this topic to make Tutorial more friendly and help new developers to avoid pitfalls.

## Proposed Solution

Add "Tip" section with some clarification.

The box is placed inside `Tutorial Setting Details` inside `/tutorial/#step-1` which is folded by default and only shows when user actively clicks on it.

## Additional Information

I am not sure about the form, so I am more than happy to read the feedback and change the wording as necessary.
