### PR TITLE
docs: remove dead link

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -54,7 +54,6 @@ const nav: ThemeConfig['nav'] = [
         text: 'Resources',
         items: [
           { text: 'Partners', link: '/partners/' },
-          { text: 'Developers', link: '/developers/' },
           { text: 'Themes', link: '/ecosystem/themes' },
           { text: 'UI Components', link: 'https://ui-libs.vercel.app/' },
           {


### PR DESCRIPTION
## Description of Problem
The developers page was removed in https://github.com/vuejs/docs/commit/332cd2eb53a8ecdde8ac97117bee651c46ff07ad .

https://vuejs.org/developers/ now returns 404 not found.

## Proposed Solution

## Additional Information
