### PR TITLE
docs: added conditional slots section in slots guide

### DIFF
--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -296,6 +296,35 @@ function BaseLayout(slots) {
 }
 ```
 
+## Conditional Slots
+
+Sometimes you want to render something based on whether or not a slot is present. 
+
+You can use the [$slots](https://vuejs.org/api/component-instance.html#slots) property in combination with a [v-if](https://vuejs.org/guide/essentials/conditional.html#v-if) to achieve this.
+
+In the example below we define a Card component with two conditional slots: `header` and `footer`.
+When the header / footer is present we want wrap them to provide additional styling:
+
+```vue-html
+<template>
+  <div class="card">
+    <div v-if="$slots.header" class="card-header">
+      <slot name="header" />
+    </div>
+    
+    <div class="card-content">
+      <slot />
+    </div>
+    
+    <div v-if="$slots.footer" class="card-footer">
+      <slot name="footer" />
+    </div>
+  </div>
+</template>
+```
+
+[Try it in the Playground](https://play.vuejs.org/#eNqFVD1v2zAQ/SsEWyBLIjVoJlcN0AYZ2qEt2oxaaOkkMaZIgqRcGYH/e4+kqFi26wAejvfevfu0XugXrbPtAHRFC1sZrh2x4AZ9X0rea2UceWCmJo1RPbnKcv/w9KtSFnnkIxMfDnotmAN8EVJ4WrDQTgh51wGrwUx+RLrb+6eOW4I/1wGJcJGjewrND1RP1Gpo2CB8+klOL9QqJR1IV+S+lbfVGqXcYW3QL9QiXOToPqPmn1PLCz+9ps5iIQ1vs2erJA75xbNLWqlecwHmp3ZcSVvSFQmIx5gQ6u/34HNmgOvkrzqoNmf8z3b0vpL+MmDBbKGkM+aYacFF+PHPDxjRnsFe1YNA9gXwN1glBl9jpH0dZI1lH/BCtd/CqXDZPtnHEcduU1O+UM/cB35J8XQeLrT+Wu7H7C7ElXKPU0xn5690Ofeab0klmLWfcUDIKmlakEe2N7xB4L0VytksHlhJFwE3yfu6e88mkvWAlDkmnxePwpN9kGkhOd3eieYbGstq48kdV5u856udY04zJevob1BYtxNxlplPkHaxVgb7XpFbPRI8AV6TtWDV5lNENatr3PaKfAgO3NIsMM1z1sGg1ig8G5yKUKhoN7u1GOBY6U6Pp1rTIJPYZXJs/v+JBW871xq2u5g6fNjCTOj+H/sTpqs=)
+
 ## Dynamic Slot Names {#dynamic-slot-names}
 
 [Dynamic directive arguments](/guide/essentials/template-syntax.md#dynamic-arguments) also work on `v-slot`, allowing the definition of dynamic slot names:


### PR DESCRIPTION
## Description of Problem

The guide section of slots does not show how to do conditional slots.

## Proposed Solution

I've added a section on how to use slots conditionally with a card
example and a link to a playground.

Here you can see it in action:

https://deploy-preview-2751--vuejs.netlify.app/guide/components/slots.html#conditional-slots
