### PR TITLE
Enable Style Guide nav item

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -15,7 +15,7 @@ const nav: ThemeConfig['nav'] = [
       { text: 'Tutorial', link: '/tutorial/' },
       { text: 'Examples', link: '/examples/' },
       { text: 'Quick Start', link: '/guide/quick-start' },
-      // { text: 'Style Guide', link: '/style-guide/' },
+      { text: 'Style Guide', link: '/style-guide/' },
       { text: 'Glossary', link: '/glossary/' },
       { text: 'Error Reference', link: '/error-reference/' },
       {


### PR DESCRIPTION
## Description of Problem

Vue style guide has been very helpful for me and my team as a reference for work.
I've been following this guide since Vue 2, as the guideline in the documentation.

However, for Vue 3, the style guide is not prominently accessible in the documentation.
I accidentally found it in some parts of the docs, but it would be helpful if it were accessible from the navbar, as it was with Vue 2.

## Proposed Solution
I’ve removed the comment from the style guide navbar item to make it visible in the navbar.
I’m unsure if there was a specific reason it was hidden.
Please let me know if you have any feedback or suggestions.

## Screenshots

* Before
![Screen Shot 2567-11-08 at 23 34 19](https://github.com/user-attachments/assets/8c5bf3d2-b092-426f-8a17-c6d75eb72363)

* After
![image](https://github.com/user-attachments/assets/43b9f898-ec77-4f22-80ae-ae50ae475767)
https://github.com/user-attachments/assets/68ee6c0c-48c8-49cb-ae1e-f42f30987f58


