### PR TITLE
feat: generate sitemap

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -563,6 +563,10 @@ export const sidebar: ThemeConfig['sidebar'] = {
 export default defineConfigWithTheme<ThemeConfig>({
   extends: baseConfig,
 
+  sitemap: {
+    hostname: 'https://vuejs.org'
+  },
+
   lang: 'en-US',
   title: 'Vue.js',
   description: 'Vue.js - The Progressive JavaScript Framework',
@@ -773,5 +777,5 @@ export default defineConfigWithTheme<ThemeConfig>({
     json: {
       stringify: true
     }
-  }
+  },
 })

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -777,5 +777,5 @@ export default defineConfigWithTheme<ThemeConfig>({
     json: {
       stringify: true
     }
-  },
+  }
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Description of Problem
re: https://github.com/vuejs/docs/issues/2931

## Proposed Solution
1. Use native vitepress sitemap generation config (https://vitepress.dev/guide/sitemap-generation#sitemap-generation)

## Additional Information
1. Updated engine node to 18 or higher as per **README.md** documentation
2. Generated **sitemap.xml** file:
<img width="1207" alt="Screenshot 2024-07-24 at 21 46 45" src="https://github.com/user-attachments/assets/74e4a0d7-b265-48cd-b206-70ddaeb331c4">


