### PR TITLE
docs(render-function#template-refs): Make useTemplateRef the default example

### DIFF
--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -706,7 +706,25 @@ If the directive is registered by name and cannot be imported directly, it can b
 
 <div class="composition-api">
 
-With the Composition API, template refs are created by passing the `ref()` itself as a prop to the vnode:
+With the Composition API, when using [`useTemplateRef()`](/api/composition-api-helpers#usetemplateref) <sup class="vt-badge" data-text="3.5+" />  template refs are created by passing the string value as prop to the vnode:
+
+```js
+import { h, useTemplateRef } from 'vue'
+
+export default {
+  setup() {
+    const divEl = useTemplateRef('my-div')
+
+    // <div ref="my-div">
+    return () => h('div', { ref: 'my-div' })
+  }
+}
+```
+
+<details>
+<summary>Usage before 3.5</summary>
+
+In versions before 3.5 where useTemplateRef() was not introduced, template refs are created by passing the ref() itself as a prop to the vnode:
 
 ```js
 import { h, ref } from 'vue'
@@ -720,22 +738,7 @@ export default {
   }
 }
 ```
-
-or (with version >= 3.5)
-
-```js
-import { h, useTemplateRef } from 'vue'
-
-export default {
-  setup() {
-    const divEl = useTemplateRef('my-div')
-
-    // <div ref="divEl">
-    return () => h('div', { ref: 'my-div' })
-  }
-}
-```
-
+</details>
 </div>
 <div class="options-api">
 


### PR DESCRIPTION
## Description of Problem

In guide/render-function the [Template Refs](https://vuejs.org/guide/extras/render-function#template-refs) uses the old way of template ref  and only below the new (3.5) useTemplateRef. Everywhere in the docs 3.5 is the default with a fallback [Accessing the Refs](https://vuejs.org/guide/essentials/template-refs.html#accessing-the-refs)

## Proposed Solution

* Made useTemplateRef default example
* Hid the other one in a collapsable pre-3.5 version
* Fixed an example issue in the useTemplateRef version `<div ref="divEl">` -> `<div ref="my-div">`

## Additional Information
