### PR TITLE
fix: Script Setup Does Not Populate Name Property

### DIFF
--- a/src/api/options-misc.md
+++ b/src/api/options-misc.md
@@ -29,7 +29,7 @@ Explicitly declare a display name for the component.
   There is one case where `name` is explicitly necessary: when matching against cacheable components in [`<KeepAlive>`](/guide/built-ins/keep-alive) via its `include / exclude` props.
 
   :::tip
-  Since version 3.2.34, a single-file component using `<script setup>` will automatically infer its `name` option based on the filename, removing the need to manually declare the name even when used with `<KeepAlive>`.
+  Since version 3.2.34, a single-file component using `<script setup>` will automatically infer its `name` option based on the filename, removing the need to manually declare the name even when used with `<KeepAlive>`.  If you need access to this property, please use [__name](https://github.com/vuejs/core/issues/10348#issuecomment-1951604644).
   :::
 
 ## inheritAttrs {#inheritattrs}

--- a/src/guide/built-ins/keep-alive.md
+++ b/src/guide/built-ins/keep-alive.md
@@ -74,7 +74,7 @@ By default, `<KeepAlive>` will cache any component instance inside. We can custo
 The match is checked against the component's [`name`](/api/options-misc#name) option, so components that need to be conditionally cached by `KeepAlive` must explicitly declare a `name` option.
 
 :::tip
-Since version 3.2.34, a single-file component using `<script setup>` will automatically infer its `name` option based on the filename, removing the need to manually declare the name.
+Since version 3.2.34, a single-file component using `<script setup>` will automatically infer its `name` option based on the filename, removing the need to manually declare the name.  If you need access to this property, please use [__name](https://github.com/vuejs/core/issues/10348#issuecomment-1951604644).
 :::
 
 ## Max Cached Instances {#max-cached-instances}


### PR DESCRIPTION
#[10348](https://github.com/vuejs/core/issues/10348):
- Adding clarification on how to access `name` property in script setup

## Description of Problem

In `script setup`, the `name` property does not get created, per [here](https://github.com/vuejs/core/issues/10348#issuecomment-1951604644).

## Proposed Solution

In order to help clarify what can be used, it makes sense to add a reference to `__name` to help devs that need access to the component's name in `script setup`.

## Additional Information

[Original PR](https://github.com/vuejs/core/commit/9734b31c312244a2b5c5cf83c75d7b34076a0c4b) that introduced `__name`