### PR TITLE
Update tooling.md

### DIFF
--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -194,7 +194,6 @@ The official loader that provides Vue SFC support in webpack. If you are using V
 - [Vue + Vite on Repl.it](https://replit.com/@templates/VueJS-with-Vite)
 - [Vue on CodeSandbox](https://codesandbox.io/p/devbox/github/codesandbox/sandbox-templates/tree/main/vue-vite)
 - [Vue on Codepen](https://codepen.io/pen/editor/vue)
-- [Vue on Components.studio](https://components.studio/create/vue3)
 - [Vue on WebComponents.dev](https://webcomponents.dev/create/cevue)
 
 <!-- TODO ## Backend Framework Integrations -->


### PR DESCRIPTION
## Description of Problem
There is a broken link (component.studios) in https://vuejs.org/guide/scaling-up/tooling.html#other-online-playgrounds. I've proposed a solution in their repository, but the last activity is from 3 years ago.

## Proposed Solution
Remove broken playground link (component.studios) https://app.components.studio/edit/OPQn5g8a0xaVXA8oas5d/src/index.vue?p=stories

## Additional Information
re: https://github.com/divriots/components.studio/issues/6