### PR TITLE
Update transition-group.md - add detail about prop moveClass

### DIFF
--- a/src/guide/built-ins/transition-group.md
+++ b/src/guide/built-ins/transition-group.md
@@ -81,6 +81,7 @@ Now it looks much better - even animating smoothly when the whole list is shuffl
 [Full Example](/examples/#list-transition)
 
 ### Custom TransitionGroup classes
+
 You can also specify custom transition classes for the moving element by passing the `moveClass` prop to `<TransitionGroup>`, just like [custom transition classes on `<Transition>`](https://vuejs.org/guide/built-ins/transition.html#custom-transition-classes).
 
 ## Staggering List Transitions {#staggering-list-transitions}

--- a/src/guide/built-ins/transition-group.md
+++ b/src/guide/built-ins/transition-group.md
@@ -80,6 +80,9 @@ Now it looks much better - even animating smoothly when the whole list is shuffl
 
 [Full Example](/examples/#list-transition)
 
+### Custom TransitionGroup classes
+You can also specify custom transition classes for the moving element by passing the `moveClass` prop to `<TransitionGroup>`, just like [custom transition classes on `<Transition>`](https://vuejs.org/guide/built-ins/transition.html#custom-transition-classes).
+
 ## Staggering List Transitions {#staggering-list-transitions}
 
 By communicating with JavaScript transitions through data attributes, it's also possible to stagger transitions in a list. First, we render the index of an item as a data attribute on the DOM element:


### PR DESCRIPTION
## Description of Problem
Prop spec of TransitionGroup is missing on component documentation page. 

## Proposed Solution
Added the missing information.

## Additional Information
While building a library which is making use of TransitionGroup, it took me a loooong minute to find out how to pass the move-class as a prop, (that is, I thought for a while it was not possible and it was only possible using CSS, which is annoying if you want to avoid that), because it was not written on the main documentation page. 
Now I checked again and found it in the API spec and found it after all, yey! I updated my library to include the option for this by using the correct props type. 
