### PR TITLE
docs: fixed typo

### DIFF
--- a/src/api/reactivity-advanced.md
+++ b/src/api/reactivity-advanced.md
@@ -38,7 +38,7 @@ Shallow version of [`ref()`](./reactivity-core#ref).
 
 ## triggerRef() {#triggerref}
 
-Force trigger effects that depends on a [shallow ref](#shallowref). This is typically used after making deep mutations to the inner value of a shallow ref.
+Force trigger effects that depend on a [shallow ref](#shallowref). This is typically used after making deep mutations to the inner value of a shallow ref.
 
 - **Type**
 


### PR DESCRIPTION
Updated verb to match the plural subject. From "effects that depends on..." to "effects that depend on...".

## Description
The definition for the advanced reactivity utility, `triggerRef()` has a minor disconnect between the the subject, "effects" and the verb, "depends".

## Proposed Solution
Since the subject, "effects" is accurate in this case, the verb has to be updated to be plural and match the subject.

## Additional Information
The full sentence is "Force trigger effects that depends on a shallow ref". The part "effects that depends on a shallow ref" is a noun phrase with a subject and verb that have been updated to be in agreement.
