### PR TITLE
fix: add different background for dark mode on hover

### DIFF
--- a/.vitepress/theme/components/Home.vue
+++ b/.vitepress/theme/components/Home.vue
@@ -162,8 +162,14 @@ html:not(.dark) .accent,
     linear-gradient(45deg, #42d392, #647eff) border-box;
   border: 2px solid transparent;
 }
+
 .actions .security:hover {
   background: linear-gradient(var(--vt-c-gray-light-4), var(--vt-c-gray-light-4)) padding-box, 
+    linear-gradient(45deg, #42d392, #647eff) border-box;
+}
+
+.dark .actions .security:hover {
+  background: linear-gradient(var(--vt-c-gray-dark-3), var(--vt-c-gray-dark-3)) padding-box, 
     linear-gradient(45deg, #42d392, #647eff) border-box;
 }
 
@@ -171,7 +177,6 @@ html:not(.dark) .accent,
   width: 12px;
   height: 12px;
   margin-left: 4px;
-
 }
 
 .actions .get-started,

--- a/.vitepress/theme/components/SecurityUpdateBtn.vue
+++ b/.vitepress/theme/components/SecurityUpdateBtn.vue
@@ -43,6 +43,10 @@
       linear-gradient(45deg, #42d392, #647eff) border-box;
     transition-duration: 0.2s;
   }
+  .dark .container .security:hover {
+    background: linear-gradient(var(--vt-c-gray-dark-3), var(--vt-c-gray-dark-3)) padding-box, 
+      linear-gradient(45deg, #42d392, #647eff) border-box;
+  }
   .container .security .icon {
     width: 12px;
     height: 12px;


### PR DESCRIPTION
## Description of Problem
The security update buttons on both the home page and the sidebar had the same hover for both dark mode and light mode. This made the button hard to read in dark mode.

## Proposed Solution
Add css for hover on dark mode for both buttons.

