### PR TITLE
docs: rephrasing for understanding

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -466,7 +466,7 @@ Which might render something like:
 Something bad happened.
 :::
 
-This can be achieved using Vue's custom `<slot>` element, which in our example is used in the AlertBox component:
+This can be achieved using Vue's custom `<slot>` element, which in our example is being used in the AlertBox component implementation:
 
 ```vue{4}
 <template>

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -466,9 +466,10 @@ Which might render something like:
 Something bad happened.
 :::
 
-This can be achieved using Vue's custom `<slot>` element, which in our example is being used in the AlertBox component implementation:
+This can be achieved using Vue's custom `<slot>` element:
 
 ```vue{4}
+<!-- AlertBox.vue -->
 <template>
   <div class="alert-box">
     <strong>This is an Error for Demo Purposes</strong>

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -466,7 +466,7 @@ Which might render something like:
 Something bad happened.
 :::
 
-This can be achieved using Vue's custom `<slot>` element:
+This can be achieved using Vue's custom `<slot>` element in the AlertBox component:
 
 ```vue{4}
 <template>

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -466,7 +466,7 @@ Which might render something like:
 Something bad happened.
 :::
 
-This can be achieved using Vue's custom `<slot>` element in the AlertBox component:
+This can be achieved using Vue's custom `<slot>` element, which in our example is used in the AlertBox component:
 
 ```vue{4}
 <template>


### PR DESCRIPTION
## Description of Problem

On the page about [Component Basics](https://vuejs.org/guide/essentials/component-basics.html) it might take a little bit for a first time user of Vue to understand that the `<slot>` is being used inside the `AlertBox` component, given that it is not mentioned directly

## Proposed Solution
Adding direct mention of the `AlertBox` component to simplify readability

## Additional Information
Based on this rule [here](https://github.com/vuejs/docs/blob/main/.github/contributing/writing-guide.md#:~:text=When%20you%20assume%20knowledge%2C%20declare%20it%20at%20the%20beginning%20and%20link%20to%20resources%20for%20less%20common%20knowledge%20that%20you%27re%20expecting.)