### PR TITLE
Fixed Issue #3094

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -181,15 +181,15 @@ export const sidebar: ThemeConfig['sidebar'] = {
           link: '/guide/essentials/event-handling'
         },
         { text: 'Form Input Bindings', link: '/guide/essentials/forms' },
-        {
-          text: 'Lifecycle Hooks',
-          link: '/guide/essentials/lifecycle'
-        },
         { text: 'Watchers', link: '/guide/essentials/watchers' },
         { text: 'Template Refs', link: '/guide/essentials/template-refs' },
         {
           text: 'Components Basics',
           link: '/guide/essentials/component-basics'
+        },
+        {
+          text: 'Lifecycle Hooks',
+          link: '/guide/essentials/lifecycle'
         }
       ]
     },


### PR DESCRIPTION
## Description of Problem
Components basics should be addressed before the component lifecycle hooks. According to issue #3094.
## Proposed Solution
I changed the Lifecycle hooks tab to be last in the sidebar due to a suggestion that it would "fit the narrative" better.
