### PR TITLE
Fix a typo in the Privacy Policy

### DIFF
--- a/src/about/privacy.md
+++ b/src/about/privacy.md
@@ -24,7 +24,7 @@ We may collect anonymized data via 3rd party services integrated in our websites
 
   - Fathom Analytics' Privacy Policy: https://usefathom.com/legal/privacy
 
-- **Usage data of the search functionality.** Our search functionality is powered by [Algolia DocSearch](https://docsearch.algolia.com/), which does not perform any type of user tracking or fingerprinting, and does not use cookies. Algolia services are GPDR compliant, CCPA compliant, and TRUSTe Certified.
+- **Usage data of the search functionality.** Our search functionality is powered by [Algolia DocSearch](https://docsearch.algolia.com/), which does not perform any type of user tracking or fingerprinting, and does not use cookies. Algolia services are GDPR compliant, CCPA compliant, and TRUSTe Certified.
 
   - Algolia's privacy policy: https://www.algolia.com/policies/privacy/
   - Algolia's security and privacy compliance: https://www.algolia.com/distributed-secure/security-compliance/


### PR DESCRIPTION
## Description of Problem

There is a typo in the Vue [Privacy Policy](https://vuejs.org/about/privacy.html#what-kinds-of-information-do-we-collect) under “What Kinds of Information Do We Collect?”. The typo is about Algolia’s services saying that it’s “GPDR compliant”, which is a typo.

> […] Algolia services are GPDR compliant, CCPA compliant, and TRUSTe Certified.

## Proposed Solution

This PR proposes a fix of this typo, by replacing “GPDR compliant” with “GDPR compliant”.

```diff
- [...] Algolia services are GPDR compliant, CCPA compliant, and TRUSTe Certified.
+ [...] Algolia services are GDPR compliant, CCPA compliant, and TRUSTe Certified.
```

## Additional Information

_There’s no additional information required for this pull request._
