### PR TITLE
docs: fix grammar

### DIFF
--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -315,7 +315,7 @@ These restrictions are important because these are the contexts where Vue is abl
 
 ## Extracting Composables for Code Organization {#extracting-composables-for-code-organization}
 
-Composables can be extracted not only for reuse, but also for code organization. As the complexity of your components grow, you may end up with components that are too large to navigate and reason about. Composition API gives you the full flexibility to organize your component code into smaller functions based on logical concerns:
+Composables can be extracted not only for reuse, but also for code organization. As the complexity of your components grows, you may end up with components that are too large to navigate and reason about. Composition API gives you the full flexibility to organize your component code into smaller functions based on logical concerns:
 
 ```vue
 <script setup>


### PR DESCRIPTION
## Description of Problem
"Complexity" is the singular subject of the sentence, but the sentence uses the plural verb "grow".

## Proposed Solution
We should use "grows" instead of "grow".

## Additional Information
n/a