### PR TITLE
Update config.ts to restore Style-Guide to nav

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -15,7 +15,7 @@ const nav: ThemeConfig['nav'] = [
       { text: 'Tutorial', link: '/tutorial/' },
       { text: 'Examples', link: '/examples/' },
       { text: 'Quick Start', link: '/guide/quick-start' },
-      // { text: 'Style Guide', link: '/style-guide/' },
+      { text: 'Style Guide', link: '/style-guide/' },
       { text: 'Glossary', link: '/glossary/' },
       { text: 'Error Reference', link: '/error-reference/' },
       {


### PR DESCRIPTION
It appears the style-guide nav was removed two years ago in preparation for migration from v2 to v3 but never restored.

## Description of Problem

Style Guide was not easily searchable in docs.

## Proposed Solution

Restore Style-Guide path to nav

## Additional Information
