### PR TITLE
Fix punctuation in SPA section

### DIFF
--- a/src/guide/extras/ways-of-using-vue.md
+++ b/src/guide/extras/ways-of-using-vue.md
@@ -14,7 +14,7 @@ You can use Vue to [build standard Web Components](/guide/extras/web-components)
 
 ## Single-Page Application (SPA) {#single-page-application-spa}
 
-Some applications require rich interactivity, deep session depth, and non-trivial stateful logic on the frontend. The best way to build such applications is to use an architecture where Vue not only controls the entire page, but also handles data updates and navigation without having to reload the page. This type of application is typically referred to as a Single-Page Application (SPA).
+Some applications require rich interactivity, deep session depth and non-trivial stateful logic on the frontend. The best way to build such applications is to use an architecture where Vue not only controls the entire page, but also handles data updates and navigation without having to reload the page. This type of application is typically referred to as a Single-Page Application (SPA).
 
 Vue provides core libraries and [comprehensive tooling support](/guide/scaling-up/tooling) with amazing developer experience for building modern SPAs, including:
 


### PR DESCRIPTION
Removed a comma for improved sentence flow.

## Description of Problem

The original sentence contained an unnecessary comma between “deep session depth” and “and non-trivial stateful logic”.
While grammatically acceptable in some contexts, in this case it disrupted the natural flow of the sentence and reduced readability in technical documentation.

## Proposed Solution

Removed the comma to improve sentence flow and align the phrasing with standard technical writing conventions.
The change does not alter meaning, only improves clarity and consistency of the documentation.

## Additional Information

- No functional or behavioral changes.
- Documentation-only change.
- Improves readability and stylistic consistency with surrounding content.
