### PR TITLE
Update custom-directives.md

### DIFF
--- a/src/guide/reusability/custom-directives.md
+++ b/src/guide/reusability/custom-directives.md
@@ -111,23 +111,23 @@ A directive definition object can provide several hook functions (all optional):
 const myDirective = {
   // called before bound element's attributes
   // or event listeners are applied
-  created(el, binding, vnode, prevVnode) {
+  created(el, binding, vnode) {
     // see below for details on arguments
   },
   // called right before the element is inserted into the DOM.
-  beforeMount(el, binding, vnode, prevVnode) {},
+  beforeMount(el, binding, vnode) {},
   // called when the bound element's parent component
   // and all its children are mounted.
-  mounted(el, binding, vnode, prevVnode) {},
+  mounted(el, binding, vnode) {},
   // called before the parent component is updated
   beforeUpdate(el, binding, vnode, prevVnode) {},
   // called after the parent component and
   // all of its children have updated
   updated(el, binding, vnode, prevVnode) {},
   // called before the parent component is unmounted
-  beforeUnmount(el, binding, vnode, prevVnode) {},
+  beforeUnmount(el, binding, vnode) {},
   // called when the parent component is unmounted
-  unmounted(el, binding, vnode, prevVnode) {}
+  unmounted(el, binding, vnode) {}
 }
 ```
 


### PR DESCRIPTION
Removing `prevVnode` params from hooks where they aren't available.

## Description of Problem
According to the docs: `prevVnode: the VNode representing the bound element from the previous render. Only available in the beforeUpdate and updated hooks.`
However we have `prevVnode` as a parameter on all the other hooks.
## Proposed Solution
Removed `prevVnode` from hooks where they are not allowed to be used.
## Additional Information
