### PR TITLE
docs: fix transition component casing

### DIFF
--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -300,7 +300,7 @@ We can even add a transition delay to the nested element on enter, which creates
 
 However, this creates a small issue. By default, the `<Transition>` component attempts to automatically figure out when the transition has finished by listening to the **first** `transitionend` or `animationend` event on the root transition element. With a nested transition, the desired behavior should be waiting until the transitions of all inner elements have finished.
 
-In such cases you can specify an explicit transition duration (in milliseconds) using the `duration` prop on the `<transition>` component. The total duration should match the delay plus transition duration of the inner element:
+In such cases you can specify an explicit transition duration (in milliseconds) using the `duration` prop on the `<Transition>` component. The total duration should match the delay plus transition duration of the inner element:
 
 ```vue-html
 <Transition :duration="550">...</Transition>


### PR DESCRIPTION
## Description of Problem

On line 303 in the Transition document, it should be `<Transition>` instead of `<transition>`

## Proposed Solution

as above

## Additional Information
