### PR TITLE
docs: fix grammar

### DIFF
--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -135,7 +135,7 @@ watchEffect(() => {
 })
 ```
 
-In version 3.4 and below, `foo` is an actual constant and will never change. In version 3.5 and above, Vue's compiler automatically prepends `props.` when code in the same `<script setup>` block accesses variables destructured from `defineProps`. Therefore the code above becomes equivalent to the following:
+In version 3.4 and below, `foo` is an actual constant and will never change. In version 3.5 and above, Vue's compiler automatically prepends `props` when code in the same `<script setup>` block accesses variables destructured from `defineProps`. Therefore the code above becomes equivalent to the following:
 
 ```js {5}
 const props = defineProps(['foo'])


### PR DESCRIPTION
I think it would be `props` instead of `props.` with a full stop because it is just one line.