### PR TITLE
💬 Fix syntax error in defineEmits example

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -192,7 +192,7 @@ const emit = defineEmits<{
 
 // 3.3+: alternative, more succinct syntax
 const emit = defineEmits<{
-  change: [id: number] // named tuple syntax
+  change: [id: number]; // named tuple syntax
   update: [value: string]
 }>()
 ```


### PR DESCRIPTION
## Description of Problem

Current documentation of [Type-only props/emit declarations](https://vuejs.org/api/sfc-script-setup.html#type-only-props-emit-declarations) has a syntax error in the type parameters of `defineEmits`. It is missing a semi colon.

![image](https://github.com/vuejs/docs/assets/2586937/5752612e-4817-4c4c-ba68-42156a70bdf1)

## Proposed Solution
Add missing semi colon:
![image](https://github.com/vuejs/docs/assets/2586937/af9b0540-ef36-4d49-ba6f-d9c461e41194)


## Additional Information
N/A
