### PR TITLE
Swapped Chrome Extension URL to a non-beta version

### DIFF
--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -113,7 +113,7 @@ The Vue browser devtools extension allows you to explore a Vue app's component t
 ![devtools screenshot](./images/devtools.png)
 
 - [Documentation](https://devtools.vuejs.org/)
-- [Chrome Extension](https://chromewebstore.google.com/detail/vuejs-devtools-beta/ljjemllljcmogpfapbkkighbhhppjdbg)
+- [Chrome Extension](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
 - [Vite Plugin](https://devtools.vuejs.org/guide/vite-plugin)
 - [Standalone Electron app](https://devtools.vuejs.org/guide/standalone)
 


### PR DESCRIPTION
## Description of Problem

Old link pointed to [Vue.js devtools (beta)](https://chromewebstore.google.com/detail/vuejs-devtools-beta/ljjemllljcmogpfapbkkighbhhppjdbg).

## Proposed Solution

New link points to [Vue.js devtools](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd).

## Additional Information

Other than replacing the URL, having two list entries -- one for non-beta and one for beta version of the extension -- might be preferable.
