### PR TITLE
fix: correct grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ corepack enable
 
 ## Working on the theme
 
-If changes need to made for the theme, check out the [instructions for developing the theme alongside the docs](https://github.com/vuejs/vue-theme#developing-with-real-content).
+If changes need to be made for the theme, check out the [instructions for developing the theme alongside the docs](https://github.com/vuejs/vue-theme#developing-with-real-content).


### PR DESCRIPTION
## Description of Problem
Fixed a grammatical error in the README.md file where "need to made" was incorrectly written instead of the proper passive voice construction "need to be made".

## Proposed Solution
Changed "If changes need to made for the theme" to "If changes need to be made for the theme" to correct the grammar.

## Additional Information
This is a minor grammatical correction that improves the clarity and correctness of the documentation.