### PR TITLE
Update yarn create command

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -46,7 +46,11 @@ Make sure you have an up-to-date version of [Node.js](https://nodejs.org/) insta
   <VTCodeGroupTab label="yarn">
 
   ```sh
+  # For Yarn Modern (v2+)
   $ yarn create vue@latest
+  
+  # For Yarn ^v4.11
+  $ yarn dlx create-vue@latest
   ```
 
   </VTCodeGroupTab>

--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -43,7 +43,11 @@ To get started with Vite + Vue, simply run:
   <VTCodeGroupTab label="yarn">
   
   ```sh
+  # For Yarn Modern (v2+)
   $ yarn create vue@latest
+  
+  # For Yarn ^v4.11
+  $ yarn dlx create-vue@latest
   ```
 
   </VTCodeGroupTab>


### PR DESCRIPTION
## Description of Problem
Attempting to resolve issue https://github.com/vuejs/docs/issues/2898


On the [Quick Start](https://vuejs.org/guide/quick-start.html) page,` yarn create vue@latest` is one of the recommended ways to creating a Vue application. 
But yarn classic doesn't support appending @tag to the create command. And yarn modern recommends using [yarn dlx](https://yarnpkg.com/cli/dlx).

Similarly, the [Tooling](https://vuejs.org/guide/scaling-up/tooling.html) page also faces the same issue.


## Proposed Solution
List both options with comments.


## Additional Information
Before & After

| Before | After |
|----------|----------|
|<img width="696" alt="image" src="https://github.com/user-attachments/assets/cf102c0d-64c9-456c-8ecf-8d05907ed2d5">|<img width="727" alt="image" src="https://github.com/user-attachments/assets/39e0f5df-0202-4c0a-a1bf-b5813dd8a706">|