### PR TITLE
chore: bump deps, remove lock and workaround

### DIFF
--- a/.vitepress/headerMdPlugin.ts
+++ b/.vitepress/headerMdPlugin.ts
@@ -19,8 +19,6 @@ export interface AugmentedHeader extends Header {
 }
 
 export const headerPlugin = (md: MarkdownIt) => {
-  md.core.ruler.enable('text_join')
-
   md.renderer.rules.heading_open = (tokens, i, options, env, self) => {
     for (const child of tokens[i + 1].children!) {
       if (child.type === 'text' && child.content.endsWith('*')) {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   },
   "dependencies": {
     "@vue/repl": "^4.1.2",
-    "@vue/theme": "^2.2.9",
+    "@vue/theme": "^2.2.11",
     "dynamics.js": "^1.1.5",
     "gsap": "^3.12.5",
-    "vitepress": "~1.1",
+    "vitepress": "^1.2.2",
     "vue": "^3.4.27"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       '@vue/theme':
-        specifier: ^2.2.9
-        version: 2.2.9(@algolia/client-search@4.23.3)(search-insights@2.13.0)(vitepress@1.1.4(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
+        specifier: ^2.2.11
+        version: 2.2.11(@algolia/client-search@4.23.3)(search-insights@2.13.0)(vitepress@1.2.2(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))
       dynamics.js:
         specifier: ^1.1.5
         version: 1.1.5
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.12.5
         version: 3.12.5
       vitepress:
-        specifier: ~1.1
-        version: 1.1.4(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5)
+        specifier: ^1.2.2
+        version: 1.2.2(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5)
       vue:
         specifier: ^3.4.27
         version: 3.4.27(typescript@5.4.5)
@@ -486,8 +486,8 @@ packages:
   '@vue/shared@3.4.27':
     resolution: {integrity: sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==}
 
-  '@vue/theme@2.2.9':
-    resolution: {integrity: sha512-lYVs12Zqo6PpbXSAlJHbd5Ju/h75k1vwjz3sbmbA9JJR9LPmbMwNTRz7PrGBjC8aOgY86abJinswqqTUj45Sig==}
+  '@vue/theme@2.2.11':
+    resolution: {integrity: sha512-TofChQEQfHLh3BSb8vHhGRTl12gAtlFYO/3mFlSXOXSs+fG0NU+3mIXeeetA/R5CXuoCZa2fnnTNYYweWQhwnA==}
     peerDependencies:
       vitepress: ^1.2.0
 
@@ -731,8 +731,8 @@ packages:
       terser:
         optional: true
 
-  vitepress@1.1.4:
-    resolution: {integrity: sha512-bWIzFZXpPB6NIDBuWnS20aMADH+FcFKDfQNYFvbOWij03PR29eImTceQHIzCKordjXYBhM/TjE5VKFTUJ3EheA==}
+  vitepress@1.2.2:
+    resolution: {integrity: sha512-uZ3nXR5NY4nYj3RJWCo5jev9qlNZAQo5SUXu1U0QSUx84cUm/o7hCTDVjZ4njVSVui+PsV1oAbdQOg8ygbaf4w==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -1183,14 +1183,14 @@ snapshots:
 
   '@vue/shared@3.4.27': {}
 
-  '@vue/theme@2.2.9(@algolia/client-search@4.23.3)(search-insights@2.13.0)(vitepress@1.1.4(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))':
+  '@vue/theme@2.2.11(@algolia/client-search@4.23.3)(search-insights@2.13.0)(vitepress@1.2.2(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.27(typescript@5.4.5))':
     dependencies:
       '@docsearch/css': 3.6.0
       '@docsearch/js': 3.6.0(@algolia/client-search@4.23.3)(search-insights@2.13.0)
       '@vueuse/core': 10.9.0(vue@3.4.27(typescript@5.4.5))
       body-scroll-lock: 4.0.0-beta.0
       normalize.css: 8.0.1
-      vitepress: 1.1.4(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5)
+      vitepress: 1.2.2(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -1415,7 +1415,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.31.0
 
-  vitepress@1.1.4(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5):
+  vitepress@1.2.2(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.38)(search-insights@2.13.0)(terser@5.31.0)(typescript@5.4.5):
     dependencies:
       '@docsearch/css': 3.6.0
       '@docsearch/js': 3.6.0(@algolia/client-search@4.23.3)(search-insights@2.13.0)
@@ -1424,6 +1424,7 @@ snapshots:
       '@types/markdown-it': 14.1.1
       '@vitejs/plugin-vue': 5.0.4(vite@5.2.11(@types/node@20.12.12)(terser@5.31.0))(vue@3.4.27(typescript@5.4.5))
       '@vue/devtools-api': 7.2.1(vue@3.4.27(typescript@5.4.5))
+      '@vue/shared': 3.4.27
       '@vueuse/core': 10.9.0(vue@3.4.27(typescript@5.4.5))
       '@vueuse/integrations': 10.9.0(focus-trap@7.5.4)(vue@3.4.27(typescript@5.4.5))
       focus-trap: 7.5.4


### PR DESCRIPTION
reverts 4447a5e and fixes issues in #2878