### PR TITLE
fix hook name to composition version

### DIFF
--- a/src/api/composition-api-lifecycle.md
+++ b/src/api/composition-api-lifecycle.md
@@ -210,7 +210,7 @@ Registers a hook to be called when an error propagating from a descendant compon
   In production, the 3rd argument (`info`) will be a shortened code instead of the full information string. You can find the code to string mapping in the [Production Error Code Reference](/error-reference/#runtime-errors).
   :::
 
-  You can modify component state in `errorCaptured()` to display an error state to the user. However, it is important that the error state should not render the original content that caused the error; otherwise the component will be thrown into an infinite render loop.
+  You can modify component state in `onErrorCaptured()` to display an error state to the user. However, it is important that the error state should not render the original content that caused the error; otherwise the component will be thrown into an infinite render loop.
 
   The hook can return `false` to stop the error from propagating further. See error propagation details below.
 


### PR DESCRIPTION
## Description of Problem
errorCaptured() is options api, and there must be onErrorCaptured()

## Proposed Solution

## Additional Information
