### PR TITLE
fix: link to "Show and tell" forum

### DIFF
--- a/src/about/community-guide.md
+++ b/src/about/community-guide.md
@@ -35,7 +35,7 @@ Our [Code of Conduct](/about/coc) is a guide to make it easier to enrich all of 
 - [The Awesome Vue Page](https://github.com/vuejs/awesome-vue): See what other awesome resources have been published by other awesome people.
 - [Vue Telescope Explorer](https://vuetelescope.com/explore): Explore websites made with Vue, with insights on what framework / libraries they use.
 - [Made with Vue.js](https://madewithvuejs.com/): showcases of projects and libraries made with Vue.
-- [The "Show and Tell" Subforum](https://forum.vuejs.org/c/show-and-tell): Another great place to check out what others have built with and for the growing Vue ecosystem.
+- [The "Show and Tell" Subforum](https://github.com/vuejs/core/discussions/categories/show-and-tell): Another great place to check out what others have built with and for the growing Vue ecosystem.
 
 ## What You Can Do {#what-you-can-do}
 


### PR DESCRIPTION
## Description of Problem

The old link on /about/community-guide.html is not working properly - it only leads to Vue's GitHub discussions main page.

## Proposed Solution

Update link to point directly to the desired section 

## Additional Information
