### PR TITLE
fix: remove layout shift on the cute logo

### DIFF
--- a/.vitepress/theme/components/Home.vue
+++ b/.vitepress/theme/components/Home.vue
@@ -19,7 +19,12 @@ onMounted(async () => {
     <img
       v-if="uwu"
       src="/logo-uwu.svg"
-      style="width: 100%; max-width: 580px; margin: -80px auto -20px"
+      style="
+        width: 100%;
+        max-width: 580px;
+        margin: -80px auto -20px;
+        aspect-ratio: 145 / 91;
+      "
     />
     <h1 class="tagline">
       The


### PR DESCRIPTION
## Description of Problem

Because there is not dimension specified for the logo, we get a massive layout shift 

## Proposed Solution

Add the aspect ratio to the cute logo's style

## Additional Information
