### PR TITLE
fix: broken header plugin

### DIFF
--- a/.vitepress/headerMdPlugin.ts
+++ b/.vitepress/headerMdPlugin.ts
@@ -19,6 +19,8 @@ export interface AugmentedHeader extends Header {
 }
 
 export const headerPlugin = (md: MarkdownIt) => {
+  md.core.ruler.enable('text_join')
+
   md.renderer.rules.heading_open = (tokens, i, options, env, self) => {
     for (const child of tokens[i + 1].children!) {
       if (child.type === 'text' && child.content.endsWith('*')) {


### PR DESCRIPTION
closes #2857

This can be exploited though, but I don't have any better fix. Just don't merge any PRs containing obfuscated HTML entities and it will be fine. 