### PR TITLE
fix(guide/suspense): missing v3.3+ badge in suspensible prop

### DIFF
--- a/src/guide/built-ins/suspense.md
+++ b/src/guide/built-ins/suspense.md
@@ -133,7 +133,7 @@ The following example shows how to nest these components so that they all behave
 
 Vue Router has built-in support for [lazily loading components](https://router.vuejs.org/guide/advanced/lazy-loading.html) using dynamic imports. These are distinct from async components and currently they will not trigger `<Suspense>`. However, they can still have async components as descendants and those can trigger `<Suspense>` in the usual way.
 
-## Nested Suspense {#nested-suspense}
+## Nested Suspense <sup class="vt-badge" data-text="3.3+" /> {#nested-suspense}
 
 When we have multiple async components (common for nested or layout-based routes) like this:
 

--- a/src/guide/built-ins/suspense.md
+++ b/src/guide/built-ins/suspense.md
@@ -133,7 +133,9 @@ The following example shows how to nest these components so that they all behave
 
 Vue Router has built-in support for [lazily loading components](https://router.vuejs.org/guide/advanced/lazy-loading.html) using dynamic imports. These are distinct from async components and currently they will not trigger `<Suspense>`. However, they can still have async components as descendants and those can trigger `<Suspense>` in the usual way.
 
-## Nested Suspense <sup class="vt-badge" data-text="3.3+" /> {#nested-suspense}
+## Nested Suspense {#nested-suspense}
+
+- Only supported in 3.3+
 
 When we have multiple async components (common for nested or layout-based routes) like this:
 


### PR DESCRIPTION
## Description of Problem

The `suspensible` prop was added in Vue 3.3 and I forgot to add it to #2785 
