### PR TITLE
docs: delete  “attrs and slots are not reactive”

### DIFF
--- a/src/api/composition-api-setup.md
+++ b/src/api/composition-api-setup.md
@@ -111,7 +111,7 @@ export default {
 }
 ```
 
-`attrs` and `slots` are stateful objects that are always updated when the component itself is updated. This means you should avoid destructuring them and always reference properties as `attrs.x` or `slots.x`. Also note that, unlike `props`, the properties of `attrs` and `slots` are **not** reactive. If you intend to apply side effects based on changes to `attrs` or `slots`, you should do so inside an `onBeforeUpdate` lifecycle hook.
+`attrs` and `slots` are stateful objects that are always updated when the component itself is updated. This means you should avoid destructuring them and always reference properties as `attrs.x` or `slots.x`. If you intend to apply side effects based on changes to `attrs` or `slots`, you should do so inside an `onBeforeUpdate` lifecycle hook.
 
 ### Exposing Public Properties {#exposing-public-properties}
 


### PR DESCRIPTION
## Description of Problem

## Proposed Solution

## Additional Information
经测试发现，当前 Vue 版本中 attrs 和 slots 已经是响应式的。
Testing shows that in the current Vue version, attrs and slots are reactive.
[demo](https://play.vuejs.org/#eNp9U8tu1DAU/RXLQkqihkQIVqPMiIe6gAUgyq7uws3czKR17Mh2hpFG2bJFSBWbii38ACCx4WtgVP6i104yE1VtN0l8z7nH5z6yoc/qOlk1QCc0M7kua0sM2KaeMVlWtdKWbIiGgrSk0KoiAVIDJnfgC1XVPZKk7uC0kJAraSzhZOqSw0cRk1nayaMwHixUteAW8ERI5lUmfMooZ3S22fC2zbxaB5821ipJnuaizM8d6eAAadvLH9uL3zxLOxipWTqSpTG1Bm0U5SI5M0pigRunxmiOwqUA/aa2JdpkdEI84jAuhPrwysesbiAe4vkS8vNb4mdm7WKMvtVgQK+A0R1muV6A7eDDo9ewxu8dWKl5I5B9D/gOjBKN89jRnjdyjrZHPO/2pZ9EKRfvzeHagjRDUc6oY7aezyhOxvX0rtL3dh8nT3weky12cZjq3RtyhMMZdgA73a/APQPHmbqc1cPTUs5xoA+4tRrdDKARypK0G36KzFtm29+zNzVe2GUMRQG5vbG1sPb4HAreCOQ5fV9KWGtVmxgzvZGYOAP4gqq0+MQ0A6SNhl514mEYTWd9hHSJCR+Obv+VgESoRRhcff/279Pnv3++Xv38sr349f/yY4A/hKO1/VujCy2JUyTLMJiXqyA+7rWOd5HAX4J/1YoLLCiKB6C/PIpP+tUYJ/lm7nO62pK+CWE0pJx4K27mo9HR9hq/yWIO)