### PR TITLE
chore: remove shikiji workaround

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -711,6 +711,7 @@ export default defineConfigWithTheme<ThemeConfig>({
   },
 
   markdown: {
+    theme: 'github-dark',
     config(md) {
       md.use(headerPlugin)
       // .use(textAdPlugin)

--- a/.vitepress/theme/styles/index.css
+++ b/.vitepress/theme/styles/index.css
@@ -4,8 +4,3 @@
 @import "./inline-demo.css";
 @import "./utilities.css";
 @import "./style-guide.css";
-
-/* vitepress rc.31 migrated to shijiki and need this to apply code styles */
-.vp-code span {
-  color: var(--shiki-dark, inherit);
-}


### PR DESCRIPTION
If Vue docs only use one code theme, we could explicitly specify that, and there is no CSS required (also save some bits as we never use the light theme).