### PR TITLE
Use the correct class variable based on the context

### DIFF
--- a/src/guide/essentials/class-and-style.md
+++ b/src/guide/essentials/class-and-style.md
@@ -189,7 +189,7 @@ This will always apply `errorClass`, but `activeClass` will only be applied when
 However, this can be a bit verbose if you have multiple conditional classes. That's why it's also possible to use the object syntax inside the array syntax:
 
 ```vue-html
-<div :class="[{ active: isActive }, errorClass]"></div>
+<div :class="[{ activeClass: isActive }, errorClass]"></div>
 ```
 
 ### With Components {#with-components}


### PR DESCRIPTION
## Description of Problem
The example code mentioned a variable that is out of context. The `active` variable is used way up on the page, later on the page `activeClass` is used along with `errorClass`.

I suggest the variable here is changed to `activeClass` to remove any confusions that may arise.