### PR TITLE
Update link to official certification website

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -49,7 +49,7 @@ const nav: ThemeConfig['nav'] = [
           { text: 'UI Components', link: 'https://ui-libs.vercel.app/' },
           {
             text: 'Certification',
-            link: 'https://certification.vuejs.org/?ref=vuejs-nav'
+            link: 'https://certificates.dev/vuejs/?friend=VUEJS&ref=vuejs-nav&utm_source=vuejs&utm_medium=link&utm_campaign=vuejs_nav'
           },
           { text: 'Jobs', link: 'https://vuejobs.com/?ref=vuejs' },
           { text: 'T-Shirt Shop', link: 'https://vue.threadless.com/' }


### PR DESCRIPTION
This PR updates the link to the official certification website.

![update-certification-link-vuejs-docs](https://github.com/vuejs/docs/assets/20980237/93e6a3d6-14f0-4093-a3e7-edc9fa79c070)

