### PR TITLE
docs: fix theme description typo

### DIFF
--- a/src/ecosystem/themes/themes.json
+++ b/src/ecosystem/themes/themes.json
@@ -266,7 +266,7 @@
       {
         "name": "Free Berry Vuetify VueJs Admin Template",
         "price": 0,
-        "description": "Free & Open Source VueJs Admin Template with well known desing of Berry",
+        "description": "Free & Open Source VueJs Admin Template with well known design of Berry",
         "url": "https://codedthemes.com/item/berry-free-vuetify-vuejs-admin-template/?ref=evan.vuejs",
         "image": "https://org-public-assets.s3.us-west-2.amazonaws.com/Banners/Berry-free-vue.png"
       },


### PR DESCRIPTION
## Summary
- fix a typo in a theme description entry

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- Reviewed `README.md` and `.github/contributing/writing-guide.md`
- Kept the change to one content file with no behavior impact

## Validation
- `git diff --check`