### PR TITLE
docs(withModifiers): change type of withModifiers param

### DIFF
--- a/src/api/render-function.md
+++ b/src/api/render-function.md
@@ -305,7 +305,7 @@ For adding built-in [`v-on` modifiers](/guide/essentials/event-handling#event-mo
 - **Type**
 
   ```ts
-  function withModifiers(fn: Function, modifiers: string[]): Function
+  function withModifiers(fn: Function, modifiers: ModifierGuardsKeys[]): Function
   ```
 
 - **Example**


### PR DESCRIPTION
## Description of Problem

change type of withModifiers param
update documentation to reflect the change in #10856, where the type of the second parameter of withModifiers was changed from string[] to ModifierGuardsKeys[]

[vue/core #10856](https://github.com/vuejs/core/pull/10856)

![image](https://github.com/vuejs/docs/assets/47178158/049600cc-f703-414f-ad8a-3bdb97fc08f6)


## Proposed Solution

## Additional Information
