### PR TITLE
Update plugins.md on how to bundle a plugin.

### DIFF
--- a/src/guide/reusability/plugins.md
+++ b/src/guide/reusability/plugins.md
@@ -135,3 +135,6 @@ export default {
 ```
 
 </div>
+
+### Bundle for NPM
+If you further want to build and publish your plugin for others to use, see [Vite's section on Library Mode](https://vitejs.dev/guide/build.html#library-mode).

--- a/src/guide/reusability/plugins.md
+++ b/src/guide/reusability/plugins.md
@@ -137,4 +137,5 @@ export default {
 </div>
 
 ### Bundle for NPM
+
 If you further want to build and publish your plugin for others to use, see [Vite's section on Library Mode](https://vitejs.dev/guide/build.html#library-mode).


### PR DESCRIPTION
## Description of Problem
There exists instructions how to write a plugin,
but not how to prepare or build said plugin for npm.

## Proposed Solution
Add link to vite's docs.
I don't think that's a good solution, but it's at least better than what we have now (which is none).

In the long term a detailed instruction would be great,
even better would be if we could have a scaffolding for it, see https://github.com/vuejs/create-vue/issues/565

## Additional Information
—