### PR TITLE
docs: remarks about minor versions

### DIFF
--- a/src/api/application.md
+++ b/src/api/application.md
@@ -285,9 +285,9 @@ Provide a value that can be injected in all descendant components within the app
 
 ## app.runWithContext() {#app-runwithcontext}
 
-Execute a callback with the current app as injection context.
-
 - Only supported in 3.3+
+
+Execute a callback with the current app as injection context.
 
 - **Type**
 

--- a/src/api/built-in-special-attributes.md
+++ b/src/api/built-in-special-attributes.md
@@ -91,7 +91,9 @@ Used for binding [dynamic components](/guide/essentials/component-basics#dynamic
 
 - **Expects:** `string | Component`
 
-- **Usage on native elements** <sup class="vt-badge">3.1+</sup>
+- **Usage on native elements**
+ 
+  - Only supported in 3.1+
 
   When the `is` attribute is used on a native HTML element, it will be interpreted as a [Customized built-in element](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-customized-builtin-example), which is a native web platform feature.
 

--- a/src/api/composition-api-dependency-injection.md
+++ b/src/api/composition-api-dependency-injection.md
@@ -109,9 +109,9 @@ Injects a value provided by an ancestor component or the application (via `app.p
 
 ## hasInjectionContext() {#has-injection-context}
 
-Returns true if [inject()](#inject) can be used without warning about being called in the wrong place (e.g. outside of `setup()`). This method is designed to be used by libraries that want to use `inject()` internally without triggering a warning to the end user.
-
 - Only supported in 3.3+
+
+Returns true if [inject()](#inject) can be used without warning about being called in the wrong place (e.g. outside of `setup()`). This method is designed to be used by libraries that want to use `inject()` internally without triggering a warning to the end user.
 
 - **Type**
 

--- a/src/api/options-rendering.md
+++ b/src/api/options-rendering.md
@@ -86,7 +86,9 @@ Configure runtime compiler options for the component's template.
 
 ## slots<sup class="vt-badge ts"/> {#slots}
 
-An option to assist with type inference when using slots programmatically in render functions. Only supported in 3.3+.
+- Only supported in 3.3+
+
+An option to assist with type inference when using slots programmatically in render functions.
 
 - **Details**
 

--- a/src/api/reactivity-utilities.md
+++ b/src/api/reactivity-utilities.md
@@ -134,11 +134,11 @@ Can also be used to create a ref for a property on a source reactive object. The
 
 ## toValue() {#tovalue}
 
+- Only supported in 3.3+
+
 Normalizes values / refs / getters to values. This is similar to [unref()](#unref), except that it also normalizes getters. If the argument is a getter, it will be invoked and its return value will be returned.
 
 This can be used in [Composables](/guide/reusability/composables.html) to normalize an argument that can be either a value, a ref, or a getter.
-
-- Only supported in 3.3+
 
 - **Type**
 

--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -379,7 +379,9 @@ defineExpose({
 
 When a parent gets an instance of this component via template refs, the retrieved instance will be of the shape `{ a: number, b: number }` (refs are automatically unwrapped just like on normal instances).
 
-## defineOptions() <sup class="vt-badge" data-text="3.3+" /> {#defineoptions}
+## defineOptions() {#defineoptions}
+
+- Only supported in 3.3+
 
 This macro can be used to declare component options directly inside `<script setup>` without having to use a separate `<script>` block:
 
@@ -394,10 +396,11 @@ defineOptions({
 </script>
 ```
 
-- Only supported in 3.3+.
 - This is a macro. The options will be hoisted to module scope and cannot access local variables in `<script setup>` that are not literal constants.
 
 ## defineSlots()<sup class="vt-badge ts"/> {#defineslots}
+
+- Only supported in 3.3+
 
 This macro can be used to provide type hints to IDEs for slot name and props type checking.
 
@@ -412,8 +415,6 @@ const slots = defineSlots<{
 }>()
 </script>
 ```
-
-- Only supported in 3.3+.
 
 ## `useSlots()` & `useAttrs()` {#useslots-useattrs}
 

--- a/src/api/utility-types.md
+++ b/src/api/utility-types.md
@@ -34,15 +34,15 @@ Used to annotate a prop with more advanced types when using runtime props declar
 
 ## MaybeRef\<T> {#mayberef}
 
-Alias for `T | Ref<T>`. Useful for annotating arguments of [Composables](/guide/reusability/composables.html).
+- Only supported in 3.3+
 
-- Only supported in 3.3+.
+Alias for `T | Ref<T>`. Useful for annotating arguments of [Composables](/guide/reusability/composables.html).
 
 ## MaybeRefOrGetter\<T> {#maybereforgetter}
 
-Alias for `T | Ref<T> | (() => T)`. Useful for annotating arguments of [Composables](/guide/reusability/composables.html).
+- Only supported in 3.3+
 
-- Only supported in 3.3+.
+Alias for `T | Ref<T> | (() => T)`. Useful for annotating arguments of [Composables](/guide/reusability/composables.html).
 
 ## ExtractPropTypes\<T> {#extractproptypes}
 
@@ -77,9 +77,9 @@ To extract public facing props, i.e. props that the parent is allowed to pass, u
 
 ## ExtractPublicPropTypes\<T> {#extractpublicproptypes}
 
-Extract prop types from a runtime props options object. The extracted types are public facing - i.e. the props that the parent is allowed to pass.
+- Only supported in 3.3+
 
-- Only supported in 3.3+.
+Extract prop types from a runtime props options object. The extracted types are public facing - i.e. the props that the parent is allowed to pass.
 
 - **Example**
 


### PR DESCRIPTION
follow up to b6339b62a9522eb195a24ef74ee6392d65d2bfd7

In mentioned commit a lot of "3.x+" badges were removed from docs and replaced with text "Only suported in 3.x+"

I found two more places, where 3.1 / 3.3 were still present, so I altered them in the same manner.

I also noticed sometimes the text is placed before function description and sometimes after. I took liberty to unify the usage and put all of them **before**, because I think this good to know in advance whether I can use it in my project or not.