### PR TITLE
Update v-model.md

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -209,7 +209,11 @@ const title = defineModel('title', { required: true })
 ```vue
 <!-- MyComponent.vue -->
 <script setup>
-defineProps(['title'])
+defineProps({
+  title: {
+    required: true 
+  }
+})
 defineEmits(['update:title'])
 </script>
 


### PR DESCRIPTION
the pre 3.4 usage of `defineModel('title', { required: true })` is missing the `required: true` property

## Description of Problem

In the pre 3.4 usage code of `defineModel('title', { required: true })`, the `required: true` property is missing

## Proposed Solution

Changed `defineProps(['title'])` to 
``` js
defineProps({
  title: {
    required: true 
  }
})
```