### PR TITLE
Update event-handling.md to avoid horizontal scrolling

### DIFF
--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -257,8 +257,9 @@ Order matters when using modifiers because the relevant code is generated in the
 The `.capture`, `.once`, and `.passive` modifiers mirror the [options of the native `addEventListener` method](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options):
 
 ```vue-html
-<!-- use capture mode when adding the event listener -->
-<!-- i.e. an event targeting an inner element is handled here before being handled by that element -->
+<!-- use capture mode when adding the event listener     -->
+<!-- i.e. an event targeting an inner element is handled -->
+<!-- here before being handled by that element           -->
 <div @click.capture="doThis">...</div>
 
 <!-- the click event will be triggered at most once -->


### PR DESCRIPTION
comment lines are being splitted to avoid horizontal scrolling as in a comment right after

## Description of Problem
![ScreenCap horizontal scrolling](https://github.com/vuejs/docs/assets/3853621/5f61fc5b-bfdd-4ca9-9064-ef0ff0d65c0f)
the comment is in one line and right after there is another comment in 3 lines that avoid horizontal scrolling

## Proposed Solution
Split the comment in two lines

## Additional Information