### PR TITLE
docs: remove unnecessary line break

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -12,8 +12,7 @@ While Vue's declarative rendering model abstracts away most of the direct DOM op
 
 <div class="composition-api">
 
-To obtain the reference with Composition API, we can use the [`useTemplateRef()`](/api/composition-api-helpers#usetemplateref) <sup class="vt-badge" data-text=
-"3.5+" /> helper:
+To obtain the reference with Composition API, we can use the [`useTemplateRef()`](/api/composition-api-helpers#usetemplateref) <sup class="vt-badge" data-text="3.5+" /> helper:
 
 ```vue
 <script setup>


### PR DESCRIPTION
## Proposed Solution
Removed a single unnecessary line break in the documentation.

Please review. Thank you!