### PR TITLE
Add reactivity information in Options API to Template Refs page

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -346,3 +346,24 @@ export default {
 In the above example, a parent referencing this component via template ref will only be able to access `publicData` and `publicMethod`.
 
 </div>
+
+<div class="options-api">
+
+## Reactivity of Refs {#reactivity-of-refs}
+
+Note that `this.$refs` is not reactive. For a reactive ref, you can use `useTemplateRef`:
+
+```vue
+<script>
+export default {
+  setup() {
+    useTemplateRef('input')
+  }
+}
+</script>
+
+<template>
+  <input ref="input" />
+</template>
+```
+</div>


### PR DESCRIPTION
## Description of Problem
`this.$refs` is not reactive. This is not reflected in the documentation, as far as I can tell.

## Proposed Solution
Add a small chapter about reactivity of Template Refs for the Options API.

## Additional Information
For more context, see https://github.com/vuejs/core/issues/13168.

It appears calling `useTemplateRefs('someRef')`, without doing anything with the result, is enough to make `$this.refs['someRef']` reactive. I'm not sure if that's the intended behaviour, or the result should be used. The suggested solution in the linked issue was to use the result, but it appears [it also works without using the result](https://play.vuejs.org/#eNqtVm1P2zAQ/iteNimt1KVMbF+6drAhmJi0FwEfQGSaQnJpDY6T+aUrQv3vOztp4qZpQQh/qe073z0XP8+5D97nogjmGryRN1aQFSxS8CnkBMc4ofNqapcnlMEpL7Rq9syYv83yBNgk9FJ0kKG3bhaQokkXLI8S1zZ0Q2MmItU9A3S9ieK7qcg1T0bk9cneXuiRw5jR+A5tcc5lziBI4EZPe28wtrz2y9j+7wEpZ19BKRAD0jIfBFSe8nnEaEIODoifRoyZXP76ua1u/dBzIJvx8LD15GQyIVgBpJQDxiF+vfDJiPTcY24+4lNJaLkyjmZZLvpkudzIvqPCRwC0Tj4Xw5hu8sEMdV/Yq9RK5bzNCEuaiGnjcXnZZR0lVEY3DJKaOZ13o4SG9nGXVi+C8OrqMYS7efYYyPGwkdlqPh46UsSljAUtVOVEsyIXiiD3JFxUbmeQkiVJRZ4RH8Xsfwx55VaLtrIGw3rHyN54lmFhYf2RJJFmGL5BKEHpotd3t8xYT99b1d9vvJaDZp5EKtqMITC04O1dM2wvGRGuGXOi2KgIuStDnGdYFGDXaAN1GLQJoTzqtpWqkjogibEFoG76TuJWAWpGZdDiQcvbhdqGnXPgCqttQatvquOo+QrjYU0Mb+ApiWWkdBrcypxjO7fBTMvMCowjfhaKYpmhV6cJPawr//fN7hmaVqHxzAziu479W7kwe6H3S4AEMUdi1zYViSmo0nx8/gMWOK+N+EJoht47jGeAV6ANxtLtCzYshO34WbSnltaUTy/k8UIBl6uirM7Qs/xAoYfkPtpRegN3P3hvz4V8iV9xTR1dj2Krn1R9xNDVVbmAv5oKSJqdw3gW8anxxV+szCQ6slvr58xrWeaotk2z2NkQtiu3EHmBtLr2V3DwkXy+JG1H7JSkbUtlyzsHBrH53N+jBJ0d+jxbv3U77RavK8EuEE/UYYb/ODD7Zo6tgcmEvHKFb28N31LrSdV9OdlSbQZqliebmm+To7tmm9beB4LowmDbZ0e/erlidn1Lw0iJt49hVndXM2+tcaHg/sxBGBGj1vaDD8G7fW/5H/8sF1M=).

In this PR I've added a call to `useTemplateRefs()` without using the result.

## Note
I've never contributed to this repository, so I've no clue what I'm doing ;)