### PR TITLE
docs: improve clarity on using refs

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -148,6 +148,8 @@ onMounted(() => console.log(itemRefs.value))
 <details>
 <summary>Usage before 3.5</summary>
 
+In versions before 3.5 where `useTemplateRef()` was not introduced, we need to declare a ref with a name that matches the template ref attribute's value. The ref should also contain an array value:
+
 ```vue
 <script setup>
 import { ref, onMounted } from 'vue'


### PR DESCRIPTION
## Description of Problem (Fixes #3048)
A section of the guide on using template refs has the tendency to be ambiguous because there's not much intentional context around it. It may not be understood without reading the previous section.
The section addresses usage with v-for before v3.5, 'before v3.5' here means before the `useTemplateRef()` helper was introduced. 

## Proposed Solution
I added a description before the code of the summary comes up.

## Additional Information
