### PR TITLE
fix: remove comma splice

### DIFF
--- a/src/guide/reusability/custom-directives.md
+++ b/src/guide/reusability/custom-directives.md
@@ -211,7 +211,7 @@ app.directive('demo', (el, binding) => {
 ## Usage on Components {#usage-on-components}
 
 :::warning Not recommended
-Using custom directives on components is not recommended, unexpected behaviour may occur when a component has multiple root nodes.
+Using custom directives on components is not recommended. Unexpected behaviour may occur when a component has multiple root nodes.
 :::
 
 


### PR DESCRIPTION
## Description of Problem

Fix comma splice. This sentence should be two.
