### PR TITLE
Document long-form checkbox bindings

### DIFF
--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -126,6 +126,12 @@ Single checkbox, boolean value:
   <label for="checkbox-demo">{{ checked }}</label>
 </div>
 
+The v-model is equivalent to:
+
+```vue-html
+<input type="checkbox" id="checkbox" :checked="checked" @input="checked = $event.target.checked" />
+```
+
 <div class="composition-api">
 
 [Try it in the Playground](https://play.vuejs.org/#eNpVjssKgzAURH/lko3tonVfotD/yEaTKw3Ni3gjLSH/3qhUcDnDnMNk9gzhviRkD8ZnGXUgmJFS6IXTNvhIkCHiBAWm6C00ddoIJ5z0biaQL5RvVNCtmwvFhFfheLuLqqIGQhvMQLgm4tqFREDfgJ1gGz36j2Cg1TkvN+sVmn+JqnbtrjDDiAYmH09En/PxphTebqsK8PY4wMoPslBUxQ==)


### PR DESCRIPTION
I couldn't find anywhere in the docs that spelled this out. I expected to use `:value`, not `:checked`, because that's what's listed on https://vuejs.org/guide/components/v-model.html#under-the-hood

In the end I had to look on StackOverflow instead of the docs. This is one of the places I went to look before I did that, so hopefully this is a good place for others to find it.