### PR TITLE
docs: add omitted anchors for 3.5

### DIFF
--- a/src/guide/components/async.md
+++ b/src/guide/components/async.md
@@ -118,7 +118,7 @@ In Vue 3.5+, async components can control when they are hydrated by providing a 
 
 - The design is intentionally low-level for flexibility. Compiler syntax sugar can potentially be built on top of this in the future either in core or in higher level solutions (e.g. Nuxt).
 
-### Hydrate on Idle
+### Hydrate on Idle {#hydrate-on-idle}
 
 Hydrates via `requestIdleCallback`:
 
@@ -131,7 +131,7 @@ const AsyncComp = defineAsyncComponent({
 })
 ```
 
-### Hydrate on Visible
+### Hydrate on Visible {#hydrate-on-visible}
 
 Hydrate when element(s) become visible via `IntersectionObserver`.
 
@@ -150,7 +150,7 @@ Can optionally pass in an options object value for the observer:
 hydrateOnVisible({ rootMargin: '100px' })
 ```
 
-### Hydrate on Media Query
+### Hydrate on Media Query {#hydrate-on-media-query}
 
 Hydrates when the specified media query matches.
 
@@ -163,7 +163,7 @@ const AsyncComp = defineAsyncComponent({
 })
 ```
 
-### Hydrate on Interaction
+### Hydrate on Interaction {#hydrate-on-interaction}
 
 Hydrates when specified event(s) are triggered on the component element(s). The event that triggered the hydration will also be replayed once hydration is complete.
 
@@ -182,7 +182,7 @@ Can also be a list of multiple event types:
 hydrateOnInteraction(['wheel', 'mouseover'])
 ```
 
-### Custom Strategy
+### Custom Strategy {#custom-strategy}
 
 ```ts
 import { defineAsyncComponent, type HydrationStrategy } from 'vue'

--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -154,7 +154,7 @@ const { foo = 'hello' } = defineProps<{ foo?: string }>()
 
 If you prefer to have more visual distinction between destructured props and normal variables in your IDE, Vue's VSCode extension provides a setting to enable inlay-hints for destructured props.
 
-### Passing Destructured Props into Functions
+### Passing Destructured Props into Functions {#passing-destructured-props-into-functions}
 
 When we pass a destructured prop into a function, e.g.:
 


### PR DESCRIPTION
## Description of Problem

While translating new content I found a few headlines without usual anchors for future language-prone references from other places

## Proposed Solution

Add missing anchors in the traditional style

## Additional Information
