### PR TITLE
chore: replace all instances of twitter.com with x.com

### DIFF
--- a/.vitepress/theme/components/NewsLetter.vue
+++ b/.vitepress/theme/components/NewsLetter.vue
@@ -45,7 +45,7 @@ import { VTLink } from '@vue/theme'
           href="https://news.vuejs.org/"
           no-icon
         >news.vuejs.org</VTLink>. You may also go social at
-        <VTLink class="link" href="https://twitter.com/vuejs" no-icon>Twitter</VTLink>, or join our home at
+        <VTLink class="link" href="https://x.com/vuejs" no-icon>Twitter</VTLink>, or join our home at
         <VTLink class="link" href="https://discord.com/invite/vue" no-icon>Discord</VTLink>.
       </p>
     </div>

--- a/src/about/community-guide.md
+++ b/src/about/community-guide.md
@@ -16,7 +16,7 @@ Our [Code of Conduct](/about/coc) is a guide to make it easier to enrich all of 
 
 ### Stay in the Know {#stay-in-the-know}
 
-- Follow our [official Twitter account](https://twitter.com/vuejs).
+- Follow our [official Twitter account](https://x.com/vuejs).
 - Follow our [team members](./team) on Twitter or GitHub.
 - Follow the [RFC discussions](https://github.com/vuejs/rfcs).
 - Subscribe to the [official blog](https://blog.vuejs.org/).
@@ -28,7 +28,7 @@ Our [Code of Conduct](/about/coc) is a guide to make it easier to enrich all of 
 - [DEV Community](https://dev.to/t/vue): Share and discuss Vue related topics on Dev.to.
 - [Meetups](https://events.vuejs.org/meetups): Want to find local Vue enthusiasts like yourself? Interested in becoming a community leader? We have the help and support you need right here!
 - [GitHub](https://github.com/vuejs): If you have a bug to report or feature to request, that's what the GitHub issues are for. Please respect the rules specified in each repository's issue template.
-- [Twitter Community (unofficial)](https://twitter.com/i/communities/1516368750634840064): A Twitter community, where you can meet other Vue enthusiasts, get help, or just chat about Vue.
+- [Twitter Community (unofficial)](https://x.com/i/communities/1516368750634840064): A Twitter community, where you can meet other Vue enthusiasts, get help, or just chat about Vue.
 
 ### Explore the Ecosystem {#explore-the-ecosystem}
 
@@ -80,4 +80,4 @@ There's a lot you can do to help Vue grow in your community:
 - **Start your own meetup.** If there's not already a Vue meetup in your area, you can start your own! Use the [resources at events.vuejs.org](https://events.vuejs.org/resources/#getting-started) to help you succeed!
 - **Help meetup organizers.** There can never be too much help when it comes to running an event, so offer a hand to help out local organizers to help make every event a success.
 
-If you have any questions on how you can get more involved with your local Vue community, reach out on Twitter at [@vuejs_events](https://www.twitter.com/vuejs_events)!
+If you have any questions on how you can get more involved with your local Vue community, reach out on Twitter at [@vuejs_events](https://www.x.com/vuejs_events)!

--- a/src/about/faq.md
+++ b/src/about/faq.md
@@ -2,7 +2,7 @@
 
 ## Who maintains Vue? {#who-maintains-vue}
 
-Vue is an independent, community-driven project. It was created by [Evan You](https://twitter.com/youyuxi) in 2014 as a personal side project. Today, Vue is actively maintained by [a team of both full-time and volunteer members from all around the world](/about/team), where Evan serves as the project lead. You can learn more about the story of Vue in this [documentary](https://www.youtube.com/watch?v=OrxmtDw4pVI).
+Vue is an independent, community-driven project. It was created by [Evan You](https://x.com/youyuxi) in 2014 as a personal side project. Today, Vue is actively maintained by [a team of both full-time and volunteer members from all around the world](/about/team), where Evan serves as the project lead. You can learn more about the story of Vue in this [documentary](https://www.youtube.com/watch?v=OrxmtDw4pVI).
 
 Vue's development is primarily funded through sponsorships and we have been financially sustainable since 2016. If you or your business benefit from Vue, consider [sponsoring us](/sponsor/) to support Vue's development!
 

--- a/src/about/team/TeamMember.vue
+++ b/src/about/team/TeamMember.vue
@@ -153,7 +153,7 @@ function arrayify(value: string | string[]): string[] {
           <li v-if="member.socials.twitter" class="social-item">
             <VTLink
               class="social-link"
-              :href="`https://twitter.com/${member.socials.twitter}`"
+              :href="`https://x.com/${member.socials.twitter}`"
               :no-icon="true"
             >
               <VTIconX class="social-icon" />

--- a/src/about/team/members-partner.json
+++ b/src/about/team/members-partner.json
@@ -214,7 +214,7 @@
     "projects": [
       {
         "label": "VueJsNews",
-        "url": "https://twitter.com/VueJsNews"
+        "url": "https://x.com/VueJsNews"
       }
     ],
     "website": {

--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -252,7 +252,7 @@ End-to-end tests do not import any of your Vue application's code but instead re
 
 End-to-end tests validate many of the layers in your application. They can either target your locally built application or even a live Staging environment. Testing against your Staging environment not only includes your frontend code and static server but all associated backend services and infrastructure.
 
-> The more your tests resemble how your software is used, the more confidence they can give you. - [Kent C. Dodds](https://twitter.com/kentcdodds/status/977018512689455106) - Author of the Testing Library
+> The more your tests resemble how your software is used, the more confidence they can give you. - [Kent C. Dodds](https://x.com/kentcdodds/status/977018512689455106) - Author of the Testing Library
 
 By testing how user actions impact your application, E2E tests are often the key to higher confidence in whether an application is functioning properly or not.
 

--- a/src/sponsor/index.md
+++ b/src/sponsor/index.md
@@ -43,7 +43,7 @@ You can also try to convince your employer to sponsor Vue as a business. This ma
 - **Global Special Sponsor**:
   - Limited to **one** sponsor globally. <span v-if="!data?.special">Currently vacant. [Get in touch](mailto:sponsor@vuejs.org?subject=Vue.js%20special%20sponsor%20inquiry)!</span><span v-else>(Currently filled)</span>
   - (Exclusive) **Above the fold** logo placement on the front page of [vuejs.org](/).
-  - (Exclusive) Special shoutout and regular retweets of major product launches via [Vue's official X account](https://twitter.com/vuejs) (320k followers).
+  - (Exclusive) Special shoutout and regular retweets of major product launches via [Vue's official X account](https://x.com/vuejs) (320k followers).
   - Most prominent logo placement in all locations from tiers below.
 - **Platinum (USD$2,000/mo)**:
   - Prominent logo placement on the front page of [vuejs.org](/).


### PR DESCRIPTION
## Description of Problem

Outdated links that now automatically redirect to x.com

## Proposed Solution

Replaced with x.com to avoid the redirection

## Additional Information

N/A