### PR TITLE
docs: fix 'see also' for provide/inject API page

### DIFF
--- a/src/api/composition-api-dependency-injection.md
+++ b/src/api/composition-api-dependency-injection.md
@@ -102,6 +102,10 @@ Injects a value provided by an ancestor component or the application (via `app.p
   const baz = inject('factory', () => new ExpensiveObject(), true)
   </script>
   ```
+  
+- **See also**
+  - [Guide - Provide / Inject](/guide/components/provide-inject)
+  - [Guide - Typing Provide / Inject](/guide/typescript/composition-api#typing-provide-inject) <sup class="vt-badge ts" />
 
 ## hasInjectionContext() <sup class="vt-badge" data-text="3.3+" /> {#has-injection-context}
 
@@ -112,7 +116,3 @@ Returns true if [inject()](#inject) can be used without warning about being call
   ```ts
   function hasInjectionContext(): boolean
   ```
-
-* **See also**
-  - [Guide - Provide / Inject](/guide/components/provide-inject)
-  - [Guide - Typing Provide / Inject](/guide/typescript/composition-api#typing-provide-inject) <sup class="vt-badge ts" />


### PR DESCRIPTION
## Description of Problem

I believe second "See also" on https://vuejs.org/api/composition-api-dependency-injection logically belongs to **#inject()** section. Few months ago, new section for **hasInjectionContext()** was inserted and broke this logical bond. But since it is only a true/false indicator, I don't think further info, especially about TypeScript, is relevant to it.

## Proposed Solution

Move "See also" links to appropriate place

## Additional Information
