### PR TITLE
fix: add missings anchors

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -335,7 +335,7 @@ Similar to component updates, user-created watcher callbacks are batched to avoi
 
 By default, a watcher's callback is called **after** parent component updates (if any), and **before** the owner component's DOM updates. This means if you attempt to access the owner component's own DOM inside a watcher callback, the DOM will be in a pre-update state.
 
-### Post Watchers
+### Post Watchers {#post-watchers}
 
 If you want to access the owner component's DOM in a watcher callback **after** Vue has updated it, you need to specify the `flush: 'post'` option:
 
@@ -379,7 +379,7 @@ watchPostEffect(() => {
 
 </div>
 
-### Sync Watchers
+### Sync Watchers {#sync-watchers}
 
 It's also possible to create a watcher that fires synchronously, before any Vue-managed updates:
 

--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -577,7 +577,7 @@ JSX equivalent:
 
 Passing slots as functions allows them to be invoked lazily by the child component. This leads to the slot's dependencies being tracked by the child instead of the parent, which results in more accurate and efficient updates.
 
-### Scoped Slots
+### Scoped Slots {#scoped-slots}
 
 To render a scoped slot in the parent component, a slot is passed to the child. Notice how the slot now has a parameter `text`. The slot will be called in the child component and the data from the child component will be passed up to the parent component.
 


### PR DESCRIPTION
## Description of Problem

For translating purpose, there is missing anchors.
I guess, we should write somewhere to think about those missing anchors because it's the 3rd time I spot this situation.
