### PR TITLE
docs: explain default error handler behaviour

### DIFF
--- a/src/api/application.md
+++ b/src/api/application.md
@@ -400,6 +400,11 @@ Assign a global handler for uncaught errors propagating from within the applicat
   }
   ```
 
+- **Default**
+
+  The default error handler will re-throw errors during development and log errors during production.
+  You can configure this using the [throwUnhandledErrorInProduction](#app-config-throwunhandlederrorinproduction) property.
+
 ## app.config.warnHandler {#app-config-warnhandler}
 
 Assign a custom handler for runtime warnings from Vue.


### PR DESCRIPTION
## Description of Problem

Currently, it is very hard to understand how the default error handler behaves.

- It throws during development, triggering the global error handler.
- It only logs/does not throw in production, causing error events missing in the error reporting loop.
- The difference in behavior causes confusion

## Proposed Solution

Explicitly mention the default behaviour and link to properties to configure this.
Feel free to suggest improvements or different solutions.

Preview: https://deploy-preview-3320--vuejs.netlify.app/api/application.html#app-config-errorhandler

## Additional Information

I spend multiple hours trying to detect why no errors were reported to our monitoring solution.
In the end, I had to look into the default error handler source code to become aware of the throwunhandlederrorinproduction property.
During my search I didn't find any other part in the documentation mentioning this behavior, the errorhandler and throwunhandlederrorinproduction properties being separated by a bunch of other properties didn't help either.
