### PR TITLE
Domain csstriggers.com was dropped. Need to remove.

### DIFF
--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -324,7 +324,7 @@ You may notice that the animations shown above are mostly using properties like 
 
 2. Most modern browsers can leverage GPU hardware acceleration when animating `transform`.
 
-In comparison, properties like `height` or `margin` will trigger CSS layout, so they are much more expensive to animate, and should be used with caution. We can check resources like [CSS-Triggers](https://csstriggers.com/) to see which properties will trigger layout if we animate them.
+In comparison, properties like `height` or `margin` will trigger CSS layout, so they are much more expensive to animate, and should be used with caution.
 
 ## JavaScript Hooks {#javascript-hooks}
 


### PR DESCRIPTION
## Description of Problem
Domain csstriggers.com was dropped 2022 Aug 27. It has a new owner since 2022 Oct 2, so it can turn malicious at any time.

## Proposed Solution
Remove sentence with it

## Additional Information
![1wkFZhlrsc](https://github.com/vuejs/docs/assets/49349165/82889de9-4da3-4659-842c-40b3faca98d4)
