### PR TITLE
docs: include example of `@vue-generic` directive

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -522,6 +522,18 @@ defineProps<{
 </script>
 ```
 
+You can use `@vue-generic` the directive to pass in explicit types, for when the type cannot be inferred:
+
+```vue
+<template>
+  <!-- @vue-generic {import('@/api').Actor} -->
+  <ApiSelect v-model="selectedPeopleIds" endpoint="/api/actors" id-prop="actorId" />
+
+  <!-- @vue-generic {import('@/api').Genre} -->
+  <ApiSelect v-model="selectedGenreIds" endpoint="/api/genres" id-prop="genreId" />
+</template>
+```
+
 In order to use a reference to a generic component in a `ref` you need to use the [`vue-component-type-helpers`](https://www.npmjs.com/package/vue-component-type-helpers) library as `InstanceType` won't work.
 
 ```vue


### PR DESCRIPTION
## Description of Problem

Currently the docs on generics are very light and very focused on how to define a generic component, rather than how to actually use said component and seems to assume that the generic value can always be inferred.

## Proposed Solution

This adds an example of how to use generics in a template with the `@vue-generic` directive to explicitly tell TypeScript what type to use, for when the type cannot be inferred.

Currently I've used a very basic example based on my real-world usage, which does technically have a few assumptions but I think just having an `@vue-generic` example in the docs should greatly increase the chances of people figuring this out quickly.

I'm happy to expand on this further if people think that would be useful, such as adding an example of the component implementation to show why the type cannot be inferred or adding a contrasting example of a component not using the directive to avoid implying the directive should always be used

## Additional Information
I personally spent a lot of time trying to figure this out which I ended up doing through a chain of something like a comment on an RFC that linked to another RFC which linked to a pull request which had been closed in favor of another, before eventually I found https://github.com/vuejs/language-tools/wiki/Directive-Comments (and that in turn lead me to learn about https://github.com/vuejs/language-tools/wiki/Vue-Compiler-Options which was very interesting too).

As far as I can tell, there's absolutely no documentation on the compiler options or directives.
