### PR TITLE
docs(computed): correct parameter in computed example

### DIFF
--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -279,7 +279,7 @@ export default {
     // This computed will return the value of count when it's less or equal to 3.
     // When count is >=4, the last value that fulfilled our condition will be returned
     // instead until count is less or equal to 3
-    alwaysSmall(previous) {
+    alwaysSmall(_, previous) {
       if (this.count <= 3) {
         return this.count
       }


### PR DESCRIPTION
The first parameter in	computed is actually `publicThis`: [Playground](https://play.vuejs.org/#eNp9UstOwzAQ/BXLF4pUglDhUkIlHj3AARBwtFSFZpumOI5lr0OkKP/O2mkeB+Bie3fWuzNjN/xW66hywJc8tluTa1wJxRjUujTIUtglTiJrfI6xNMFkdtpHjBlAZ9QYM1bYbMlO1nVSaAmsAGuTDE56vO0O7bzbt2WhHUK6HDsgWJxt5kwbqPLS2cmw7oaypYRIltlsKLmeVhwp4T63EZEZsH6032iJzwexFCAQ3QQhSI9zRaxYdVaUKcgbwamN4Kv40wT4gTwgwo2Xytq2T9+PWpqggjA/ZtJaKD7naEnDLs+igy0VmR7kCe6tyCWYF405aRR88ETwRMry+ynk0Dg4mkd39rD9+iV/sLXPCf5qwIKpQPABw8RkgB28fn+Gms4DSIKdpOp/wDcg/53n2JXdOZUS7UldYPtY+O+Tq+zDrmsEZXtRnmh4glAvOP0879xf0ke6i+jy+HQtubipwPieZOAiuoouFrz9ATLd44Y=)

https://github.com/vuejs/core/blob/93d663a0462d37d2678f0a2198425703749950ec/packages/runtime-core/src/componentOptions.ts#L660-L664