### PR TITLE
docs: more specific mention of where PascalCase naming is allowed, in components/registration.md file.

### DIFF
--- a/src/guide/components/registration.md
+++ b/src/guide/components/registration.md
@@ -138,4 +138,4 @@ Throughout the guide, we are using PascalCase names when registering components.
 
 This is the recommended style when working with SFC or string templates. However, as discussed in [in-DOM Template Parsing Caveats](/guide/essentials/component-basics#in-dom-template-parsing-caveats), PascalCase tags are not usable in in-DOM templates.
 
-Luckily, Vue supports resolving kebab-case tags to components registered using PascalCase. This means a component registered as `MyComponent` can be referenced in the template via both `<MyComponent>` and `<my-component>`. This allows us to use the same JavaScript component registration code regardless of template source.
+Luckily, Vue supports resolving kebab-case tags to components registered using PascalCase. This means a component registered as `MyComponent` can be referenced inside a Vue template (or inside an HTML element rendered by Vue) via both `<MyComponent>` and `<my-component>`. This allows us to use the same JavaScript component registration code regardless of template source.


### PR DESCRIPTION
> a component registered as `MyComponent` can be referenced in the template via both `<MyComponent>` and `<my-component>`.


While learning about Vue components and navigating the PascalCase and kebab-case support between html and vue, I came across this line in the docs. IMO it is not initially clear what is meant here without having to write some components first and get idea.

## Proposed Solution
Making it slightly more verbose to specify exactly where PascalCase components are allowed.

> a component registered as `MyComponent` can be referenced inside a Vue template (or inside an HTML element rendered by Vue) via both `<MyComponent>` and `<my-component>`.
 