### PR TITLE
fix: wrong remark in guide step-11

### DIFF
--- a/src/tutorial/src/step-11/App/composition.js
+++ b/src/tutorial/src/step-11/App/composition.js
@@ -1,3 +1,3 @@
 export default {
-  // register component
+  // register child component
 }


### PR DESCRIPTION
## Description of Problem

It should be `register child component`, not `register component`.

Also, refer to [here](https://github.com/vuejs/docs/blob/main/src/tutorial/src/step-11/App/options.js).