### PR TITLE
docs(guide/components/slots): clarify slot presence phrasing

### DIFF
--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -298,7 +298,7 @@ function BaseLayout(slots) {
 
 ## Conditional Slots {#conditional-slots}
 
-Sometimes you want to render something based on whether or not a slot is present. 
+Sometimes you want to render something based on whether or not content has been passed to a slot. 
 
 You can use the [$slots](/api/component-instance.html#slots) property in combination with a [v-if](/guide/essentials/conditional.html#v-if) to achieve this.
 

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -303,7 +303,7 @@ Sometimes you want to render something based on whether or not content has been 
 You can use the [$slots](/api/component-instance.html#slots) property in combination with a [v-if](/guide/essentials/conditional.html#v-if) to achieve this.
 
 In the example below we define a Card component with three conditional slots: `header`, `footer` and the `default` one.
-When the header / footer / default is present we want to wrap them to provide additional styling:
+When content for the header / footer / default is present, we want to wrap it to provide additional styling:
 
 ```vue-html
 <template>


### PR DESCRIPTION
## Description of Problem
The original phrasing "**_whether or not a slot is present_**" was potentially misleading, as it suggested checking the existence of the slot itself rather than whether content was passed to it. Updated the explanation to clarify this distinction for better readability and accuracy.

## Proposed Solution
The original phrase was replaced with "...**_whether or not content has been passed to a slot_**"

## Additional Information
-