### PR TITLE
Update event-handling.md hyperlink

### DIFF
--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -286,7 +286,7 @@ When listening for keyboard events, we often need to check for specific keys. Vu
 <input @keyup.enter="submit" />
 ```
 
-You can directly use any valid key names exposed via [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) as modifiers by converting them to kebab-case.
+You can directly use any valid key names exposed via [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values) as modifiers by converting them to kebab-case.
 
 ```vue-html
 <input @keyup.page-down="onPageDown" />


### PR DESCRIPTION
## Description of Problem

The original link `https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values` of MDN has expired.


## Proposed Solution

The new link address is `https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values`.

## Additional Information
