### PR TITLE
docs(computed): remove semicolons

### DIFF
--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -281,10 +281,10 @@ export default {
     // instead until count is less or equal to 3
     alwaysSmall(previous) {
       if (this.count <= 3) {
-        return this.count;
+        return this.count
       }
 
-      return previous;
+      return previous
     }
   }
 }
@@ -304,10 +304,10 @@ const count = ref(2)
 // instead until count is less or equal to 3
 const alwaysSmall = computed((previous) => {
   if (count.value <= 3) {
-    return count.value;
+    return count.value
   }
 
-  return previous;
+  return previous
 })
 </script>
 ```
@@ -328,13 +328,13 @@ export default {
     alwaysSmall: {
       get(previous) {
         if (this.count <= 3) {
-          return this.count;
+          return this.count
         }
 
         return previous;
       },
       set(newValue) {
-        this.count = newValue * 2;
+        this.count = newValue * 2
       }
     }
   }
@@ -353,13 +353,13 @@ const count = ref(2)
 const alwaysSmall = computed({
   get(previous) {
     if (count.value <= 3) {
-      return count.value;
+      return count.value
     }
 
-    return previous;
+    return previous
   },
   set(newValue) {
-    count.value = newValue * 2;
+    count.value = newValue * 2
   }
 })
 </script>


### PR DESCRIPTION
## Description of Problem
In the entire vue.js documentation, codes are written without semicolons. Having semicolons in code is not wrong, but for keeping consistency with the other codes in the vue.js doc, I think we can remove the semicolons in the given examples. Only here semicolons are used. I think it would be better to remove the semicolons here to maintain consistency with the other codes in vue.js doc.

## Proposed Solution

## Additional Information
