### PR TITLE
fix: Vue 3.x targets ES2016+, not ES2015

### DIFF
--- a/src/about/faq.md
+++ b/src/about/faq.md
@@ -30,7 +30,7 @@ Vue is a free and open source project released under the [MIT License](https://o
 
 ## What browsers does Vue support? {#what-browsers-does-vue-support}
 
-The latest version of Vue (3.x) only supports [browsers with native ES2015 support](https://caniuse.com/es6). This excludes IE11. Vue 3.x uses ES2015 features that cannot be polyfilled in legacy browsers, so if you need to support legacy browsers, you will need to use Vue 2.x instead.
+The latest version of Vue (3.x) only supports [browsers with native ES2016 support](https://caniuse.com/es2016). This excludes IE11. Vue 3.x uses ES2016 features that cannot be polyfilled in legacy browsers, so if you need to support legacy browsers, you will need to use Vue 2.x instead.
 
 ## Is Vue reliable? {#is-vue-reliable}
 


### PR DESCRIPTION
References:
- https://github.com/vuejs/core/blob/76c43c6040518c93b41f60a28b224f967c007fdf/tsconfig.json#L6
- Use of `Array.prototype.includes()` (ES2016 feature) in Vue 3.x source code: https://github.com/vuejs/core/blob/76c43c6040518c93b41f60a28b224f967c007fdf/packages/runtime-core/src/compat/renderHelpers.ts#L160
