### PR TITLE
Fix: provide/inject in plugins.md

### DIFF
--- a/src/guide/reusability/plugins.md
+++ b/src/guide/reusability/plugins.md
@@ -97,7 +97,7 @@ Use global properties scarcely, since it can quickly become confusing if too man
 
 ### Provide / Inject with Plugins {#provide-inject-with-plugins}
 
-Plugins also allow us to use `provide` to provide a function or attribute to the plugin's users. For example, we can allow the application to have access to the `options` parameter to be able to use the translations object.
+Plugins also allow us to use `provide` to give plugin users access to a function or attribute. For example, we can allow the application to have access to the `options` parameter to be able to use the translations object.
 
 ```js{10}
 // plugins/i18n.js

--- a/src/guide/reusability/plugins.md
+++ b/src/guide/reusability/plugins.md
@@ -97,7 +97,7 @@ Use global properties scarcely, since it can quickly become confusing if too man
 
 ### Provide / Inject with Plugins {#provide-inject-with-plugins}
 
-Plugins also allow us to use `inject` to provide a function or attribute to the plugin's users. For example, we can allow the application to have access to the `options` parameter to be able to use the translations object.
+Plugins also allow us to use `provide` to provide a function or attribute to the plugin's users. For example, we can allow the application to have access to the `options` parameter to be able to use the translations object.
 
 ```js{10}
 // plugins/i18n.js


### PR DESCRIPTION
plugins allow us to use `provide` to provide a function or attribute plugin, users are able to `inject` the plugin function or attribute

## Description of Problem
It says: _Plugins also allow us to use `inject` to provide a function or attribute to the plugin's users..._ and the example shows that `provide` is used. Also after the example it says _Plugin users will now be able to inject the plugin options..._

## Proposed Solution
Replace `inject` with `provide` 

## Additional Information
