### PR TITLE
Fix: uwu logo style & alt text from Home.vue

### DIFF
--- a/.vitepress/theme/components/Home.vue
+++ b/.vitepress/theme/components/Home.vue
@@ -11,7 +11,7 @@ onMounted(load)
 
 <template>
   <section id="hero">
-    <img id="uwu" />
+    <img id="uwu" src="/logo-uwu.svg" alt="Vue.js Kawaii Logo by @icarusgkx" width="145" height="91" />
     <h1 class="tagline">
       The
       <span class="accent">Progressive</span>
@@ -309,12 +309,14 @@ html:not(.dark) .accent,
   }
 }
 
-:global(.uwu #uwu) {
+#uwu {
+  display: none;
+}
+
+.uwu #uwu {
   display: block;
   width: 100%;
   max-width: 580px;
   margin: -80px auto -20px;
-  aspect-ratio: 145 / 91;
-  content: url(/logo-uwu.svg);
 }
 </style>


### PR DESCRIPTION
## Description of Problem

- Insert alternative text for the logo itself (because **this is a meaningful logo image**, not a background image)
- To prevent layout shift for the image, specify the `width` and `height`
- The `:global` specification is meaningless since CSS Modules are not being used

