### PR TITLE
Update list.md - description of iterating Objects with v-for

### DIFF
--- a/src/guide/essentials/list.md
+++ b/src/guide/essentials/list.md
@@ -134,7 +134,7 @@ You can also use `of` as the delimiter instead of `in`, so that it is closer to 
 
 ## `v-for` with an Object {#v-for-with-an-object}
 
-You can also use `v-for` to iterate through the properties of an object. The iteration order will be based on the result of calling `Object.keys()` on the object:
+You can also use `v-for` to iterate through the properties of an object. The iteration order will be based on the result of calling `Object.values()` on the object:
 
 <div class="composition-api">
 


### PR DESCRIPTION
Update list.md to reflect a better description of result for iterating Objects in v-for

`iterating v-for="value in myObject" is based on the result of calling Object.values()`

## Description of Problem
Minor nit - just reading the documentation and see that iterating an Object with `v-for` is more like `Object.values` than `Object.keys` 

## Proposed Solution
switch `Object.keys()` for `Object.values()`

## Additional Information
