### PR TITLE
:lipstick: update reverse array example to modern syntax

### DIFF
--- a/src/guide/essentials/list.md
+++ b/src/guide/essentials/list.md
@@ -436,5 +436,5 @@ Be careful with `reverse()` and `sort()` in a computed property! These two metho
 
 ```diff
 - return numbers.reverse()
-+ return [...numbers].reverse()
++ return numbers.toReversed()
 ```


### PR DESCRIPTION

## Description of Problem

This is not a problem but a stylistic suggestion.

The example currently uses `[...array].reverse()`, which can be simplified using a more modern and concise syntax.


## Proposed Solution

Suggest using the simpler:

`array.toReversed()`

This achieves the same result reversing the array without mutating the original, but in a cleaner and more modern way.

## Additional Information

array.toReversed() was introduced in ECMAScript 2023
