### PR TITLE
Change the way focus is set in skip link example code

### DIFF
--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -13,6 +13,7 @@ You should add a link at the top of each page that goes directly to the main con
 Typically this is done on the top of `App.vue` as it will be the first focusable element on all your pages:
 
 ```vue-html
+<span ref="backToTop" tabindex="-1" />
 <ul class="skip-links">
   <li>
     <a href="#main" ref="skipLink" class="skip-link">Skip to main content</a>
@@ -23,6 +24,9 @@ Typically this is done on the top of `App.vue` as it will be the first focusable
 To hide the link unless it is focused, you can add the following style:
 
 ```css
+.skip-links {
+  list-style: none;
+}
 .skip-link {
   white-space: nowrap;
   margin: 1em auto;
@@ -40,7 +44,7 @@ To hide the link unless it is focused, you can add the following style:
 }
 ```
 
-Once a user changes route, bring focus back to the skip link. This can be achieved by calling focus on the skip link's template ref (assuming usage of `vue-router`):
+Once a user changes route, bring focus back to the very beginning of the page, right before the skip link. This can be achieved by calling focus on the `backToTop` template ref (assuming usage of `vue-router`):
 
 <div class="options-api">
 
@@ -49,7 +53,7 @@ Once a user changes route, bring focus back to the skip link. This can be achiev
 export default {
   watch: {
     $route() {
-      this.$refs.skipLink.focus()
+      this.$refs.backToTop.focus()
     }
   }
 }
@@ -65,12 +69,12 @@ import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
 const route = useRoute()
-const skipLink = ref()
+const backToTop = ref()
 
 watch(
   () => route.path,
   () => {
-    skipLink.value.focus()
+    backToTop.value.focus()
   }
 )
 </script>


### PR DESCRIPTION
## Description of Problem
The example code in the skip link section of the [accessibility best practices documentation](https://vuejs.org/guide/best-practices/accessibility#skip-link), resets the focus to the skip link every time the route changes. This brings the link into focus and shows it every time. This is technically functional, but defeats the purpose of hiding it with CSS, and doesn't match the behavior on the documentation website itself (or a few others I checked, like Wikipedia, github, w3.org). If the goal is to replicate the way regular web page navigation would affect the focus, then it should be reset to somewhere directly before the skip link.

Expected behavior: On a route change, the skip link is hidden, and when you press tab it appears and is focused.

Actual behavior: On a route change, the skip link is visible and focused. Pressing tab moves the focus to whatever the next element is.

Also, in the current example code the skip link list still has visible bullet points, so I added some CSS to hide those. 

## Proposed Solution
[The Vue theme](https://github.com/vuejs/theme/blob/0c5e8a7d9ef6f7f23cc5694782c21ab629e3a5a6/src/vitepress/components/VPSkipLink.vue) sets the focus to a `backToTop` `<span>` element directly before the skip link. This way the skip link will only ever be focused if someone presses tab just after there is a route change. This seems to be more in line with what most web pages with a hidden skip link do. 

## Additional Information
For easy reference, [WCAG skip link success criteria](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/G1)