### PR TITLE
docs: Correct indentation of a code sample in composition-api-helpers

### DIFF
--- a/src/api/composition-api-helpers.md
+++ b/src/api/composition-api-helpers.md
@@ -45,7 +45,7 @@ This is the underlying helper that powers [`defineModel()`](/api/sfc-script-setu
   type ModelRef<T, M extends PropertyKey = string, G = T, S = T> = Ref<G, S> & [
     ModelRef<T, M, G, S>,
     Record<M, true | undefined>
-]
+  ]
   ```
 
 - **Example**


### PR DESCRIPTION
## Description
The code sample in composition-api-helpers(useModel) had the end of a square bracket outside of the code sample due to an incorrect indentation as seen below
<img width="1097" alt="Screenshot 2024-10-15 at 09 37 27" src="https://github.com/user-attachments/assets/ca947d5e-1cd0-46e2-bb91-ca35a0be3dfa">

## Solution
Removed the extra spaces and the bracket is back inside the code;
<img width="1080" alt="Screenshot 2024-10-15 at 09 38 01" src="https://github.com/user-attachments/assets/a631dd3b-0090-46bf-a1ae-27419d9cf6fe">

