### PR TITLE
docs: fix outdated link in keep-alive.md

### DIFF
--- a/src/guide/built-ins/keep-alive.md
+++ b/src/guide/built-ins/keep-alive.md
@@ -79,7 +79,7 @@ Since version 3.2.34, a single-file component using `<script setup>` will automa
 
 ## Max Cached Instances {#max-cached-instances}
 
-We can limit the maximum number of component instances that can be cached via the `max` prop. When `max` is specified, `<KeepAlive>` behaves like an [LRU cache](<https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)>): if the number of cached instances is about to exceed the specified max count, the least recently accessed cached instance will be destroyed to make room for the new one.
+We can limit the maximum number of component instances that can be cached via the `max` prop. When `max` is specified, `<KeepAlive>` behaves like an [LRU cache](<https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_Recently_Used_(LRU)>): if the number of cached instances is about to exceed the specified max count, the least recently accessed cached instance will be destroyed to make room for the new one.
 
 ```vue-html
 <KeepAlive :max="10">


### PR DESCRIPTION
## Description of Problem
The guide contained a link with an outdated anchor to Wikipedia

## Proposed Solution
Update the link to the latest version of the page on Wikipedia to send the user directly to the right anchor

## Additional Information
[Difference between revisions that introduced this change on Wikipedia](https://en.wikipedia.org/w/index.php?title=Cache_replacement_policies&diff=prev&oldid=1234591614)