### PR TITLE
docs: fix update theme property to a reactive property

### DIFF
--- a/src/api/sfc-css-features.md
+++ b/src/api/sfc-css-features.md
@@ -183,9 +183,10 @@ The syntax works with [`<script setup>`](./sfc-script-setup), and supports JavaS
 
 ```vue
 <script setup>
-const theme = {
-  color: 'red'
-}
+import { ref, reactive } from 'vue'
+const theme = reactive({
+    color: 'red',
+})
 </script>
 
 <template>


### PR DESCRIPTION
Update theme to reactive  property

## Description of Problem

Theme should be a reactive property before you can use v-bind in css.

## Proposed Solution

## Additional Information
