### PR TITLE
Fix: Update Russian translation repository link in config.ts

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -698,7 +698,7 @@ export default defineConfigWithTheme<ThemeConfig>({
       {
         link: 'https://ru.vuejs.org',
         text: 'Русский',
-        repo: 'https://github.com/translation-gang/docs-ru'
+        repo: 'https://github.com/vuejs-translations/docs-ru'
       },
       {
         link: 'https://cs.vuejs.org',


### PR DESCRIPTION
   This PR updates the Russian translation repository link in `.vitepress/config.ts` from `translation-gang/docs-ru` to `vuejs-translations/docs-ru` to maintain consistency with the link in `src/translations/index.md`.
   
   The `vuejs-translations/docs-ru` is the correct and active repository for Russian translations.