### PR TITLE
docs(computed): correct parameter positions in the computed example

### DIFF
--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -263,8 +263,15 @@ Now when you run `fullName.value = 'John Doe'`, the setter will be invoked and `
 
 - Only supported in 3.4+
 
+<p class="options-api">
+In case you need it, you can get the previous value returned by the computed property accessing
+the second argument of the getter:
+</p>
+
+<p class="composition-api">
 In case you need it, you can get the previous value returned by the computed property accessing
 the first argument of the getter:
+</p>
 
 <div class="options-api">
 
@@ -326,7 +333,7 @@ export default {
   },
   computed: {
     alwaysSmall: {
-      get(previous) {
+      get(_, previous) {
         if (this.count <= 3) {
           return this.count
         }


### PR DESCRIPTION
## Description of Problem

In the Options API, the first parameter in the computed getter is actually `publicThis`.

## Additional Information

See [https://github.com/vuejs/docs/pull/3206](https://github.com/vuejs/docs/pull/3206)
