### PR TITLE
docs: add section for handling multiple v-model bindings updates

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -374,6 +374,8 @@ export default {
 
 [Try it in the Playground](https://play.vuejs.org/#eNqNkk1rg0AQhv/KIAETSJRexYYWeuqhl9JTt4clmSSC7i7rKCnif+/ObtYkELAiujPzztejQ/JqTNZ3mBRJ2e5sZWgrVNUYbQm+WrQfskE4WN1AmuXRwQmpUELh2Qv3eJBdTTAIBbDTLluhoraA4VpjXHNwL0kuV0EIYJE6q6IFcKhsSwWk7/qkUq/nq5be+aa5JztGfrmHu8t8GtoZhI2pJaGzAMrT03YYQk0YR3BnruSOZe5CXhKnC3X7TaP3WBc+ZaOc/1kk3hDJvYILRQGfQzx3Rct8GiJZJ7fA7gg/AmesNszMrUIXFpxbwCfZSh09D0Hc7tbN6sAWm4qZf6edcZgxrMHSdA3RF7PTn1l8lTIdhbXp1/CmhOeJRNHLupv4eIaXyItPdJEFD7R8NM0Ce/d/ZCTtESnzlVZXhP/vHbeZaT0tPdf59uONfx7mDVM=)
 
+</div>
+
 We can also handle multiple bindings updates easily with `@update`:
 
 ```vue-html

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -374,7 +374,27 @@ export default {
 
 [Try it in the Playground](https://play.vuejs.org/#eNqNkk1rg0AQhv/KIAETSJRexYYWeuqhl9JTt4clmSSC7i7rKCnif+/ObtYkELAiujPzztejQ/JqTNZ3mBRJ2e5sZWgrVNUYbQm+WrQfskE4WN1AmuXRwQmpUELh2Qv3eJBdTTAIBbDTLluhoraA4VpjXHNwL0kuV0EIYJE6q6IFcKhsSwWk7/qkUq/nq5be+aa5JztGfrmHu8t8GtoZhI2pJaGzAMrT03YYQk0YR3BnruSOZe5CXhKnC3X7TaP3WBc+ZaOc/1kk3hDJvYILRQGfQzx3Rct8GiJZJ7fA7gg/AmesNszMrUIXFpxbwCfZSh09D0Hc7tbN6sAWm4qZf6edcZgxrMHSdA3RF7PTn1l8lTIdhbXp1/CmhOeJRNHLupv4eIaXyItPdJEFD7R8NM0Ce/d/ZCTtESnzlVZXhP/vHbeZaT0tPdf59uONfx7mDVM=)
 
-</div>
+We can also handle multiple bindings updates easily with `@update`:
+
+```vue-html
+<UserName
+  v-model:first-name="first"
+  v-model:last-name="last"
+  @update:first-name="foo"
+  @update:last-name="foo2"
+/>
+```
+
+Alternatively, adding `.model-value` at the end also work:
+
+```vue-html
+<UserName
+  v-model:first-name="first"
+  v-model:last-name="last"
+  @update:first-name.mode-value="foo"
+  @update:last-name=.model-value"foo2"
+/>
+```
 
 ## Handling `v-model` modifiers {#handling-v-model-modifiers}
 


### PR DESCRIPTION
#3058

## Description of Problem
Currently, the documentation lacks detailed information on how to handle v-model updates, especially when dealing with multiple bindings. Understanding this is crucial for working with Vue's two-way data binding system, particularly using the @update:model-value event.

Most importantly, there is no mention of handling multiple v-model bindings updates—neither in the official documentation nor through external resources.

## Proposed Solution
I propose adding a section in the documentation that clearly explains this pattern, with examples and guidelines on how to handle updates for multiple v-model bindings. This would greatly enhance the developer experience and provide clarity for a commonly needed feature.
