### PR TITLE
doc:add a warn about '~' in src-imports

### DIFF
--- a/src/api/sfc-spec.md
+++ b/src/api/sfc-spec.md
@@ -136,6 +136,13 @@ Beware that `src` imports follow the same path resolution rules as webpack modul
 </unit-test>
 ```
 
+:::warning Note
+While using aliases in `src`,don't start with `~`(It can be used in `import` seq ), anything after it is interpreted as a module request. This means you can reference assets inside node modules:
+```vue
+<img src="~some-npm-package/foo.png">
+```
+:::
+
 ## Comments {#comments}
 
 Inside each block you shall use the comment syntax of the language being used (HTML, CSS, JavaScript, Pug, etc.). For top-level comments, use HTML comment syntax: `<!-- comment contents here -->`


### PR DESCRIPTION
## Description of Problem
`\~` is not mentioned in src-imports ,which is different from the others.
## Proposed Solution
Add description.
## Additional Information
Nothing.