### PR TITLE
Wrong comment in the description of the setup

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -99,7 +99,7 @@ To access refs in a component's template, declare and return them from a compone
 import { ref } from 'vue'
 
 export default {
-  // `setup` is a special hook dedicated for the Composition API.
+  // `setup` is a special hook dedicated for the Options API.
   setup() {
     const count = ref(0)
 


### PR DESCRIPTION
## Description of Problem
This comment should be referencing the setup() method of the OptionsAPI() 

## Proposed Solution
Changed comment.

## Additional Information