### PR TITLE
fix: transition nested example

### DIFF
--- a/src/guide/built-ins/transition-demos/NestedTransitions.vue
+++ b/src/guide/built-ins/transition-demos/NestedTransitions.vue
@@ -24,6 +24,7 @@ const show = ref(true)
 
 .transition-demo-inner {
   background: #ccc;
+  color: rgb(33, 53, 71);
 }
 
 .nested-enter-active,


### PR DESCRIPTION
## Description of Problem
[Nested Transitions](https://vuejs.org/guide/built-ins/transition.html#nested-transitions-and-explicit-transition-durations) example color is not suitable in the dark theme

![Screenshot_2024-01-27_17_19_07](https://github.com/vuejs/docs/assets/17986464/a1f25a91-3284-443e-95eb-b24a3f650a28)

## Proposed Solution
I added the color that is in light theme directly in its style

![Screenshot_2024-01-27_18_21_22](https://github.com/vuejs/docs/assets/17986464/24366885-2872-4cb6-8640-e193ffc134c4)

## Additional Information
