### PR TITLE
chore: Add Wails.io as an alternative desktop framework to Vue docs

### DIFF
--- a/src/guide/extras/ways-of-using-vue.md
+++ b/src/guide/extras/ways-of-using-vue.md
@@ -53,7 +53,7 @@ The Vue team also maintains a static-site generator called [VitePress](https://v
 
 Although Vue is primarily designed for building web applications, it is by no means limited to just the browser. You can:
 
-- Build desktop apps with [Electron](https://www.electronjs.org/)
+- Build desktop apps with [Electron](https://www.electronjs.org/) or [Wails](https://wails.io)
 - Build mobile apps with [Ionic Vue](https://ionicframework.com/docs/vue/overview)
 - Build desktop and mobile apps from the same codebase with [Quasar](https://quasar.dev/) or [Tauri](https://tauri.app)
 - Build 3D WebGL experiences with [TresJS](https://tresjs.org/)


### PR DESCRIPTION
This pull request includes an update to the `src/guide/extras/ways-of-using-vue.md` file to expand the options for building desktop applications with Vue.

Enhancements to documentation:

* [`src/guide/extras/ways-of-using-vue.md`](diffhunk://#diff-1c4da34ef08c9e5f7c7264572b6defe977f49d972b19fb8fd5f4c92dc591ca1dL56-R56): Added a reference to [Wails](https://wails.io) as an additional option for building desktop apps alongside [Electron](https://www.electronjs.org/).