### PR TITLE
fix(example): fix repo and branches names in fetching example

### DIFF
--- a/src/examples/src/fetching-data/App/composition.js
+++ b/src/examples/src/fetching-data/App/composition.js
@@ -1,7 +1,7 @@
 import { ref, watchEffect } from 'vue'
 
 const API_URL = `https://api.github.com/repos/vuejs/core/commits?per_page=3&sha=`
-const branches = ['main', 'v2-compat']
+const branches = ['main', 'minor']
 
 export default {
   setup() {

--- a/src/examples/src/fetching-data/App/options.js
+++ b/src/examples/src/fetching-data/App/options.js
@@ -2,7 +2,7 @@ const API_URL = `https://api.github.com/repos/vuejs/core/commits?per_page=3&sha=
 
 export default {
   data: () => ({
-    branches: ['main', 'v2-compat'],
+    branches: ['main', 'minor'],
     currentBranch: 'main',
     commits: []
   }),

--- a/src/examples/src/fetching-data/App/template.html
+++ b/src/examples/src/fetching-data/App/template.html
@@ -7,7 +7,7 @@
     v-model="currentBranch">
   <label :for="branch">{{ branch }}</label>
 </template>
-<p>vuejs/vue@{{ currentBranch }}</p>
+<p>vuejs/core@{{ currentBranch }}</p>
 <ul v-if="commits.length > 0">
   <li v-for="{ html_url, sha, author, commit } in commits" :key="sha">
     <a :href="html_url" target="_blank" class="commit">{{ sha.slice(0, 7) }}</a>

--- a/src/examples/src/fetching-data/description.txt
+++ b/src/examples/src/fetching-data/description.txt
@@ -1,2 +1,2 @@
-This example fetches latest Vue.js commits data from GitHub’s API and displays them as a list.
-You can switch between the two branches.
+This example fetches latest Vue Core commits data from GitHub’s API and displays them as a list.
+You can switch between the two primary branches.


### PR DESCRIPTION
## Description of Problem

Currently, [the fetching example](https://vuejs.org/examples/#fetching-data) does not work as intended, since it uses an outdated second branch.

Additionally, the paragraph before the commit list mentions repo of Vue 2, even though the data is fetched for Vue 3 Core repo.

## Proposed Solution

Update the repo and branches names. The branches names are the primary branches from https://github.com/vuejs/core/blob/main/.github/contributing.md.

Also, make the example description a bit clearer.

## Additional Information

[The edited example in the preview](https://deploy-preview-3102--vuejs.netlify.app/examples/#fetching-data).