### PR TITLE
docs: adjust punctuation in /src/guide/built-ins/transition.md.

### DIFF
--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -450,7 +450,7 @@ When using JavaScript-only transitions, it is usually a good idea to add the `:c
 
 With `:css="false"`, we are also fully responsible for controlling when the transition ends. In this case, the `done` callbacks are required for the `@enter` and `@leave` hooks. Otherwise, the hooks will be called synchronously and the transition will finish immediately.
 
-Here's a demo using the [GSAP library](https://gsap.com/) to perform the animations. You can, of course, use any other animation library you want, for example [Anime.js](https://animejs.com/) or [Motion One](https://motion.dev/).
+Here's a demo using the [GSAP library](https://gsap.com/) to perform the animations. You can, of course, use any other animation library you want, for example [Anime.js](https://animejs.com/) or [Motion One](https://motion.dev/):
 
 <JsHooks />
 
@@ -587,7 +587,7 @@ You can also apply different behavior in JavaScript transition hooks based on th
 
 Sometimes you need to force the re-render of a DOM element in order for a transition to occur.
 
-Take this counter component for example.
+Take this counter component for example:
 
 <div class="composition-api">
 


### PR DESCRIPTION
## Description of Problem

[/src/guide/built-ins/transition.md] 
some sentences need punctuation adjustments at the end.
![image](https://github.com/vuejs/docs/assets/47178158/132eb0f0-9cab-41c7-99af-efcdbb826a6e)
![image](https://github.com/vuejs/docs/assets/47178158/c7343906-87be-4e00-aaae-2c35a601ae19)

## Proposed Solution

change the symbol from 【.】 to 【:】

## Additional Information

![image](https://github.com/vuejs/docs/assets/47178158/e3c35783-67c6-4ba4-9011-bb08b09828ba)
![image](https://github.com/vuejs/docs/assets/47178158/64ae6cd1-0414-4d05-9a57-131a09751dfe)


