### PR TITLE
docs(essentials/template-refs): fix typo

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -31,7 +31,7 @@ onMounted(() => {
 </template>
 ```
 
-When using TypeScript, Vue's IDE support and `vue-tsc` will automatically infer the type of `inputRef.value` based on what element or component the matching `ref` attribute is used on.
+When using TypeScript, Vue's IDE support and `vue-tsc` will automatically infer the type of `input.value` based on what element or component the matching `ref` attribute is used on.
 
 <details>
 <summary>Usage before 3.5</summary>


### PR DESCRIPTION
## Description of Problem

In the [Template Refs](https://vuejs.org/guide/essentials/template-refs.html) guide, the example code uses `input` as the template ref, but the documentation text refers to `inputRef.value`, which does not match the code. This causes confusion for readers.

## Proposed Solution

I have updated the documentation to replace `inputRef.value` with `input.value`, ensuring consistency between the example code and the explanation.

## Additional Information

This Pull Request addresses issue #3064.