### PR TITLE
docs: add Error type on defineProps

### DIFF
--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -519,6 +519,7 @@ The `type` can be one of the following native constructors:
 - `Date`
 - `Function`
 - `Symbol`
+- `Error`
 
 In addition, `type` can also be a custom class or constructor function and the assertion will be made with an `instanceof` check. For example, given the following class:
 


### PR DESCRIPTION
- I propose to add Error Type on defineProps docs


- regarding code: https://github.com/vuejs/core/blob/v3.3.8/packages/compiler-sfc/__tests__/compileScript/__snapshots__/defineProps.spec.ts.snap#L235

## Description of Problem

## Proposed Solution

## Additional Information
