### PR TITLE
docs: fix custom element helper wording

### DIFF
--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -348,7 +348,7 @@ The implementation details have been omitted, but the important part is that we 
 Let's create a type helper for easily registering custom element type definitions in Vue:
 
 ```ts [some-lib/src/DefineCustomElement.ts]
-// We can re-use this type helper per each element we need to define.
+// We can reuse this type helper for each element we need to define.
 type DefineCustomElement<
   ElementType extends HTMLElement,
   Events extends EventMap = {},


### PR DESCRIPTION
## Summary
- fix a small wording typo in the custom element helper example

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- Reviewed `README.md` and `.github/contributing/writing-guide.md`
- Kept the change to one docs file with no behavior impact

## Validation
- `git diff --check`