### PR TITLE
add useCssModule example

### DIFF
--- a/src/api/sfc-css-features.md
+++ b/src/api/sfc-css-features.md
@@ -153,6 +153,26 @@ useCssModule()
 useCssModule('classes')
 ```
 
+- **Example**
+
+```vue
+<script setup lang="ts">
+import { useCssModule } from 'vue'
+
+const classes = useCssModule()
+</script>
+
+<template>
+  <p :class="classes.red">red</p>
+</template>
+
+<style module>
+.red {
+  color: red;
+}
+</style>
+```
+
 ## `v-bind()` in CSS {#v-bind-in-css}
 
 SFC `<style>` tags support linking CSS values to dynamic component state using the `v-bind` CSS function:


### PR DESCRIPTION
## Description of Problem

The style module is an interesting feature in Vue.js, and the `useCssModule` helper is also quite useful. However, it seems like `useCssModule` lacks an example, which would make it easier for beginners to understand and use.

## Proposed Solution

I have added a simple example for `useCssModule` to demonstrate how to implement it.

## Additional Information
### Screenshot result:
<img width="735" alt="image" src="https://github.com/user-attachments/assets/c06dc57f-d8cb-4400-bb34-d8798de14c6c">

---

If you have any feedback or suggestions, please do not hesitate to let me know. 😁
