### PR TITLE
fix: scope SecurityUpdateBtn css styles

### DIFF
--- a/.vitepress/theme/components/SecurityUpdateBtn.vue
+++ b/.vitepress/theme/components/SecurityUpdateBtn.vue
@@ -22,7 +22,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .container {
     margin-top: 20px;
   }


### PR DESCRIPTION
## Description of Problem

Recent update 8a4f627 introduced new button component in VitePress theme. CSS styles of this component are not scoped and since `.container` is used several other times, the style leaked:

![image](https://github.com/vuejs/docs/assets/7399922/7314f52c-8bdc-4daa-b698-f9625d1a8738)

It might not be apparent for page titles. But we spotted it out, because I added [specific width in Czech translation](https://github.com/vuejs-translations/docs-cs/issues/267). I thought it is only for the button, but it shifted whole layout badly....

## Proposed Solution

I believe there was no intention to edit `.container` style globally and the simplilest solution is just to add `scoped` attribute into `SecurityUpdateBtn.vue`, which I think is also the recommended way of using styles in components to avoid such situations.

## Additional Information
