### PR TITLE
Update component-basics.md - wrong highlight about `slot`

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -468,7 +468,7 @@ Something bad happened.
 
 This can be achieved using Vue's custom `<slot>` element:
 
-```vue{4}
+```vue{5}
 <!-- AlertBox.vue -->
 <template>
   <div class="alert-box">


### PR DESCRIPTION
In line 471, the line 4 is highlighted but that's wrong and the line 5 must be highlighted that is about `slot`.
