### PR TITLE
docs: fix missing model modifier

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -397,7 +397,7 @@ console.log(modifiers) // { capitalize: true }
 </script>
 
 <template>
-  <input type="text" v-model="model" />
+  <input type="text" v-model.capitalize="model" />
 </template>
 ```
 
@@ -416,7 +416,7 @@ const [model, modifiers] = defineModel({
 </script>
 
 <template>
-  <input type="text" v-model="model" />
+  <input type="text" v-model.capitalize="model" />
 </template>
 ```
 


### PR DESCRIPTION
## Description of Problem

The example is missing the `.capitalize` modifier.
