### PR TITLE
Fixed a typo in watchers.md

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -486,7 +486,7 @@ export default {
 
 </div>
 
-This works in versions before 3.5. In addition, `onCleanup` passed via function argument is bound to the watcher instance so it is not subject to the synchronously constraint of `onWatcherCleanup`.
+This works in versions before 3.5. In addition, `onCleanup` passed via function argument is bound to the watcher instance so it is not subject to the synchronous constraint of `onWatcherCleanup`.
 
 ## Callback Flush Timing {#callback-flush-timing}
 


### PR DESCRIPTION
Hi, while reading about [watchers](https://vuejs.org/guide/essentials/watchers.html), I found a typo that I fixed.

**Before**

```text
... is not subject to the `synchronously` constraint of ...
```


**After**

```text
... is not subject to the `synchronous` constraint of ...
```