### PR TITLE
docs: fixes in 3.5 updates on reactivity-api page

### DIFF
--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -278,19 +278,6 @@ Runs a function immediately while reactively tracking its dependencies and re-ru
   // -> logs 1
   ```
 
-  Side effect cleanup:
-
-  ```js
-  watchEffect(async (onCleanup) => {
-    const { response, cancel } = doAsyncWork(id.value)
-    // `cancel` will be called if `id` changes
-    // so that previous pending request will be cancelled
-    // if not yet completed
-    onCleanup(cancel)
-    data.value = await response
-  })
-  ```
-
   Stopping the watcher:
 
   ```js

--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -515,7 +515,7 @@ Watches one or more reactive data sources and invokes a callback function when t
   Pausing / resuming the watcher: <sup class="vt-badge" data-text="3.5+" />
 
   ```js
-  const { stop, pause, resume } = watchEffect(() => {})
+  const { stop, pause, resume } = watch(() => {})
 
   // temporarily pause the watcher
   pause()


### PR DESCRIPTION
## Description of Problem

1) In 66a8ced546bc2feb3b9bb90c09b236039f621b65 example for "side effect cleanup" got duplicated for `watchEffect` (lines `281` and `318`)
2) The example for "Pausing / resuming the watcher" shows `watchEffect` instead of `watch`

## Proposed Solution

1) Remove the duplicated text
2) Fix the function name

## Additional Information

1) I removed the original occurence to maintain same order of examples as for `watch` function listed later on the page
