### PR TITLE
docs: sync vite need node version

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -23,7 +23,7 @@ import { VTCodeGroup, VTCodeGroupTab } from '@vue/theme'
 :::tip Prerequisites
 
 - Familiarity with the command line
-- Install [Node.js](https://nodejs.org/) version 18.3 or higher
+- Install [Node.js](https://nodejs.org/) version `^20.19.0 || >=22.12.0`
   :::
 
 In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vitejs.dev) and allow us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).


### PR DESCRIPTION
## Description of Problem

The vite version currently supported by create-vue is 7, and the node version required by vite is as follows. In order to ensure that the created project is OK, you need to synchronize the node version information.

https://github.com/vitejs/vite/blob/588b3b5a44eef35bcca0e3079df579d50a528421/package.json#L6
## Proposed Solution

## Additional Information
