### PR TITLE
Add docs addressing "$attrs no longer contains events declared in the emits option" issue

### DIFF
--- a/src/api/options-state.md
+++ b/src/api/options-state.md
@@ -433,20 +433,20 @@ Declare the custom events emitted by the component.
   }
   ```
 
-Listeners on events may be captured in components by defining them as properties with the naming scheme of `on{Event}`:
-
-> If an event contains a colon, use the naming scheme `on{Event}:{event}`.
-
-```js
-export default {
-  props: {
-    onCheck: Function,
-    'onClick:export': Function,
-  },
-
-  emits: ['check', 'click:export'],
-}
-```
+  Listeners on events may be captured in components by defining them as properties with the naming scheme of `on{Event}`:
+  
+  > If an event contains a colon, use the naming scheme `on{Event}:{event}`.
+  
+  ```js
+  export default {
+    props: {
+      onCheck: Function,
+      'onClick:export': Function,
+    },
+  
+    emits: ['check', 'click:export'],
+  }
+  ```
 
 - **See also**
   - [Guide - Fallthrough Attributes](/guide/components/attrs)


### PR DESCRIPTION
## Description of Problem

There is a long-standing discussion from 2021 with comments as recent as September 6th on the disappearance of event listeners in `$attrs` when those events are declared in the `emits` property:

https://github.com/vuejs/rfcs/discussions/397

This is documented here, but with no solution proposed:

https://vuejs.org/api/options-state.html#emits

![Screenshot 2024-10-09 at 11 17 47 AM](https://github.com/user-attachments/assets/2df88604-152e-4eb0-a6d3-244c09da0db0)

## Proposed Solution

Additional docs can be added for those who discover that this occurs so that developers can properly utilize this un-documented functionality in Vue (or, if the docs do exist, correct me if I'm wrong) that allows developers to create props for these event listeners that Vue will auto-populate if they conform to a specific naming convention.

## Additional Information

N/A