### PR TITLE
docs: fix blockquote language

### DIFF
--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -330,7 +330,7 @@ In comparison, properties like `height` or `margin` will trigger CSS layout, so 
 
 You can hook into the transition process with JavaScript by listening to events on the `<Transition>` component:
 
-```html
+```vue-html
 <Transition
   @before-enter="onBeforeEnter"
   @enter="onEnter"


### PR DESCRIPTION
## Description of Problem

On line 333 in the Transition page, `vue-html` should be used instead of `html`

## Proposed Solution

as above

## Additional Information
