### PR TITLE
Internal link to compile time flags

### DIFF
--- a/src/guide/best-practices/production-deployment.md
+++ b/src/guide/best-practices/production-deployment.md
@@ -27,7 +27,7 @@ Projects scaffolded via `create-vue` (based on Vite) or Vue CLI (based on webpac
 If using a custom setup, make sure that:
 
 1. `vue` resolves to `vue.runtime.esm-bundler.js`.
-2. The [compile time feature flags](https://github.com/vuejs/core/tree/main/packages/vue#bundler-build-feature-flags) are properly configured.
+2. The [compile time feature flags](/api/compile-time-flags) are properly configured.
 3. <code>process.env<wbr>.NODE_ENV</code> is replaced with `"production"` during build.
 
 Additional references:

--- a/src/guide/extras/composition-api-faq.md
+++ b/src/guide/extras/composition-api-faq.md
@@ -114,7 +114,7 @@ Since 3.3 you can directly use `defineOptions` in `<script setup>` to set the co
 
 :::
 
-If you intend to exclusively use Composition API (along with the options listed above), you can shave a few kbs off your production bundle via a [compile-time flag](https://github.com/vuejs/core/tree/main/packages/vue#bundler-build-feature-flags) that drops Options API related code from Vue. Note this also affects Vue components in your dependencies.
+If you intend to exclusively use Composition API (along with the options listed above), you can shave a few kbs off your production bundle via a [compile-time flag](/api/compile-time-flags) that drops Options API related code from Vue. Note this also affects Vue components in your dependencies.
 
 ### Can I use both APIs in the same component? {#can-i-use-both-apis-in-the-same-component}
 


### PR DESCRIPTION
## Description of Problem

There are two places, where docs mention compile time flags and link [GitHub readme file](https://github.com/vuejs/core/tree/main/packages/vue#bundler-build-feature-flags). But some time ago an internal [docs page about Compile time flags](https://vuejs.org/api/compile-time-flags) was added. I believe, it is better to link this page - it has more info + examples + is translated

## Proposed Solution

Change links accordingly

## Additional Information
