### PR TITLE
Update composition-api.md 

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -432,7 +432,7 @@ const compRef = useTemplateRef<FooType | BarType>('comp')
 </script>
 
 <template>
-  <component :is="Math.random() > 0.5 ? Foo : Bar" ref="comp" />
+  <component :is="Math.random() > 0.5 ? Foo : Bar" ref="compRef" />
 </template>
 ```
 


### PR DESCRIPTION
## Description of Problem
I was going through the documentations and found an error in the documentations. In the  "Typing Component Template Refs" section of "TS with composition API", there is a first code snippet below the description of "Typing Component Template Refs". In this code snippet when we are passing the ref in the component there is a typo error in the name of the ref. We have declared the ref as "compRef " and passed the ref as "comp". This needs to be fixed to ref="compRef".

## Proposed Solution
current:
<component :is="Math.random() > 0.5 ? Foo : Bar" ref="comp"

expected:
<component :is="Math.random() > 0.5 ? Foo : Bar" ref="compRef" 

## Additional Information
