### PR TITLE
Update Vueschool banner script URL

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -636,7 +636,7 @@ export default defineConfigWithTheme<ThemeConfig>({
     [
       'script',
       {
-        src: 'https://vueschool.io/banner.js?affiliate=vuejs&type=top',
+        src: 'https://media.bitterbrains.com/main.js?from=vuejs&type=top',
         async: 'true'
       }
     ],


### PR DESCRIPTION
## Description of Problem
Vue School Banner script is being blocked by adblockers

## Proposed Solution
Banner Script url updated 

## Additional Information
new url - `https://media.bitterbrains.com/main.js?from=vuejs&type=top`