### PR TITLE
docs: add once option on watcher

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -291,6 +291,7 @@ export default {
   }
 }
 ```
+
 </div>
 
 <div class="composition-api">

--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -272,6 +272,41 @@ watch(
 
 </div>
 
+
+## Once Watchers <sup class="vt-badge" data-text="3.4+" /> {#once-watchers}
+
+Watcher's callback will execute whenever the watched source changes. If you want the callback to trigger only once when the source changes, use the `once: true` option.
+
+<div class="options-api">
+  
+```js
+export default {
+  watch: {
+    source: {
+      handler(newValue, oldValue) {
+        // when `source` changes, triggers only once
+      },
+      once: true
+    }
+  }
+}
+```
+</div>
+
+<div class="composition-api">
+
+```js
+watch(
+  source,
+  (newValue, oldValue) => {
+    // when `source` changes, triggers only once
+  },
+  { once: true }
+)
+```
+
+</div>
+
 <div class="composition-api">
 
 ## `watchEffect()` \*\* {#watcheffect}


### PR DESCRIPTION
Vue(v3.4) is provide once option on watcher([commit link](https://github.com/vuejs/core/commit/a645e7aa51006516ba668b3a4365d296eb92ee7d), [discussion link](https://github.com/vuejs/core/pull/9034)) 

I propose to add once option description on watcher
