### PR TITLE
improves `api/sfc-script-setup` defineModel TS examples

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -347,14 +347,15 @@ Like `defineProps` and `defineEmits`, `defineModel` can also receive type argume
 
 ```ts
 const modelValue = defineModel<string>()
-//    ^? Ref<string | undefined>
+// type: Ref<string | undefined>
 
 // default model with options, required removes possible undefined values
 const modelValue = defineModel<string>({ required: true })
-//    ^? Ref<string>
+// type: Ref<string>
 
 const [modelValue, modifiers] = defineModel<string, 'trim' | 'uppercase'>()
-//                 ^? Record<'trim' | 'uppercase', true | undefined>
+// modelValue: Ref<string | undefined>
+// modifiers:  Record<'trim' | 'uppercase', true | undefined>
 ```
 
 ## defineExpose() {#defineexpose}


### PR DESCRIPTION
This PR improves the comment's of code for `defineModel with TypeScript`

https://vuejs.org/api/sfc-script-setup.html#usage-with-typescript