### PR TITLE
docs: fix $el type in documentation to 'any'

### DIFF
--- a/src/api/component-instance.md
+++ b/src/api/component-instance.md
@@ -42,7 +42,7 @@ The root DOM node that the component instance is managing.
 
   ```ts
   interface ComponentPublicInstance {
-    $el: Node | undefined
+    $el: any
   }
   ```
 


### PR DESCRIPTION
## Description of Problem
Related issue: [#3138](https://github.com/vuejs/docs/issues/3138)

## Proposed Solution
Updated the `$el` type in the documentation to `any`, as suggested in the Vue Core discussion ([#7915](https://github.com/vuejs/core/issues/7915)) and to align with the actual behaviour.