### PR TITLE
fix: render error for fetching-data example

### DIFF
--- a/src/examples/src/fetching-data/App/composition.js
+++ b/src/examples/src/fetching-data/App/composition.js
@@ -6,7 +6,7 @@ const branches = ['main', 'v2-compat']
 export default {
   setup() {
     const currentBranch = ref(branches[0])
-    const commits = ref(null)
+    const commits = ref([])
 
     watchEffect(async () => {
       // this effect will run immediately and then

--- a/src/examples/src/fetching-data/App/options.js
+++ b/src/examples/src/fetching-data/App/options.js
@@ -4,7 +4,7 @@ export default {
   data: () => ({
     branches: ['main', 'v2-compat'],
     currentBranch: 'main',
-    commits: null
+    commits: []
   }),
 
   created() {

--- a/src/examples/src/fetching-data/App/template.html
+++ b/src/examples/src/fetching-data/App/template.html
@@ -8,8 +8,8 @@
   <label :for="branch">{{ branch }}</label>
 </template>
 <p>vuejs/vue@{{ currentBranch }}</p>
-<ul>
-  <li v-for="{ html_url, sha, author, commit } in commits">
+<ul v-if="commits.length > 0">
+  <li v-for="{ html_url, sha, author, commit } in commits" :key="sha">
     <a :href="html_url" target="_blank" class="commit">{{ sha.slice(0, 7) }}</a>
     - <span class="message">{{ truncate(commit.message) }}</span><br>
     by <span class="author">


### PR DESCRIPTION
## Description of Problem

When using [fetching-data example](https://vuejs.org/examples/#fetching-data), I encountered rendering error when the data from asynchronous interface has not returned or the request fails.

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/483dc0f7-0919-4c2a-b8a8-2f1daa1df650">

## Proposed Solution

I added some protection logic.

## Additional Information

Maybe also catch and display the retrieval when the request fails (Github API is particularly easy to reach rate limit), this needs to be designed for display.
