### PR TITLE
fix: slots.md link to Dynamic Argument Syntax Constraints

### DIFF
--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -313,7 +313,7 @@ function BaseLayout(slots) {
 </base-layout>
 ```
 
-Do note the expression is subject to the [syntax constraints](/guide/essentials/template-syntax#directives) of dynamic directive arguments.
+Do note the expression is subject to the [syntax constraints](/guide/essentials/template-syntax.md#dynamic-argument-syntax-constraints) of dynamic directive arguments.
 
 ## Scoped Slots {#scoped-slots}
 


### PR DESCRIPTION
## Description of Problem
The link talks about syntax constraints of dynamic directive arguments, but points to Directives [#directives](https://vuejs.org/guide/essentials/template-syntax#directives)

## Proposed Solution
Change link to Dynamic Argument Syntax Constraints [#dynamic-argument-syntax-constraints](https://vuejs.org/guide/essentials/template-syntax#dynamic-argument-syntax-constraints)