### PR TITLE
docs: add missing comments to the Options API in the transition page

### DIFF
--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -407,6 +407,8 @@ export default {
 
     // called when the enter transition has finished.
     onAfterEnter(el) {},
+
+    // called when the enter transition is cancelled before completion.
     onEnterCancelled(el) {},
 
     // called before the leave hook.


### PR DESCRIPTION
## Description of Problem

the Options API in the transition page is missing the comment for onEnterCancelled().

Options API:
![image](https://github.com/vuejs/docs/assets/47178158/b67314a9-be56-4c92-9a4c-1385c1fede35)
Composition API:
![image](https://github.com/vuejs/docs/assets/47178158/adde16dd-2b90-429a-8afa-7be9f44230d4)

## Proposed Solution

add the same comment as the Composition API's onEnterCancelled().

## Additional Information
