### PR TITLE
Make `v-model` code example more readable

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -99,11 +99,15 @@ const model = defineModel({ default: 0 })
 :::warning
 If you have a `default` value for `defineModel` prop and you don't provide any value for this prop from the parent component, it can cause a de-synchronization between parent and child components. In the example below, the parent's `myRef` is undefined, but the child's `model` is 1:
 
-```js
-// child component:
-const model = defineModel({ default: 1 })
+**Child component:**
 
-// parent component:
+```js
+const model = defineModel({ default: 1 })
+```
+
+**Parent component:**
+
+```js
 const myRef = ref()
 ```
 


### PR DESCRIPTION
## Description of Problem

Currently, the visual separation of the code blocks (JS vs. HTML) doesn't match the logical separation (child component vs. parent component):

![grafik](https://github.com/user-attachments/assets/98c3f434-d28d-41a0-a5de-2ef82a6046b3)

## Proposed Solution

Split the first code block in two and change the code comments to headings:

![grafik](https://github.com/user-attachments/assets/34982d50-c3ce-42cd-9848-69c46e6c627e)

(see https://deploy-preview-3069--vuejs.netlify.app/guide/components/v-model.html#under-the-hood)
