### PR TITLE
docs: fix required version for useTemplateRef

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -115,7 +115,7 @@ See also: [Typing Template Refs](/guide/typescript/composition-api#typing-templa
 
 ## Refs inside `v-for` {#refs-inside-v-for}
 
-> Requires v3.2.25 or above
+> Requires v3.5 or above
 
 <div class="composition-api">
 


### PR DESCRIPTION
## Description of Problem

The required version stated in the docs is incorrect (v3.2.25). Looking at [the changelog](https://github.com/vuejs/core/blob/main/CHANGELOG.md), `useTemplateRef` was only introduced in v3.5.

## Proposed Solution
Update the version to v3.5

## Additional Information
