### PR TITLE
docs: capitalize text

### DIFF
--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -259,7 +259,7 @@ Now when you run `fullName.value = 'John Doe'`, the setter will be invoked and `
 
 </div>
 
-## Getting the previous value {#previous}
+## Getting the Previous Value {#previous}
 
 - Only supported in 3.4+
 


### PR DESCRIPTION
Text is capitalized for consistency because all the titles are capitalized.
