### PR TITLE
docs: update v-text directive details for clarity

### DIFF
--- a/src/api/built-in-directives.md
+++ b/src/api/built-in-directives.md
@@ -8,7 +8,7 @@ Update the element's text content.
 
 - **Details**
 
-  `v-text` works by setting the element's [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) property, so it will overwrite any existing content inside the element. If you need to update only part of the `textContent`, you should use [mustache interpolations](/guide/essentials/template-syntax#text-interpolation) instead (ie. <span v-pre><span>Keep this but update a {{dynamicPortion}}</span></span>).
+  `v-text` works by setting the element's [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) property, so it will overwrite any existing content inside the element. If you need to update only part of the `textContent`, you should use [mustache interpolations](/guide/essentials/template-syntax#text-interpolation) instead (ie. <span v-pre>`<span>Keep this but update a {{dynamicPortion}}</span>`</span>).
 
 - **Example**
 


### PR DESCRIPTION
Clarified usage of v-text directive regarding textContent updates.

## Description of Problem
The idea seemed to be incomplete after reading it a few times.

## Proposed Solution
Clarify that when you want to update _portions_ of the `textContent` is when you want to reach out for the Mustache syntax.

## Additional Information
