### PR TITLE
fix: missing lang="ts" in code snippet

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -182,7 +182,7 @@ The `emits` option and `defineEmits()` macro also support an object syntax. If u
 <div class="composition-api">
 
 ```vue
-<script setup>
+<script setup lang="ts">
 const emit = defineEmits({
   submit(payload: { email: string, password: string }) {
     // return `true` or `false` to indicate


### PR DESCRIPTION
## Description of Problem

As noticed in #2720, one of the code snippets in `guide/components/events.md` is missing `lang="ts"`, making it essentially invalid for Vue - Official extension in TS.

![image](https://github.com/vuejs/docs/assets/7399922/a99b8377-a110-49ad-8125-62b19700b865)

## Proposed Solution

Added attribute to the place

## Additional Information

Didn't noticed any other place, where `lang="ts"` should also be added. Snippets using TS features alredy have it.
