### PR TITLE
docs: use badge instead of text for version support

### DIFF
--- a/src/api/composition-api-helpers.md
+++ b/src/api/composition-api-helpers.md
@@ -22,11 +22,9 @@ If using TypeScript, [`defineSlots()`](/api/sfc-script-setup#defineslots) should
   function useSlots(): Record<string, (...args: any[]) => VNode[]>
   ```
 
-## useModel() {#usemodel}
+## useModel() <sup class="vt-badge" data-text="3.4+" /> {#usemodel}
 
 This is the underlying helper that powers [`defineModel()`](/api/sfc-script-setup#definemodel). If using `<script setup>`, `defineModel()` should be preferred instead.
-
-- Only available in 3.4+
 
 - **Type**
 


### PR DESCRIPTION
## Description of Problem
Use badge to show what version is the helper is available in for consistency.

## Proposed Solution
N/A

## Additional Information
N/A
