### PR TITLE
Add translation link to ru.vuejs.org

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -670,6 +670,11 @@ export default defineConfigWithTheme<ThemeConfig>({
         repo: 'https://github.com/vuejs-translations/docs-it'
       },
       {
+        link: 'https://ru.vuejs.org',
+        text: 'Русский',
+        repo: 'https://github.com/translation-gang/docs-ru'
+      },
+      {
         link: '/translations/',
         text: 'Help Us Translate!',
         isTranslationsDesc: true

--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -16,7 +16,6 @@ aside: false
 - [বাংলা / Bengali](https://bn.vuejs.org) [[source](https://github.com/vuejs-translations/docs-bn)]
 - [Italiano / Italian](https://it.vuejs.org) [[source](https://github.com/vuejs-translations/docs-it)]
 - [فارسی / Persian](https://fa.vuejs.org) [[source](https://github.com/vuejs-translations/docs-fa)]
-
 - [Русский / Russian](https://ru.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-ru)]
 
 ## Work in Progress Languages {#work-in-progress-languages}

--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -17,6 +17,8 @@ aside: false
 - [Italiano / Italian](https://it.vuejs.org) [[source](https://github.com/vuejs-translations/docs-it)]
 - [فارسی / Persian](https://fa.vuejs.org) [[source](https://github.com/vuejs-translations/docs-fa)]
 
+- [Русский / Russian](https://ru.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-ru)]
+
 ## Work in Progress Languages {#work-in-progress-languages}
 
 - [Čeština / Czech](https://cs.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-cs)]


### PR DESCRIPTION
## Description of Problem

Hello @yyx990803 and @bencodezen, i am a member of the organization [translation-gang](https://github.com/translation-gang/docs-ru).

We have finished translating the documentation into Russian and would like to place a link to the official website of the documentation with the translation, as well as link the domain https://ru.vuejs.org/ for https://vuejs-doc-ru.vercel.app/.

You can help with the domain and consider this PR?

PS: Added additional information here https://github.com/vuejs/docs/issues/478#issuecomment-1943122897

Repository: https://github.com/vuejs-translations/docs-ru

Discussion: https://github.com/orgs/vuejs-translations/discussions/12#discussioncomment-8756236