### PR TITLE
Fix(web-component): Set right link #3110

### DIFF
--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -274,7 +274,7 @@ export function MyComponent() {
 
 When writing Vue SFC templates, you may want to [type check](/guide/scaling-up/tooling.html#typescript) your Vue components, including those that are defined as custom elements.
 
-Custom elements are registered globally in browsers using their built-in APIs, and by default they won't have type inference when used in Vue templates. To provide type support for Vue components registered as custom elements, we can register global component typings by augmenting the [`GlobalComponents` interface](https://github.com/vuejs/language-tools/blob/master/packages/vscode-vue/README.md#usage) for type checking in Vue templates (JSX users can augment the [JSX.IntrinsicElements](https://www.typescriptlang.org/docs/handbook/jsx.html#intrinsic-elements) type instead, which is not shown here).
+Custom elements are registered globally in browsers using their built-in APIs, and by default they won't have type inference when used in Vue templates. To provide type support for Vue components registered as custom elements, we can register global component typings by augmenting the [`GlobalComponents` interface](https://github.com/vuejs/language-tools/wiki/Global-Component-Types) for type checking in Vue templates (JSX users can augment the [JSX.IntrinsicElements](https://www.typescriptlang.org/docs/handbook/jsx.html#intrinsic-elements) type instead, which is not shown here).
 
 Here is how to define the type for a custom element made with Vue:
 


### PR DESCRIPTION
#3110

## Description of Problem

In file src/guide/extras/web-components.md {#web-components-and-typescript} we have the breaking link [GlobalComponents interface](https://github.com/vuejs/language-tools/blob/master/packages/vscode-vue/README.md#usage) the page is not found.

https://github.com/vuejs/language-tools/blob/master/packages/vscode-vue/README.md#usage

## Proposed Solution

Change the link to https://github.com/vuejs/language-tools/wiki/Global-Component-Types

## Additional Information
