### PR TITLE
docs: remove "computed" from composable usage restrictions

### DIFF
--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -302,7 +302,7 @@ These restrictions are important because these are the contexts where Vue is abl
 
 1. Lifecycle hooks can be registered to it.
 
-2. Computed properties and watchers can be linked to it, so that they can be disposed when the instance is unmounted to prevent memory leaks.
+2. Watchers can be linked to it, so that they can be disposed when the instance is unmounted to prevent memory leaks.
 
 :::tip
 `<script setup>` is the only place where you can call composables **after** using `await`. The compiler automatically restores the active instance context for you after the async operation.


### PR DESCRIPTION
This PR removes the mention of linking computed properties to the instance of a component in order to be stopped.
If I'm not mistaken, this is no longer how computed properties work after the reactivity refactor introduced in 3.5 https://github.com/vuejs/core/pull/10397. Computed properties now do not need to be stopped and can be garbage collected once they are no longer in scope.