### PR TITLE
docs(reactivity-watchers.md): remove ambiguous “versions before 3.5” statement from watcher onCleanup section

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -486,7 +486,7 @@ export default {
 
 </div>
 
-This works in versions before 3.5. In addition, `onCleanup` passed via function argument is bound to the watcher instance so it is not subject to the synchronous constraint of `onWatcherCleanup`.
+`onCleanup` passed via function argument is bound to the watcher instance so it is not subject to the synchronous constraint of `onWatcherCleanup`.
 
 ## Callback Flush Timing {#callback-flush-timing}
 


### PR DESCRIPTION
## Description of Problem
Removed the ambiguous line “This works in versions before 3.5. In addition”.

The onCleanup callback argument remains available in 3.5+, so the old note could mislead readers into thinking it was deprecated; dropping it keeps the wording accurate and concise.

## Proposed Solution

Remove the misleading sentence. No other changes to code examples or surrounding explanations are needed.

## Additional Information

none
