### PR TITLE
Corrected the arguments of the computed with a single getter in compu…

### DIFF
--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -279,7 +279,7 @@ export default {
     // This computed will return the value of count when it's less or equal to 3.
     // When count is >=4, the last value that fulfilled our condition will be returned
     // instead until count is less or equal to 3
-    alwaysSmall(_, previous) {
+    alwaysSmall(previous) {
       if (this.count <= 3) {
         return this.count
       }


### PR DESCRIPTION
computed.md

## Description of Problem
The document says that the previous value is accessed through the first parameter, while the demonstration code accesses it through the second parameter. I checked the source code and did not find any processing logic for multiple parameters.
## Proposed Solution
Remove redundant parameters

