### PR TITLE
pref: pre-requisite for Yarn 4+ usage

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -106,6 +106,10 @@ If you are unsure about an option, simply choose `No` by hitting enter for now. 
   <VTCodeGroupTab label="yarn">
 
   ```sh-vue
+  # Set enableGlobalCache to false and specify the cache folder to "./.yarn/cache" in `.yarnrc.yml` 
+  # before running the following commands if you're using Yarn v4+,
+  # as Vite currently does not support global cache (https://github.com/vitejs/vite/issues/15801).
+
   $ cd {{'<your-project-name>'}}
   $ yarn
   $ yarn dev


### PR DESCRIPTION
## Description of Problem
By default, yarn 4 use global caches. but vite does not support global cache right now.

so it can't run `yarn dev` successfully if not disable global cache.

we need to add a tip in the document, or people will facing an error when they follow the tutorial.

## Proposed Solution
add pre-requisite tips for Yarn 4+ usage

## Additional Information
