### PR TITLE
fix: missing anchor in slots

### DIFF
--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -296,7 +296,7 @@ function BaseLayout(slots) {
 }
 ```
 
-## Conditional Slots
+## Conditional Slots {#conditional-slots}
 
 Sometimes you want to render something based on whether or not a slot is present. 
 


### PR DESCRIPTION
## Description of Problem

New section for "Conditional slots" is missing anchor as other headings have

## Proposed Solution

## Additional Information
