### PR TITLE
Fix: misplaced semicolon in crud example

### DIFF
--- a/src/examples/src/crud/App/composition.js
+++ b/src/examples/src/crud/App/composition.js
@@ -15,7 +15,7 @@ export default {
     )
 
     watch(selected, (name) => {
-      [last.value, first.value] = name.split(', ');
+      [last.value, first.value] = name.split(', ')
     })
 
     function create() {

--- a/src/examples/src/crud/App/composition.js
+++ b/src/examples/src/crud/App/composition.js
@@ -15,7 +15,7 @@ export default {
     )
 
     watch(selected, (name) => {
-      ;[last.value, first.value] = name.split(', ')
+      [last.value, first.value] = name.split(', ');
     })
 
     function create() {


### PR DESCRIPTION
## Description of Problem

this is more a typo

## Proposed Solution

## Additional Information

this is really not something important, but I spotted it while going through the docs and example, I guess it can be clearer if fixed
