### PR TITLE
fix: ExtractPublicPropTypes is only supported in 3.3+.

### DIFF
--- a/src/api/utility-types.md
+++ b/src/api/utility-types.md
@@ -79,6 +79,8 @@ To extract public facing props, i.e. props that the parent is allowed to pass, u
 
 Extract prop types from a runtime props options object. The extracted types are public facing - i.e. the props that the parent is allowed to pass.
 
+- Only supported in 3.3+.
+
 - **Example**
 
   ```ts


### PR DESCRIPTION
## Description of Problem
`ExtractPublicPropTypes` is only supported in 3.3+.

see https://github.com/vuejs/core/blob/main/changelogs/CHANGELOG-3.3.md#330-rurouni-kenshin-2023-05-11

## Proposed Solution
Update the docs utility-types.md

## Additional Information
