### PR TITLE
chore: bump node version on netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22"
 
 [build]
   publish = ".vitepress/dist"


### PR DESCRIPTION
Since node version 22 is stable, I think we can use it now.