### PR TITLE
docs: move `data-allow-mismatch` to built-in-special-attributes.md

### DIFF
--- a/src/api/built-in-special-attributes.md
+++ b/src/api/built-in-special-attributes.md
@@ -109,3 +109,23 @@ Used for binding [dynamic components](/guide/essentials/component-basics#dynamic
 
   - [Built-in Special Element - `<component>`](/api/built-in-special-elements#component)
   - [Dynamic Components](/guide/essentials/component-basics#dynamic-components)
+
+## data-allow-mismatch <sup class="vt-badge" data-text="3.5+" /> {#data-allow-mismatch}
+
+A special attribute that can be used to suppress [hydration mismatch](/guide/scaling-up/ssr#hydration-mismatch) warnings.
+
+- **Example**
+
+  ```html
+  <div data-allow-mismatch="text">{{ data.toLocaleString() }}</div>
+  ```
+
+  The value can limit the allowed mismatch to a specific type. Allowed values are:
+
+  - `text`
+  - `children` (only allows mismatch for direct children)
+  - `class`
+  - `style`
+  - `attribute`
+
+  If no value is provided, all types of mismatches will be allowed.

--- a/src/api/ssr.md
+++ b/src/api/ssr.md
@@ -220,23 +220,3 @@ A runtime API used to retrieve the context object passed to `renderToString()` o
   }
   </script>
   ```
-
-## data-allow-mismatch <sup class="vt-badge" data-text="3.5+" /> {#data-allow-mismatch}
-
-A special attribute that can be used to suppress [hydration mismatch](/guide/scaling-up/ssr#hydration-mismatch) warnings.
-
-- **Example**
-
-  ```html
-  <div data-allow-mismatch="text">{{ data.toLocaleString() }}</div>
-  ```
-
-  The value can limit the allowed mismatch to a specific type. Allowed values are:
-
-  - `text`
-  - `children` (only allows mismatch for direct children)
-  - `class`
-  - `style`
-  - `attribute`
-
-  If no value is provided, all types of mismatches will be allowed.


### PR DESCRIPTION
## Description of Problem

language-tools uses the documentation in Built-ins to provide the completion of special attributes, while currently `data-allow-mismatch` is located in another page.

## Proposed Solution

## Additional Information
