### PR TITLE
update: required node version

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -21,7 +21,7 @@ import { VTCodeGroup, VTCodeGroupTab } from '@vue/theme'
 :::tip Prerequisites
 
 - Familiarity with the command line
-- Install [Node.js](https://nodejs.org/) version 18.13 or higher
+- Install [Node.js](https://nodejs.org/) version 18.12 or higher
   :::
 
 In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vitejs.dev) and allow us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -21,7 +21,7 @@ import { VTCodeGroup, VTCodeGroupTab } from '@vue/theme'
 :::tip Prerequisites
 
 - Familiarity with the command line
-- Install [Node.js](https://nodejs.org/) version 18.12 or higher
+- Install [Node.js](https://nodejs.org/) version 18.11 or higher
   :::
 
 In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vitejs.dev) and allow us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -21,7 +21,7 @@ import { VTCodeGroup, VTCodeGroupTab } from '@vue/theme'
 :::tip Prerequisites
 
 - Familiarity with the command line
-- Install [Node.js](https://nodejs.org/) version 18.11 or higher
+- Install [Node.js](https://nodejs.org/) version 18.3 or higher
   :::
 
 In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vitejs.dev) and allow us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -21,7 +21,7 @@ import { VTCodeGroup, VTCodeGroupTab } from '@vue/theme'
 :::tip Prerequisites
 
 - Familiarity with the command line
-- Install [Node.js](https://nodejs.org/) version 18.0 or higher
+- Install [Node.js](https://nodejs.org/) version 18.13 or higher
   :::
 
 In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vitejs.dev) and allow us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).


### PR DESCRIPTION
## Description of Problem

vue-cli relies on a more up-to-date Node.js version since v3.10 (now it's using parseArgs from node:util):
— https://github.com/vuejs/create-vue/releases/tag/v3.10.0
— https://github.com/vuejs/create-vue/issues/469

## Proposed Solution

Update required node version to greater than 18.11

## Additional Information

Based on Node.js changelog, the value should be 18.11 https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2022-10-13-version-18110-current-danielleadams