### PR TITLE
docs: add explanation for template-refs defineExpose before await

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -314,7 +314,7 @@ defineExpose({
 
 When a parent gets an instance of this component via template refs, the retrieved instance will be of the shape `{ a: number, b: number }` (refs are automatically unwrapped just like on normal instances).
 
-Note that defineExpose must be called before any await operation. Otherwise, properties and methods exposed after the await operation will not be accessible. ([Related Discussion](https://github.com/vuejs/core/issues/4930))
+Note that defineExpose must be called before any await operation. Otherwise, properties and methods exposed after the await operation will not be accessible. 
 
 See also: [Typing Component Template Refs](/guide/typescript/composition-api#typing-component-template-refs) <sup class="vt-badge ts" />
 

--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -314,6 +314,8 @@ defineExpose({
 
 When a parent gets an instance of this component via template refs, the retrieved instance will be of the shape `{ a: number, b: number }` (refs are automatically unwrapped just like on normal instances).
 
+Note that defineExpose must be called before any await operation. Otherwise, properties and methods exposed after the await operation will not be accessible. ([Related Discussion](https://github.com/vuejs/core/issues/4930))
+
 See also: [Typing Component Template Refs](/guide/typescript/composition-api#typing-component-template-refs) <sup class="vt-badge ts" />
 
 </div>


### PR DESCRIPTION
## Description of Problem

In the child component’s <script setup>, if defineExpose is called before an await operation, the parent component will not be able to access the exposed properties and methods.

refs
- https://github.com/vuejs/core/issues/4930

## Proposed Solution

Add an explanation in the template-refs.md document to provide users with a workaround for this issue. If a PR later resolves this issue, update this document accordingly.

## Additional Information

I spent several hours on this issue. If the document provides this solution, it will help many people
