### PR TITLE
Added a link explaining how to use inheritAttrs in normal <script>

### DIFF
--- a/src/api/options-misc.md
+++ b/src/api/options-misc.md
@@ -102,6 +102,9 @@ Controls whether the default component attribute fallthrough behavior should be 
   </div>
 
 - **See also** [Fallthrough Attributes](/guide/components/attrs)
+<div class="composition-api">
+- **See also** [Using `inheritAttrs` in normal <script>](api/sfc-script-setup.html#usage-alongside-normal-script)
+</div>
 
 ## components {#components}
 

--- a/src/api/options-misc.md
+++ b/src/api/options-misc.md
@@ -101,10 +101,13 @@ Controls whether the default component attribute fallthrough behavior should be 
 
   </div>
 
-- **See also** [Fallthrough Attributes](/guide/components/attrs)
-<div class="composition-api">
-- **See also** [Using `inheritAttrs` in normal <script>](api/sfc-script-setup.html#usage-alongside-normal-script)
-</div>
+- **See also**
+
+  - [Fallthrough Attributes](/guide/components/attrs)
+  <div class="composition-api">
+
+  - [Using `inheritAttrs` in normal `<script>`](/api/sfc-script-setup.html#usage-alongside-normal-script)
+  </div>
 
 ## components {#components}
 


### PR DESCRIPTION
## Description of Problem

Currently, Composition API documentation offers only `defineOptions` macro for using `inheritAttrs` but said macro was not available before Vue 3.3

## Proposed Solution

Add a link to a part of the documentation that explains how we can use `inheritAttrs` as a component option in normal <script>

## Additional Information

Close #2933 
