### PR TITLE
Fix themes

### DIFF
--- a/.vitepress/theme/components/SecurityUpdateBtn.vue
+++ b/.vitepress/theme/components/SecurityUpdateBtn.vue
@@ -22,7 +22,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
   .container {
     margin-top: 20px;
   }

--- a/src/ecosystem/themes/themes.json
+++ b/src/ecosystem/themes/themes.json
@@ -197,7 +197,7 @@
   },
   {
     "name": "WrapPixel",
-    "description": "Check out top [dashboard templates](https://www.wrappixel.com/templates/category/admin-dashboard-templates/?ref=320) built by our partners from [WrapPixel](https://www.wrappixel.com/?ref=320). Download highly customizable vue templates (https://www.wrappixel.com/templates/category/vuejs-templates/?ref=320) to start building your real time web application quickly to save hundreds of hours in development and design.",
+    "description": "Check out top [dashboard templates](https://www.wrappixel.com/templates/category/admin-dashboard-templates/?ref=320) built by our partners from [WrapPixel](https://www.wrappixel.com/?ref=320). Download highly customizable [Vue templates](https://www.wrappixel.com/templates/category/vuejs-templates/?ref=320) to start building your real time web application quickly to save hundreds of hours in development and design.",
     "seeMoreUrl": "https://www.wrappixel.com/templates/category/vuejs-templates/?ref=320",
     "products": [
       {
@@ -344,7 +344,7 @@
   },
   {
     "name": "AdminMart",
-    "description": "Check out top [vue dashboard templates](https://adminmart.com/templates/vuejs-admin/?ref=34) built by our partners from [AdminMart](https://adminmart.com/?ref=34). Download them to speed up your web development process and build top class web applications.",
+    "description": "Check out top [Vue dashboard templates](https://adminmart.com/templates/vuejs-admin/?ref=34) built by our partners from [AdminMart](https://adminmart.com/?ref=34). Download them to speed up your web development process and build top class web applications.",
     "seeMoreUrl": "https://adminmart.com/templates/vuejs-admin/?ref=34",
     "products": [
       {
@@ -390,5 +390,5 @@
         "image": "https://adminmart.com/wp-content/uploads/2023/02/modernize-nuxt-js-admin-dashboard.png"
       }
     ]
-  },
+  }
 ]


### PR DESCRIPTION
## Description of Problem

In #2896 two problems were introduced.

1) The trailing comma at the end of the .json file broke the page completely:
![image](https://github.com/user-attachments/assets/fd02b481-ddf5-41b6-a93e-8530ed4c9da0)

2) Orphaned link with no markdown
![image](https://github.com/user-attachments/assets/e75e7626-b4e8-49bb-ad4b-3db706494dca)

## Proposed Solution

Little adjustments to fix it

## Additional Information

_(I am sorry for two extra commits in this PR. Apparently I put my [latest fix](https://github.com/vuejs/docs/pull/2918) into main instead of a separate branch.)_
