### PR TITLE
doc:fix method handler access the DOM element way

### DIFF
--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -116,7 +116,7 @@ methods: {
 
 </div>
 
-A method handler automatically receives the native DOM Event object that triggers it - in the example above, we are able to access the element dispatching the event via `event.target.tagName`.
+A method handler automatically receives the native DOM Event object that triggers it - in the example above, we are able to access the element dispatching the event via `event.target`.
 
 <div class="composition-api">
 


### PR DESCRIPTION
## Description of Problem

The documentation mentions that method handler can access the DOM element through `event.target.tagName`. However, I think that `event.target.tagName` actually retrieves the tag name of the DOM element, not the DOM element itself. To access the DOM element directly, one should use `event.target`.

## Proposed Solution
I suggest updating the documentation to replace `event.target.tagName` with `event.target`.

## Additional Information
