### PR TITLE
docs: fix missing anchors

### DIFF
--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -216,7 +216,7 @@ function render() {
 }
 ```
 
-### Using Vnodes in `<template>`
+### Using Vnodes in `<template>` {#using-vnodes-in-template}
 
 ```vue
 <script setup>

--- a/src/guide/reusability/plugins.md
+++ b/src/guide/reusability/plugins.md
@@ -133,6 +133,6 @@ export default {
 
 </div>
 
-### Bundle for NPM
+### Bundle for NPM {#bundle-for-npm}
 
 If you further want to build and publish your plugin for others to use, see [Vite's section on Library Mode](https://vite.dev/guide/build.html#library-mode).


### PR DESCRIPTION
## Description of Problem

I have noticed two places in `.md` files where anchors are not defined after a heading

## Proposed Solution

Anchors added to both places 

## Additional Information

I found the missing ones via regex `^#[^\{]*$` - _line starting with `#` and not containing any `{` until the end_ - which indicates the anchor in Vitepress way is not defined. There are a handful of false positives that can be easilly ignored, so this allows to quickly check it on regular basis.