### PR TITLE
fix: Correctly link to i18n custom blocks

### DIFF
--- a/src/api/sfc-spec.md
+++ b/src/api/sfc-spec.md
@@ -66,7 +66,7 @@ Additional custom blocks can be included in a `*.vue` file for any project-speci
 
 - [Gridsome: `<page-query>`](https://gridsome.org/docs/querying-data/)
 - [vite-plugin-vue-gql: `<gql>`](https://github.com/wheatjs/vite-plugin-vue-gql)
-- [vue-i18n: `<i18n>`](https://github.com/intlify/bundle-tools/tree/main/packages/vite-plugin-vue-i18n#i18n-custom-block)
+- [vue-i18n: `<i18n>`](https://github.com/intlify/bundle-tools/tree/main/packages/unplugin-vue-i18n#i18n-custom-block)
 
 Handling of Custom Blocks will depend on tooling - if you want to build your own custom block integrations, see the [SFC custom block integrations tooling section](/guide/scaling-up/tooling#sfc-custom-block-integrations) for more details.
 


### PR DESCRIPTION
## Description of Problem
In i18n custom blocks, vite-plugin-vue-i18n is currently not the main one but unplugin-vue-i18n is mainstream.

## Proposed Solution
fix the link

## Additional Information

related https://github.com/vuejs/language-tools/pull/4392