### PR TITLE
docs:  align custom-directive example with content

### DIFF
--- a/src/guide/reusability/custom-directives.md
+++ b/src/guide/reusability/custom-directives.md
@@ -25,7 +25,7 @@ In addition to the default set of directives shipped in core (like `v-model` or 
 
 We have introduced two forms of code reuse in Vue: [components](/guide/essentials/component-basics) and [composables](./composables). Components are the main building blocks, while composables are focused on reusing stateful logic. Custom directives, on the other hand, are mainly intended for reusing logic that involves low-level DOM access on plain elements.
 
-A custom directive is defined as an object containing lifecycle hooks similar to those of a component. The hooks receive the element the directive is bound to. Here is an example of a directive that focuses an input when the element is inserted into the DOM by Vue:
+A custom directive is defined as an object containing lifecycle hooks similar to those of a component. The hooks receive the element the directive is bound to. Here is an example of a directive that adds a class to an element when it is inserted into the DOM by Vue:
 
 <div class="composition-api">
 


### PR DESCRIPTION
## Description of Problem
The text is not aligned with the provided example.

## Additional Information
the text is about focusing on the element, but the example is about highlighting the text.
[https://vuejs.org/guide/reusability/custom-directives.html#introduction](https://vuejs.org/guide/reusability/custom-directives.html#introduction)


![Screenshot from 2024-11-05 11-34-06](https://github.com/user-attachments/assets/364f2ff8-87d7-44c6-a28e-d1073d70bcbe)
