### PR TITLE
docs: improve the description of beforeCreate

### DIFF
--- a/src/api/options-lifecycle.md
+++ b/src/api/options-lifecycle.md
@@ -18,7 +18,9 @@ Called when the instance is initialized.
 
 - **Details**
 
-  Called immediately when the instance is initialized, after props resolution, before processing other options such as `data()` or `computed`.
+  Called immediately when the instance is initialized and props are resolved .
+
+  Then the props will be defined as reactive properties and the state such as `data()` or `computed` will be set up.
 
   Note that the `setup()` hook of Composition API is called before any Options API hooks, even `beforeCreate()`.
 


### PR DESCRIPTION
## Description of Problem
#2706
The description of `beforeCreate` is some ambiguous and can lead to misunderstanding, because the `initProps` is called after `beforeCreate` and the document only mention `beforeCreate` is called after the props resolution.

## Proposed Solution
Add the description that after `beforeCreate` the props will be defined as reactive properties and the state such as `data()` or `computed` will be set up.
## Additional Information
