### PR TITLE
Renamed GreenSock to GSAP + updated link

### DIFF
--- a/src/guide/built-ins/transition-group.md
+++ b/src/guide/built-ins/transition-group.md
@@ -102,7 +102,7 @@ By communicating with JavaScript transitions through data attributes, it's also 
 </TransitionGroup>
 ```
 
-Then, in JavaScript hooks, we animate the element with a delay based on the data attribute. This example is using the [GreenSock library](https://greensock.com/) to perform the animation:
+Then, in JavaScript hooks, we animate the element with a delay based on the data attribute. This example is using the [GSAP library](https://gsap.com/) to perform the animation:
 
 ```js{5}
 function onEnter(el, done) {

--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -450,7 +450,7 @@ When using JavaScript-only transitions, it is usually a good idea to add the `:c
 
 With `:css="false"`, we are also fully responsible for controlling when the transition ends. In this case, the `done` callbacks are required for the `@enter` and `@leave` hooks. Otherwise, the hooks will be called synchronously and the transition will finish immediately.
 
-Here's a demo using the [GreenSock library](https://greensock.com/) to perform the animations. You can, of course, use any other animation library you want, for example [Anime.js](https://animejs.com/) or [Motion One](https://motion.dev/).
+Here's a demo using the [GSAP library](https://gsap.com/) to perform the animations. You can, of course, use any other animation library you want, for example [Anime.js](https://animejs.com/) or [Motion One](https://motion.dev/).
 
 <JsHooks />
 


### PR DESCRIPTION
## Description of Problem

"GreenSock" CSS library is now widely referenced as "GSAP", also the link changed accordingly

## Proposed Solution

Update the two mentions on `<Transition>` and `<TransitionGroup>` pages

## Additional Information
