### PR TITLE
fix: shorten variable names to avoid code block overflow

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -527,10 +527,10 @@ You can use `@vue-generic` the directive to pass in explicit types, for when the
 ```vue
 <template>
   <!-- @vue-generic {import('@/api').Actor} -->
-  <ApiSelect v-model="selectedPeopleIds" endpoint="/api/actors" id-prop="actorId" />
+  <ApiSelect v-model="peopleIds" endpoint="/api/actors" id-prop="actorId" />
 
   <!-- @vue-generic {import('@/api').Genre} -->
-  <ApiSelect v-model="selectedGenreIds" endpoint="/api/genres" id-prop="genreId" />
+  <ApiSelect v-model="genreIds" endpoint="/api/genres" id-prop="genreId" />
 </template>
 ```
 


### PR DESCRIPTION
## Description of Problem

The new code example for @vue-generic has too long lines that cause overflow
![image](https://github.com/user-attachments/assets/05739470-ca42-4d28-91a5-01c4e48c5dfc)

## Proposed Solution

Since the variable names are purely arbitrary with no actual meaning or reference to other part of the docs, I'd just make the names shorter to fit the code inside the content area
![image](https://github.com/user-attachments/assets/a24ffda6-7596-4167-854d-f6c3ca4e2b4e)


## Additional Information
