### PR TITLE
docs: clarify HTML validator warnings for Vue-specific directives

### DIFF
--- a/src/guide/template-syntax.md
+++ b/src/guide/template-syntax.md
@@ -1,0 +1,3 @@
+:::tip Vue-specific Attributes
+You might see HTML validators or IDEs warn that attributes like `v-if`, `@click`, or `v-bind` are invalid. These are Vue-specific directives that are processed by Vue’s template compiler and are not standard HTML attributes. This is expected and safe to ignore in Vue templates.
+:::


### PR DESCRIPTION
## What This Does

This adds a tip box to the `template-syntax.md` guide explaining that Vue-specific attributes like `v-if`, `@click`, and `v-bind` may appear as invalid in HTML validators or IDEs. These are Vue template directives and are expected to be handled by Vue's compiler.

## Why

Fixes [vuejs/vue#4428](https://github.com/vuejs/vue/issues/4428), which notes that new users may find these attributes invalid when writing Vue templates. This update clarifies that this is expected behavior and not a bug.

Thanks!
