### PR TITLE
docs: fix type description in composition-api.md

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -252,10 +252,10 @@ const year = ref<string | number>('2020')
 year.value = 2020 // ok!
 ```
 
-If you specify a generic type argument but omit the initial value, the resulting type will be a union type that includes `undefined`:
+If you specify a generic type argument but omit the initial value, the resulting type will be the specified type (not a union with `undefined`):
 
 ```ts
-// inferred type: Ref<number | undefined>
+// inferred type: Ref<number>
 const n = ref<number>()
 ```
 


### PR DESCRIPTION
## Description of Problem

The documentation incorrectly states that when you specify a generic type argument but omit the initial value for `ref()`, the resulting type will be a union type that includes `undefined` (e.g., `Ref<number | undefined>`). However, the actual inferred type is still the specified type (`Ref<number>`), not a union type with `undefined`.

## Proposed Solution

Fixed the type description to clarify that even when the initial value is omitted, the resulting type remains the specified type (not a union with `undefined`). Also updated the type annotation in the code example from `Ref<number | undefined>` to `Ref<number>` to accurately reflect the actual behavior.

## Additional Information

- Modified file: `src/guide/typescript/composition-api.md`
- Modified lines: 255-260