### PR TITLE
Fix "Hydration" typo

### DIFF
--- a/src/api/compile-time-flags.md
+++ b/src/api/compile-time-flags.md
@@ -26,7 +26,7 @@ See [Configuration Guides](#configuration-guides) on how to configure them depen
 
   Enable / disable devtools support in production builds. This will result in more code included in the bundle, so it is recommended to only enable this for debugging purposes.
 
-## `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__` <sup class="vt-badge" data-text="3.4+" /> {#VUE_PROD_HYDRATATION_MISMATCH_DETAILS}
+## `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__` <sup class="vt-badge" data-text="3.4+" /> {#VUE_PROD_HYDRATION_MISMATCH_DETAILS}
 
 - **Default:** `false`
 


### PR DESCRIPTION
## Description of Problem

"Hydration" was misspelled in the `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__` anchor link.  

```diff
- VUE_PROD_HYDRATATION_MISMATCH_DETAILS
+ VUE_PROD_HYDRATION_MISMATCH_DETAILS
```

## Proposed Solution

Correct "Hydration" spelling
