### PR TITLE
docs(theme): fix incorrect URL with missing query parameter

### DIFF
--- a/src/ecosystem/themes/themes.json
+++ b/src/ecosystem/themes/themes.json
@@ -337,7 +337,7 @@
         "name": "Sneat - Vue Laravel Admin",
         "price": 0,
         "description": "Free & Open Source VueJS Laravel Admin using Sneat Design System",
-        "url": "https://themeselection.com/item/sneat-free-vuetify-vuejs-laravel-admin-template/ref=14",
+        "url": "https://themeselection.com/item/sneat-free-vuetify-vuejs-laravel-admin-template/?ref=14",
         "image": "https://cdn.themeselection.com/ts-assets/sneat/sneat-vuetify-vuejs-laravel-admin-template-free/banner/banner.png"
       },
       {


### PR DESCRIPTION
## Description of Problem

I'm Yagnik from ThemeSelection.

While browsing the documentation, I noticed that one of the theme URLs in the `themes.json` file has an incorrect link due to a missing `?` character in the query parameter.

## Proposed Solution

**Corrected URL:** https://themeselection.com/item/sneat-free-vuetify-vuejs-laravel-admin-template/?ref=14

## Additional Information

![image](https://github.com/user-attachments/assets/1225fd80-9bb9-47de-8430-621236db5fb4)

