### PR TITLE
Update FAQ after Vue2 reached end of life

### DIFF
--- a/src/about/faq.md
+++ b/src/about/faq.md
@@ -20,7 +20,7 @@ If you intend to migrate an existing Vue 2 app to Vue 3, consult the [migration 
 
 ## Is Vue 2 Still Supported? {#is-vue-2-still-supported}
 
-Vue 2.7, which was shipped in July 2022, is the final minor release of the Vue 2 version range. Vue 2 has now entered maintenance mode: it will no longer ship new features, but will continue to receive critical bug fixes and security updates for 18 months starting from the 2.7 release date. This means **Vue 2 will reach End of Life on December 31st, 2023**.
+Vue 2.7, which was shipped in July 2022, is the final minor release of the Vue 2 version range. Vue 2 has entered maintenance mode: it will no longer ship new features, but will continue to receive critical bug fixes and security updates for 18 months starting from the 2.7 release date. This means **Vue 2 reached End of Life on December 31st, 2023**.
 
 We believe this should provide plenty of time for most of the ecosystem to migrate over to Vue 3. However, we also understand that there could be teams or projects that cannot upgrade by this timeline while still needing to fulfill security and compliance requirements. We are partnering with industry experts to provide extended support for Vue 2 for teams with such needs - if your team expects to be using Vue 2 beyond the end of 2023, make sure to plan ahead and learn more about [Vue 2 Extended LTS](https://v2.vuejs.org/lts/).
 


### PR DESCRIPTION
While studying the FAQ I noticed the text has not been updated after reaching end of life date of Vue2.

I haven’t deleted the paragraphs because they still contain relevant historical information.