### PR TITLE
Factory functions for default values are optional

### DIFF
--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -467,7 +467,7 @@ defineProps({
   // Object with a default value
   propF: {
     type: Object,
-    // Object or array defaults must be returned from
+    // Object or array defaults can be returned from
     // a factory function. The function receives the raw
     // props received by the component as the argument.
     default(rawProps) {


### PR DESCRIPTION
There's no more error and types also allow for directly passing objects as the default value.

## Description of Problem

In Vue2 passing objects as a default would cause an error message in the logs. This message is gone now and the type system also seems to allow passing objects directly.
At the same time the docs still claim that a factory function must be used.

## Proposed Solution

Update documentation to match the current state.

## Additional Information

I have no knowledge about the implication of using a factory function or not. Would just be nice if docs and type hints / warnings matched.