### PR TITLE
Fix typo: remove duplicate word "be"

### DIFF
--- a/src/api/composition-api-helpers.md
+++ b/src/api/composition-api-helpers.md
@@ -134,5 +134,5 @@ Used to generate unique-per-application IDs for accessibility attributes or form
   If you have more than one Vue application instance of the same page, you can avoid ID conflicts by giving each app an ID prefix via [`app.config.idPrefix`](/api/application#app-config-idprefix).
 
   :::warning Caution
-  `useId()` should be not be called inside a `computed()` property as it may cause instance conflicts. Instead, declare the ID outside of `computed()` and reference it within the computed function.
+  `useId()` should not be called inside a `computed()` property as it may cause instance conflicts. Instead, declare the ID outside of `computed()` and reference it within the computed function.
   :::


### PR DESCRIPTION
## Description of Problem

In [the warning at the end of the useId() section](https://vuejs.org/api/composition-api-helpers.html#useid) the word "be" is duplicated. 

## Proposed Solution

Change the copy from

> `useId()` should be not be called inside a `computed()` property...

to 

> `useId()` should not be called inside a `computed()` property...
