### PR TITLE
docs: typescript essential style guide

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -548,6 +548,10 @@ export const sidebar: ThemeConfig['sidebar'] = {
           link: '/style-guide/rules-essential'
         },
         {
+          text: 'A - Essential (TypeScript)',
+          link: '/style-guide/rules-essential-ts'
+        },
+        {
           text: 'B - Strongly Recommended',
           link: '/style-guide/rules-strongly-recommended'
         },

--- a/src/style-guide/index.md
+++ b/src/style-guide/index.md
@@ -4,42 +4,44 @@ outline: deep
 
 # Style Guide {#style-guide}
 
-::: warning Note
-This Vue.js Style Guide is outdated and needs to be reviewed. If you have any questions or suggestions, please [open an issue](https://github.com/vuejs/docs/issues/new).
+::: warning Status
+This section is under active revision. Priority A: Essential is currently the maintained section of the guide. Priority B, C, and D are retained as legacy reference content.
 :::
 
-This is the official style guide for Vue-specific code. If you use Vue in a project, it's a great reference to avoid errors, bikeshedding, and anti-patterns. However, we don't believe that any style guide is ideal for all teams or projects, so mindful deviations are encouraged based on past experience, the surrounding tech stack, and personal values.
+This is the official style guide for Vue-specific code. It is meant to help teams make sound architectural, semantic, and maintainability decisions in modern Vue applications. However, no style guide is ideal for every team or project, so mindful deviations are still encouraged when they are deliberate and well understood.
 
-For the most part, we also avoid suggestions about JavaScript or HTML in general. We don't mind whether you use semicolons or trailing commas. We don't mind whether your HTML uses single-quotes or double-quotes for attribute values. Some exceptions will exist however, where we've found that a particular pattern is helpful in the context of Vue.
+This guide focuses on a small set of human-facing Vue rules. It is not intended to mirror every rule that lint tooling may enforce. Tools such as [eslint-plugin-vue](https://eslint.vuejs.org/), formatters, and other static analysis can still cover broader mechanical correctness and consistency checks.
 
-Finally, we've split rules into four categories:
+For the most part, we avoid suggestions about JavaScript or HTML in general. We do not try to settle choices like semicolons, trailing commas, or quote style unless they become specifically important in the context of Vue.
+
+## How to use this guide {#how-to-use-this-guide}
+
+- Start with the [essential rules](./rules-essential). They are the primary maintained part of this guide and focus on component contracts, explicit data flow, component boundaries, and the Vue mental model.
+- Treat Priority B, C, and D as legacy reference pages. They may still contain useful conventions, but they are not part of the current maintained scope.
+- If your team uses [eslint-plugin-vue](https://eslint.vuejs.org/), expect tooling to enforce additional syntax, correctness, and consistency rules that are not all repeated here.
 
 ## Rule Categories {#rule-categories}
 
-### Priority A: Essential (Error Prevention) {#priority-a-essential-error-prevention}
+### Priority A: Essential (Maintained) {#priority-a-essential-error-prevention}
 
-These rules help prevent errors, so learn and abide by them at all costs. Exceptions may exist, but should be very rare and only be made by those with expert knowledge of both JavaScript and Vue.
+These rules focus on component contracts, explicit data flow, component boundaries, and the Vue mental model. They are written to guide human decisions, not to duplicate every lint rule.
 
 - [See all priority A rules](./rules-essential)
 
-### Priority B: Strongly Recommended {#priority-b-strongly-recommended}
+### Priority B: Strongly Recommended (Legacy Reference) {#priority-b-strongly-recommended}
 
-These rules have been found to improve readability and/or developer experience in most projects. Your code will still run if you violate them, but violations should be rare and well-justified.
+This page is preserved for historical reference. Its recommendations may still be useful, but they are not part of the current maintained scope.
 
 - [See all priority B rules](./rules-strongly-recommended)
 
-### Priority C: Recommended {#priority-c-recommended}
+### Priority C: Recommended (Legacy Reference) {#priority-c-recommended}
 
-Where multiple, equally good options exist, an arbitrary choice can be made to ensure consistency. In these rules, we describe each acceptable option and suggest a default choice. That means you can feel free to make a different choice in your own codebase, as long as you're consistent and have a good reason. Please do have a good reason though! By adapting to the community standard, you will:
-
-1. Train your brain to more easily parse most of the community code you encounter
-2. Be able to copy and paste most community code examples without modification
-3. Often find new hires are already accustomed to your preferred coding style, at least in regards to Vue
+This page is also preserved as legacy reference content. It may help teams that want additional conventions, but it is not part of the current maintained scope.
 
 - [See all priority C rules](./rules-recommended)
 
-### Priority D: Use with Caution {#priority-d-use-with-caution}
+### Priority D: Use with Caution (Legacy Reference) {#priority-d-use-with-caution}
 
-Some features of Vue exist to accommodate rare edge cases or smoother migrations from a legacy code base. When overused however, they can make your code more difficult to maintain or even become a source of bugs. These rules shine a light on potentially risky features, describing when and why they should be avoided.
+This page remains available as historical guidance on risky patterns, but it is not part of the current maintained scope.
 
 - [See all priority D rules](./rules-use-with-caution)

--- a/src/style-guide/index.md
+++ b/src/style-guide/index.md
@@ -12,7 +12,9 @@ This is the official style guide for Vue-specific code. It is meant to help team
 
 This guide focuses on a small set of human-facing Vue rules. It is not intended to mirror every rule that lint tooling may enforce. Tools such as [eslint-plugin-vue](https://eslint.vuejs.org/), formatters, and other static analysis can still cover broader mechanical correctness and consistency checks.
 
-For the most part, we avoid suggestions about JavaScript or HTML in general. We do not try to settle choices like semicolons, trailing commas, or quote style unless they become specifically important in the context of Vue.
+For the most part, we avoid suggestions about JavaScript or HTML in general. We will not set explicit guidelines around formatting decisions like semicolons, quote styles, etc. These are decisions that are personal to each team and we recommend setting your own conventions with tools like [Prettier](https://prettier.io/) or [Oxfmt](https://oxc.rs/docs/guide/usage/formatter.html).
+
+Our goal is to provide guidance around patterns that are important within the context of Vue.
 
 ## How to use this guide {#how-to-use-this-guide}
 

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -141,11 +141,9 @@ const emit = defineEmits<{
 
 </div>
 
-</div>
-
 ## Keep parent-child data flow explicit {#keep-parent-child-data-flow-explicit}
 
-Pass data down with props, and communicate requested changes back up with emitted events.
+Pass data down with props, and communicate requested changes back up with emitted events or typed `defineModel()`.
 
 ::: details Why this matters
 Vue components are easier to understand and maintain when state ownership is clear. Prop mutation and other implicit parent-child coupling make updates harder to reason about and components harder to reuse.
@@ -155,63 +153,19 @@ This includes `v-model`, which still follows the same prop-and-event communicati
 
 If a child needs editable local state, derive or initialize it from the prop instead of mutating the prop itself.
 
-<div class="options-api">
-
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
-```js
-export default {
-  props: {
-    open: Boolean
-  },
-
-  methods: {
-    requestClose() {
-      this.open = false
-    }
-  }
-}
-```
-
-</div>
-
-<div class="style-example style-example-good">
-<h3>Good</h3>
-
-```js
-export default {
-  props: {
-    open: Boolean
-  },
-
-  emits: ['update:open'],
-
-  methods: {
-    requestClose() {
-      this.$emit('update:open', false)
-    }
-  }
-}
-```
-
-</div>
-
-</div>
-
-<div class="composition-api">
-
-<div class="style-example style-example-bad">
-<h3>Bad</h3>
-
-```js
-const props = defineProps({
-  open: Boolean
-})
+```vue
+<script setup lang="ts">
+const props = defineProps<{
+  open: boolean
+}>()
 
 function requestClose() {
   props.open = false
 }
+</script>
 ```
 
 </div>
@@ -219,19 +173,51 @@ function requestClose() {
 <div class="style-example style-example-good">
 <h3>Good</h3>
 
-```js
-const props = defineProps({
-  open: Boolean
-})
+<br />
 
-const emit = defineEmits(['update:open'])
+In Vue 3.4+, use `defineModel()` for two-way bindings.
+
+```vue [Child.vue]
+<script setup lang="ts">
+const open = defineModel<boolean>()
 
 function requestClose() {
-  emit('update:open', false)
+  open.value = false
 }
+</script>
 ```
 
-</div>
+In Vue 3.3 and earlier, use `defineEmits()` to request changes from the parent.
+
+```vue [Child.vue]
+<script setup lang="ts">
+defineProps<{
+  modelValue: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
+function requestClose() {
+  emit('update:modelValue', false)
+}
+</script>
+```
+
+<hr />
+
+Usage in parent component:
+
+```vue [Parent.vue]
+<script setup lang="ts">
+const isOpen = ref(false)
+</script>
+
+<template>
+  <Child v-model="isOpen" />
+</template>
+```
 
 </div>
 

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -1,25 +1,21 @@
-# Priority A Rules: Essential {#priority-a-rules-essential}
+# Priority A Rules: Essential (TypeScript) {#priority-a-rules-essential}
 
-These rules define the most important boundaries in Vue components: what a component exposes, how data flows through it, how its styles are contained, and how derived state is kept separate from side effects. Follow them by default to keep components easier to understand, maintain, and evolve.
+These rules define the most important boundaries in Vue components that use TypeScript: what a component exposes, how data flows through it, how its styles are contained, and how derived state is kept separate from side effects. Follow them by default to keep components easier to understand, maintain, and evolve.
 
-## Use detailed prop definitions {#use-detailed-prop-definitions}
+## Props Declaration {#use-detailed-prop-definitions}
 
 In committed code, props should be treated as a key part of the component's contract and be defined in as much detail as possible.
 
 ::: details Why this matters
-Detailed [prop definitions](/guide/components/props#prop-validation) make a component's API easier to understand, easier to use correctly, and easier to change safely.
+Typed [prop definitions](/guide/typescript/composition-api#typing-component-props) make a component's API easier to understand, help editors and `vue-tsc` catch incorrect usage, and make refactors safer.
 :::
 
-<span class="composition-api">In TypeScript, a type-based `defineProps()` declaration can also be used when the prop contract is fully described by its types.</span>
-
-<div class="options-api">
 
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
-```js
-// This is only OK when prototyping
-props: ['status']
+```ts
+defineProps(['status'])
 ```
 
 </div>
@@ -27,69 +23,61 @@ props: ['status']
 <div class="style-example style-example-good">
 <h3>Good</h3>
 
-```js
-props: {
-  status: String
-}
-```
-
-```js
-// Even better!
-props: {
-  status: {
-    type: String,
-    required: true,
-
-    validator: value => {
-      return [
-        'syncing',
-        'synced',
-        'version-conflict',
-        'error'
-      ].includes(value)
-    }
-  }
-}
+```ts
+defineProps<{
+  status: string
+}>()
 ```
 
 </div>
 
-</div>
+### Access props variables
 
-<div class="composition-api">
+In Vue 3.5+, you can destructure typed props directly from `defineProps()`.
 
-<div class="style-example style-example-bad">
-<h3>Bad</h3>
+```ts
+// Vue 3.5+
+const { status } = defineProps<{
+  status: string
+}>()
 
-```js
-// This is only OK when prototyping
-const props = defineProps(['status'])
-```
-
-</div>
-
-<div class="style-example style-example-good">
-<h3>Good</h3>
-
-```js
-const props = defineProps({
-  status: String
+watchEffect(() => {
+  console.log(foo)
 })
 ```
 
-```js
-// Even better!
-const props = defineProps({
-  status: {
-    type: String,
-    required: true,
+In Vue 3.4 and earlier, assign the result of `defineProps()` to a variable and access props through that variable.
 
-    validator: (value) => {
-      return ['syncing', 'synced', 'version-conflict', 'error'].includes(
-        value
-      )
-    }
-  }
+```ts
+// Vue 3.4 and earlier
+const props = defineProps<{
+  status: string
+}>()
+
+watchEffect(() => {
+  console.log(props.status)
+})
+```
+
+### Declare prop defaults
+
+In Vue 3.5+, you can use JavaScript's native default value syntax to declare default values for the props.
+
+```ts
+// Vue 3.5+
+const { status = 'syncing' } = defineProps<{
+  status?: string
+}>()
+```
+
+In Vue 3.4 and earlier, use `withDefaults()` to declare default values for props.
+
+```ts
+// Vue 3.4 and earlier
+const props = withDefaults(defineProps<{
+  status?: string
+}>(), {
+  status: 'syncing'
 })
 ```
 

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -43,7 +43,11 @@ defineProps<{
 
 #### Access props variables
 
-In Vue 3.5+, you can destructure typed props directly from `defineProps()`.
+In Vue 3.5+, you can destructure typed props directly from `defineProps()` and keeps them reactive.
+
+> Under the hood, Vue's compiler automatically prepends `props.` when code in the same `script setup` block accesses variables destructured from `defineProps()`, see [Reactive Props Destructure](https://vuejs.org/guide/components/props.html#reactive-props-destructure) for details.  
+
+> In Vue's VS Code extension, you can enable `vue.inlayHints.destructuredProps` option to show inlay-hints for destructured props.
 
 ```ts
 const { status } = defineProps<{
@@ -51,7 +55,7 @@ const { status } = defineProps<{
 }>()
 
 watchEffect(() => {
-  console.log(foo)
+  console.log(status)
 })
 ```
 

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -217,11 +217,11 @@ Usage in parent component:
 
 ```vue [Parent.vue]
 <script setup lang="ts">
-const isOpen = ref(false)
+const isOpened = ref(false)
 </script>
 
 <template>
-  <Child v-model="isOpen" />
+  <Child v-model="isOpened" />
 </template>
 ```
 

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -294,60 +294,18 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 
 ## Use computed for derived state {#use-computed-for-derived-state}
 
-Use [computed](/guide/essentials/computed) for synchronous derived state instead of storing and synchronizing it manually, and use [watch](/guide/essentials/watchers), `watchEffect()`, or lifecycle hooks for side effects.
+Use [computed](/guide/essentials/computed) for synchronous derived state instead of storing and synchronizing it manually. Keep [computed](/guide/essentials/computed) getters pure (no side effects) and put side effects in [watchers](/guide/essentials/watchers).
 
 ::: details Why this matters
 Computed state should describe what values mean, not perform work. Keeping derivation pure and synchronous makes reactive code easier to reason about and keeps side effects in the places Vue expects them.
 :::
 
-<div class="options-api">
+Let computed refs infer their types when the implementation is obvious. Add an explicit return type when the computed value is part of a component contract, when it guards against accidental widening, or when inference becomes circular.
 
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
-```js
-export default {
-  computed: {
-    fullName() {
-      const value = `${this.user.firstName} ${this.user.lastName}`
-      analytics.track('full-name-changed', value)
-      return value
-    }
-  }
-}
-```
-
-</div>
-
-<div class="style-example style-example-good">
-<h3>Good</h3>
-
-```js
-export default {
-  computed: {
-    fullName() {
-      return `${this.user.firstName} ${this.user.lastName}`
-    }
-  },
-
-  watch: {
-    fullName(value) {
-      analytics.track('full-name-changed', value)
-    }
-  }
-}
-```
-
-</div>
-
-</div>
-
-<div class="composition-api">
-
-<div class="style-example style-example-bad">
-<h3>Bad</h3>
-
-```js
+```ts
 const fullName = computed(() => {
   const value = `${user.value.firstName} ${user.value.lastName}`
   analytics.track('full-name-changed', value)
@@ -360,7 +318,7 @@ const fullName = computed(() => {
 <div class="style-example style-example-good">
 <h3>Good</h3>
 
-```js
+```ts
 const fullName = computed(() => {
   return `${user.value.firstName} ${user.value.lastName}`
 })
@@ -369,7 +327,5 @@ watch(fullName, (value) => {
   analytics.track('full-name-changed', value)
 })
 ```
-
-</div>
 
 </div>

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -1,0 +1,444 @@
+# Priority A Rules: Essential {#priority-a-rules-essential}
+
+These rules define the most important boundaries in Vue components: what a component exposes, how data flows through it, how its styles are contained, and how derived state is kept separate from side effects. Follow them by default to keep components easier to understand, maintain, and evolve.
+
+## Use detailed prop definitions {#use-detailed-prop-definitions}
+
+In committed code, props should be treated as a key part of the component's contract and be defined in as much detail as possible.
+
+::: details Why this matters
+Detailed [prop definitions](/guide/components/props#prop-validation) make a component's API easier to understand, easier to use correctly, and easier to change safely.
+:::
+
+<span class="composition-api">In TypeScript, a type-based `defineProps()` declaration can also be used when the prop contract is fully described by its types.</span>
+
+<div class="options-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+// This is only OK when prototyping
+props: ['status']
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+props: {
+  status: String
+}
+```
+
+```js
+// Even better!
+props: {
+  status: {
+    type: String,
+    required: true,
+
+    validator: value => {
+      return [
+        'syncing',
+        'synced',
+        'version-conflict',
+        'error'
+      ].includes(value)
+    }
+  }
+}
+```
+
+</div>
+
+</div>
+
+<div class="composition-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+// This is only OK when prototyping
+const props = defineProps(['status'])
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+const props = defineProps({
+  status: String
+})
+```
+
+```js
+// Even better!
+const props = defineProps({
+  status: {
+    type: String,
+    required: true,
+
+    validator: (value) => {
+      return ['syncing', 'synced', 'version-conflict', 'error'].includes(
+        value
+      )
+    }
+  }
+})
+```
+
+</div>
+
+</div>
+
+## Declare emitted events {#declare-emitted-events}
+
+Treat emitted events as part of a component's public contract, and declare them explicitly.
+
+::: details Why this matters
+Explicit [event declarations](/guide/components/events) document how a component communicates outward and make parent-child interactions easier to follow.
+:::
+
+In Options API, declare events with the [`emits`](/guide/components/events#declaring-emitted-events) option. In [`<script setup>`](/api/sfc-script-setup#defineprops-defineemits), declare them with `defineEmits()`.
+
+Use the object syntax when event payloads need validation, and an array of event names when they do not.
+
+<span class="composition-api">In TypeScript, a typed `defineEmits()` declaration can also be used so the event contract is checked by the type system as well as documented in the component. Vue 3.3+ also supports a named tuple syntax for the same declaration.</span>
+
+<div class="options-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+export default {
+  methods: {
+    submit(email) {
+      this.$emit('submit', { email })
+    }
+  }
+}
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+export default {
+  emits: {
+    submit: (payload) => typeof payload?.email === 'string'
+  },
+
+  methods: {
+    submit(email) {
+      this.$emit('submit', { email })
+    }
+  }
+}
+```
+
+</div>
+
+</div>
+
+<div class="composition-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```vue
+<template>
+  <button @click="$emit('submit')">Submit</button>
+</template>
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```vue
+<script setup>
+defineEmits(['submit'])
+</script>
+
+<template>
+  <button @click="$emit('submit')">Submit</button>
+</template>
+```
+
+```vue
+<script setup lang="ts">
+const form = {
+  email: ''
+}
+
+const emit = defineEmits<{
+  // Type-based declaration
+  (e: 'submit', payload: { email: string }): void
+  // Vue 3.3+: alternative, more succinct syntax
+  // submit: [payload: { email: string }]
+}>()
+</script>
+
+<template>
+  <button @click="emit('submit', { email: form.email })">Submit</button>
+</template>
+```
+
+</div>
+
+</div>
+
+## Keep parent-child data flow explicit {#keep-parent-child-data-flow-explicit}
+
+Pass data down with props, and communicate requested changes back up with emitted events.
+
+::: details Why this matters
+Vue components are easier to understand and maintain when state ownership is clear. Prop mutation and other implicit parent-child coupling make updates harder to reason about and components harder to reuse.
+:::
+
+This includes `v-model`, which still follows the same prop-and-event communication pattern with shorthand syntax.
+
+If a child needs editable local state, derive or initialize it from the prop instead of mutating the prop itself.
+
+<div class="options-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+export default {
+  props: {
+    open: Boolean
+  },
+
+  methods: {
+    requestClose() {
+      this.open = false
+    }
+  }
+}
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+export default {
+  props: {
+    open: Boolean
+  },
+
+  emits: ['update:open'],
+
+  methods: {
+    requestClose() {
+      this.$emit('update:open', false)
+    }
+  }
+}
+```
+
+</div>
+
+</div>
+
+<div class="composition-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+const props = defineProps({
+  open: Boolean
+})
+
+function requestClose() {
+  props.open = false
+}
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+const props = defineProps({
+  open: Boolean
+})
+
+const emit = defineEmits(['update:open'])
+
+function requestClose() {
+  emit('update:open', false)
+}
+```
+
+</div>
+
+</div>
+
+## Use component-scoped styling {#use-component-scoped-styling}
+
+Keep component styles within the component boundary unless a style is intentionally global.
+
+::: details Why this matters
+Component-scoped styling reduces accidental coupling, makes style ownership clearer, and lowers the chance that a change in one component will unexpectedly affect another.
+:::
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```vue-html
+<template>
+  <button class="btn btn-close">×</button>
+</template>
+
+<style>
+.btn-close {
+  background-color: red;
+}
+</style>
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```vue-html
+<template>
+  <button class="button button-close">×</button>
+</template>
+
+<!-- Using the `scoped` attribute -->
+<style scoped>
+.button {
+  border: none;
+  border-radius: 2px;
+}
+
+.button-close {
+  background-color: red;
+}
+</style>
+```
+
+```vue-html
+<template>
+  <button :class="[$style.button, $style.buttonClose]">×</button>
+</template>
+
+<!-- Using CSS modules -->
+<style module>
+.button {
+  border: none;
+  border-radius: 2px;
+}
+
+.buttonClose {
+  background-color: red;
+}
+</style>
+```
+
+</div>
+
+**Notes**
+
+- The [`scoped` attribute](/api/sfc-css-features#scoped-css) is not the only option. CSS modules, native [CSS `@scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope), and disciplined class-based conventions such as [BEM](http://getbem.com/) can all work.
+- App-level and layout-level styles may be global when they are intentionally shared.
+
+## Use computed for derived state {#use-computed-for-derived-state}
+
+Use [computed](/guide/essentials/computed) for synchronous derived state instead of storing and synchronizing it manually, and use [watch](/guide/essentials/watchers), `watchEffect()`, or lifecycle hooks for side effects.
+
+::: details Why this matters
+Computed state should describe what values mean, not perform work. Keeping derivation pure and synchronous makes reactive code easier to reason about and keeps side effects in the places Vue expects them.
+:::
+
+<div class="options-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+export default {
+  computed: {
+    fullName() {
+      const value = `${this.user.firstName} ${this.user.lastName}`
+      analytics.track('full-name-changed', value)
+      return value
+    }
+  }
+}
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+export default {
+  computed: {
+    fullName() {
+      return `${this.user.firstName} ${this.user.lastName}`
+    }
+  },
+
+  watch: {
+    fullName(value) {
+      analytics.track('full-name-changed', value)
+    }
+  }
+}
+```
+
+</div>
+
+</div>
+
+<div class="composition-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+const fullName = computed(() => {
+  const value = `${user.value.firstName} ${user.value.lastName}`
+  analytics.track('full-name-changed', value)
+  return value
+})
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+const fullName = computed(() => {
+  return `${user.value.firstName} ${user.value.lastName}`
+})
+
+watch(fullName, (value) => {
+  analytics.track('full-name-changed', value)
+})
+```
+
+</div>
+
+</div>

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -267,7 +267,7 @@ In Vue 3.5+, use [`useTemplateRef()`](https://vuejs.org/api/composition-api-help
 <script setup lang="ts">
 import { useTemplateRef, onMounted } from 'vue'
 
-const el = useTemplateRef<HTMLInputElement>('my-input')
+const el = useTemplateRef('my-input')
 
 onMounted(() => {
   if (el.value) {

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -1,8 +1,18 @@
+---
+outline: deep
+---
+
 # Priority A Rules: Essential (TypeScript) {#priority-a-rules-essential}
 
 These rules define the most important boundaries in Vue components that use TypeScript: what a component exposes, how data flows through it, how its styles are contained, and how derived state is kept separate from side effects. Follow them by default to keep components easier to understand, maintain, and evolve.
 
-## Props Declaration {#use-detailed-prop-definitions}
+## Component Data Flow
+
+Vue components stay reliable when data flow is explicit: props go down, events go up, `v-model` handles two-way bindings, and provide/inject supports cross-tree dependencies. Blurring these boundaries leads to stale state, hidden coupling, and hard-to-debug UI.
+
+The main principle of data flow in Vue.js is **Props Down / Events Up**. This is the most maintainable default, and one-way flow scales well.
+
+### Props Declaration {#use-detailed-prop-definitions}
 
 In committed code, props should be treated as a key part of the component's contract and be defined in as much detail as possible.
 
@@ -31,7 +41,7 @@ defineProps<{
 
 </div>
 
-### Access props variables
+#### Access props variables
 
 In Vue 3.5+, you can destructure typed props directly from `defineProps()`.
 
@@ -59,7 +69,7 @@ watchEffect(() => {
 })
 ```
 
-### Declare prop defaults
+#### Declare prop defaults
 
 In Vue 3.5+, you can use JavaScript's native default value syntax to declare default values for the props.
 
@@ -81,7 +91,7 @@ const props = withDefaults(defineProps<{
 })
 ```
 
-## Emits Declaration {#declare-emitted-events}
+### Emits Declaration {#declare-emitted-events}
 
 Treat emitted events as part of a component's public contract, and declare event names and payloads explicitly.
 
@@ -141,7 +151,7 @@ const emit = defineEmits<{
 
 </div>
 
-## Keep parent-child data flow explicit {#keep-parent-child-data-flow-explicit}
+### Implement two-way binding {#keep-parent-child-data-flow-explicit}
 
 Pass data down with props, and communicate requested changes back up with emitted events or typed `defineModel()`.
 
@@ -297,7 +307,7 @@ onMounted(() => {
 
 </div>
 
-## Use component-scoped styling {#use-component-scoped-styling}
+### Use component-scoped styling {#use-component-scoped-styling}
 
 Keep component styles within the component boundary unless a style is intentionally global.
 
@@ -308,7 +318,7 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
-```vue-html
+```vue
 <template>
   <button class="btn btn-close">×</button>
 </template>
@@ -325,7 +335,7 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 <div class="style-example style-example-good">
 <h3>Good</h3>
 
-```vue-html
+```vue
 <template>
   <button class="button button-close">×</button>
 </template>
@@ -343,7 +353,7 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 </style>
 ```
 
-```vue-html
+```vue
 <template>
   <button :class="[$style.button, $style.buttonClose]">×</button>
 </template>

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -81,63 +81,15 @@ const props = withDefaults(defineProps<{
 })
 ```
 
-</div>
+## Emits Declaration {#declare-emitted-events}
 
-</div>
-
-## Declare emitted events {#declare-emitted-events}
-
-Treat emitted events as part of a component's public contract, and declare them explicitly.
+Treat emitted events as part of a component's public contract, and declare event names and payloads explicitly.
 
 ::: details Why this matters
-Explicit [event declarations](/guide/components/events) document how a component communicates outward and make parent-child interactions easier to follow.
+Typed [event declarations](/guide/typescript/composition-api#typing-component-emits) document how a component communicates outward and let TypeScript catch wrong event names or payload shapes before runtime.
 :::
 
-In Options API, declare events with the [`emits`](/guide/components/events#declaring-emitted-events) option. In [`<script setup>`](/api/sfc-script-setup#defineprops-defineemits), declare them with `defineEmits()`.
-
-Use the object syntax when event payloads need validation, and an array of event names when they do not.
-
-<span class="composition-api">In TypeScript, a typed `defineEmits()` declaration can also be used so the event contract is checked by the type system as well as documented in the component. Vue 3.3+ also supports a named tuple syntax for the same declaration.</span>
-
-<div class="options-api">
-
-<div class="style-example style-example-bad">
-<h3>Bad</h3>
-
-```js
-export default {
-  methods: {
-    submit(email) {
-      this.$emit('submit', { email })
-    }
-  }
-}
-```
-
-</div>
-
-<div class="style-example style-example-good">
-<h3>Good</h3>
-
-```js
-export default {
-  emits: {
-    submit: (payload) => typeof payload?.email === 'string'
-  },
-
-  methods: {
-    submit(email) {
-      this.$emit('submit', { email })
-    }
-  }
-}
-```
-
-</div>
-
-</div>
-
-<div class="composition-api">
+Use `defineEmits()` with named tuple syntax when events have payloads. Use a payload object when an event carries more than one value or may grow over time.
 
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
@@ -153,32 +105,37 @@ export default {
 <div class="style-example style-example-good">
 <h3>Good</h3>
 
-```vue
-<script setup>
-defineEmits(['submit'])
-</script>
+<br />
 
-<template>
-  <button @click="$emit('submit')">Submit</button>
-</template>
-```
+In Vue 3.3+, you can use named tuple syntax for a more succinct declaration:
 
 ```vue
 <script setup lang="ts">
-const form = {
-  email: ''
-}
-
 const emit = defineEmits<{
-  // Type-based declaration
-  (e: 'submit', payload: { email: string }): void
-  // Vue 3.3+: alternative, more succinct syntax
-  // submit: [payload: { email: string }]
+  submit: [payload: { email: string }]
+  close: []
 }>()
 </script>
 
 <template>
-  <button @click="emit('submit', { email: form.email })">Submit</button>
+  <button @click="emit('submit', { email: 'john@example.com' })">Submit</button>
+  <button @click="emit('close')">Close</button>
+</template>
+```
+
+In Vue 3.2 and earlier, use the function syntax to declare the payload shape:
+
+```vue
+<script setup lang="ts">
+const emit = defineEmits<{
+  (event: 'submit', payload: { email: string }): void
+  (event: 'close'): void
+}>()
+</script>
+
+<template>
+  <button @click="emit('submit', { email: 'john@example.com' })">Submit</button>
+  <button @click="emit('close')">Close</button>
 </template>
 ```
 

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -46,7 +46,6 @@ defineProps<{
 In Vue 3.5+, you can destructure typed props directly from `defineProps()`.
 
 ```ts
-// Vue 3.5+
 const { status } = defineProps<{
   status: string
 }>()
@@ -59,7 +58,6 @@ watchEffect(() => {
 In Vue 3.4 and earlier, assign the result of `defineProps()` to a variable and access props through that variable.
 
 ```ts
-// Vue 3.4 and earlier
 const props = defineProps<{
   status: string
 }>()
@@ -74,7 +72,6 @@ watchEffect(() => {
 In Vue 3.5+, you can use JavaScript's native default value syntax to declare default values for the props.
 
 ```ts
-// Vue 3.5+
 const { status = 'syncing' } = defineProps<{
   status?: string
 }>()
@@ -83,7 +80,6 @@ const { status = 'syncing' } = defineProps<{
 In Vue 3.4 and earlier, use `withDefaults()` to declare default values for props.
 
 ```ts
-// Vue 3.4 and earlier
 const props = withDefaults(defineProps<{
   status?: string
 }>(), {
@@ -378,9 +374,153 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 - The [`scoped` attribute](/api/sfc-css-features#scoped-css) is not the only option. CSS modules, native [CSS `@scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope), and disciplined class-based conventions such as [BEM](http://getbem.com/) can all work.
 - App-level and layout-level styles may be global when they are intentionally shared.
 
-## Use computed for derived state {#use-computed-for-derived-state}
+## Reactivity
 
-Use [computed](/guide/essentials/computed) for synchronous derived state instead of storing and synchronizing it manually. Keep [computed](/guide/essentials/computed) getters pure (no side effects) and put side effects in [watchers](/guide/essentials/watchers).
+### Avoid destructuring from `reactive()` directly
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```vue
+<script setup lang="ts">
+import { onMounted, reactive } from 'vue'
+
+const state = reactive({ count: 0 })
+
+onMounted(() => {
+  state.count = 1
+})
+
+// disconnected from reactivity
+const { count } = state
+</script>
+
+<template>
+  <!-- it's not updating to 1 on mount -->
+  <div>{{ count }}</div>
+</template>
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+<br />
+
+Read and write to properties on the original `reactive()` object to stay within the reactivity system.
+
+```vue
+<script setup lang="ts">
+import { onMounted, reactive } from 'vue'
+
+const state = reactive({ count: 0 })
+
+onMounted(() => {
+  state.count = 1
+})
+</script>
+
+<template>
+  <div>{{ state.count }}</div>
+</template>
+```
+
+You can use `toRef` or `toRefs()` for a more destructure-like syntax that stays reactive.
+
+```vue
+<script setup lang="ts">
+import { onMounted, reactive, toRef } from 'vue'
+
+const state = reactive({ count: 0 })
+
+// a two-way ref that syncs with the original property
+const count = toRef(state, 'count')
+
+onMounted(() => {
+  count.value = 1
+})
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>
+```
+
+```ts
+// or create readonly ref from reactive with a getter
+const count = toRef(() => state.count)
+```
+
+Use `toRefs()` if you need to destructure multiple properties.
+
+```vue
+<script setup lang="ts">
+import { onMounted, reactive, toRefs } from 'vue'
+
+const state = reactive({ count: 0 })
+
+const { count } = toRefs(state)
+
+onMounted(() => {
+  count.value = 2
+})
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>
+```
+
+</div>
+
+### Watching reactive state
+
+When watching reactive state, use a getter function or ref instead of watching the property of reactive object directly.
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```ts
+import { watch, reactive } from 'vue'
+
+const props = defineProps<{
+  title: string
+}>()
+
+const state = reactive({ count: 0 })
+
+// it won't trigger when props.title or state.count changes
+watch(props.title, () => {})
+watch(state.count, () => {})
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```ts
+import { watch, reactive } from 'vue'
+
+const props = defineProps<{
+  title: string
+}>()
+
+const state = reactive({ count: 0 })
+
+// watch reactive state with getter
+watch(() => props.title, () => {})
+watch(() => state.count, () => {})
+```
+
+</div>
+
+### Use computed for derived state {#use-computed-for-derived-state}
+
+Use [computed](/guide/essentials/computed) for synchronous derived state instead of storing and synchronizing it manually.
+
+Keep [computed](/guide/essentials/computed) getters pure (no side effects) and put side effects in [watchers](/guide/essentials/watchers).
 
 ::: details Why this matters
 Computed state should describe what values mean, not perform work. Keeping derivation pure and synchronous makes reactive code easier to reason about and keeps side effects in the places Vue expects them.
@@ -412,6 +552,63 @@ const fullName = computed(() => {
 watch(fullName, (value) => {
   analytics.track('full-name-changed', value)
 })
+```
+
+</div>
+
+### Prefer computed over watcher-assigned derived refs
+
+When a ref's value is derived from other reactive state, use a computed ref instead of a manually assigned ref in a watcher.
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```ts
+const items = ref([{ price: 10 }, { price: 20 }])
+const total = ref(0)
+
+watch(items, () => {
+  total.value = items.value.reduce((sum, item) => sum + item.price, 0)
+})
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```ts
+const items = ref([{ price: 10 }, { price: 20 }])
+const total = computed(() =>
+  items.value.reduce((sum, item) => sum + item.price, 0)
+)
+```
+
+</div>
+
+### Use eager watchers instead of duplicate initial calls
+
+Use watchers with the `immediate: true` option instead of manually duplicating an initial call to a function that also needs to run on reactive updates.
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```ts
+const userId = ref(1)
+
+onMounted(() => loadUser(userId.value))
+watch(userId, (id) => loadUser(id))
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```ts
+const userId = ref(1)
+
+watch(userId, (id) => loadUser(id), { immediate: true })
 ```
 
 </div>

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -221,6 +221,82 @@ const isOpen = ref(false)
 
 </div>
 
+## Single-File Component
+
+Using SFCs with consistent structure and performant styling keeps components easier to maintain and avoids unnecessary render overhead.
+
+### Access DOM or component instances {$#access-dom-or-component-instances}
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```vue
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const el = ref()
+
+onMounted(() => {
+  el.value = window.document.getElementById('my-input')
+  el.value.focus()
+})
+</script>
+
+<template>
+  <input id="my-input" />
+</template>
+```
+
+</div>
+
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+<br />
+
+In Vue 3.5+, use [`useTemplateRef()`](https://vuejs.org/api/composition-api-helpers.html#usetemplateref) to access DOM or component instances.
+
+```vue
+<script setup lang="ts">
+import { useTemplateRef, onMounted } from 'vue'
+
+const el = useTemplateRef<HTMLInputElement>('my-input')
+
+onMounted(() => {
+  if (el.value) {
+    el.value.focus()
+  }
+})
+</script>
+
+<template>
+  <input ref="my-input" />
+</template>
+```
+
+In Vue 3.4 and earlier, use `ref` and template refs to access DOM or component instances.
+
+```vue
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const el = ref<HTMLInputElement | null>(null)
+
+onMounted(() => {
+  if (el.value) {
+    el.value.focus()
+  }
+})
+</script>
+
+<template>
+  <input ref="el" />
+</template>
+```
+
+</div>
+
 ## Use component-scoped styling {#use-component-scoped-styling}
 
 Keep component styles within the component boundary unless a style is intentionally global.

--- a/src/style-guide/rules-essential-ts.md
+++ b/src/style-guide/rules-essential-ts.md
@@ -124,8 +124,8 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <button @click="emit('submit', { email: 'john@example.com' })">Submit</button>
-  <button @click="emit('close')">Close</button>
+  <button type="button" @click="emit('submit', { email: 'john@example.com' })">Submit</button>
+  <button type="button" @click="emit('close')">Close</button>
 </template>
 ```
 
@@ -140,8 +140,8 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <button @click="emit('submit', { email: 'john@example.com' })">Submit</button>
-  <button @click="emit('close')">Close</button>
+  <button type="button" @click="emit('submit', { email: 'john@example.com' })">Submit</button>
+  <button type="button" @click="emit('close')">Close</button>
 </template>
 ```
 
@@ -316,7 +316,7 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 
 ```vue
 <template>
-  <button class="btn btn-close">×</button>
+  <button type="button" class="btn btn-close">×</button>
 </template>
 
 <style>
@@ -333,7 +333,7 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 
 ```vue
 <template>
-  <button class="button button-close">×</button>
+  <button type="button" class="button button-close">×</button>
 </template>
 
 <!-- Using the `scoped` attribute -->
@@ -351,7 +351,7 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 
 ```vue
 <template>
-  <button :class="[$style.button, $style.buttonClose]">×</button>
+  <button type="button" :class="[$style.button, $style.buttonClose]">×</button>
 </template>
 
 <!-- Using CSS modules -->

--- a/src/style-guide/rules-essential.md
+++ b/src/style-guide/rules-essential.md
@@ -1,51 +1,12 @@
 # Priority A Rules: Essential {#priority-a-rules-essential}
 
-::: warning Note
-This Vue.js Style Guide is outdated and needs to be reviewed. If you have any questions or suggestions, please [open an issue](https://github.com/vuejs/docs/issues/new).
-:::
-
-These rules help prevent errors, so learn and abide by them at all costs. Exceptions may exist, but should be very rare and only be made by those with expert knowledge of both JavaScript and Vue.
-
-## Use multi-word component names {#use-multi-word-component-names}
-
-User component names should always be multi-word, except for root `App` components. This [prevents conflicts](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) with existing and future HTML elements, since all HTML elements are a single word.
-
-<div class="style-example style-example-bad">
-<h3>Bad</h3>
-
-```vue-html
-<!-- in pre-compiled templates -->
-<Item />
-
-<!-- in in-DOM templates -->
-<item></item>
-```
-
-</div>
-
-<div class="style-example style-example-good">
-<h3>Good</h3>
-
-```vue-html
-<!-- in pre-compiled templates -->
-<TodoItem />
-
-<!-- in in-DOM templates -->
-<todo-item></todo-item>
-```
-
-</div>
-
 ## Use detailed prop definitions {#use-detailed-prop-definitions}
 
-In committed code, prop definitions should always be as detailed as possible, specifying at least type(s).
+Treat props as part of a component's public contract, and define them as explicitly as practical.
 
-::: details Detailed Explanation
-Detailed [prop definitions](/guide/components/props#prop-validation) have two advantages:
-
-- They document the API of the component, so that it's easy to see how the component is meant to be used.
-- In development, Vue will warn you if a component is ever provided incorrectly formatted props, helping you catch potential sources of error.
-  :::
+::: details Why this matters
+Detailed [prop definitions](/guide/components/props#prop-validation) make a component's API easier to understand, easier to use correctly, and easier to change safely.
+:::
 
 <div class="options-api">
 
@@ -114,7 +75,6 @@ const props = defineProps({
 
 ```js
 // Even better!
-
 const props = defineProps({
   status: {
     type: String,
@@ -133,67 +93,28 @@ const props = defineProps({
 
 </div>
 
-## Use keyed `v-for` {#use-keyed-v-for}
+**Notes**
 
-`key` with `v-for` is _always_ required on components, in order to maintain internal component state down the subtree. Even for elements though, it's a good practice to maintain predictable behavior, such as [object constancy](https://bost.ocks.org/mike/constancy/) in animations.
+- In TypeScript, a type-based `defineProps()` declaration is equally acceptable if it expresses the contract clearly.
+- Array syntax may be acceptable while prototyping, but committed components should define a real contract.
 
-::: details Detailed Explanation
-Let's say you have a list of todos:
+## Declare emitted events {#declare-emitted-events}
 
-<div class="options-api">
+Treat emitted events as part of a component's public contract, and declare them explicitly.
 
-```js
-data() {
-  return {
-    todos: [
-      {
-        id: 1,
-        text: 'Learn to use v-for'
-      },
-      {
-        id: 2,
-        text: 'Learn to use key'
-      }
-    ]
-  }
-}
-```
-
-</div>
-
-<div class="composition-api">
-
-```js
-const todos = ref([
-  {
-    id: 1,
-    text: 'Learn to use v-for'
-  },
-  {
-    id: 2,
-    text: 'Learn to use key'
-  }
-])
-```
-
-</div>
-
-Then you sort them alphabetically. When updating the DOM, Vue will optimize rendering to perform the cheapest DOM mutations possible. That might mean deleting the first todo element, then adding it again at the end of the list.
-
-The problem is, there are cases where it's important not to delete elements that will remain in the DOM. For example, you may want to use `<transition-group>` to animate list sorting, or maintain focus if the rendered element is an `<input>`. In these cases, adding a unique key for each item (e.g. `:key="todo.id"`) will tell Vue how to behave more predictably.
-
-In our experience, it's better to _always_ add a unique key, so that you and your team simply never have to worry about these edge cases. Then in the rare, performance-critical scenarios where object constancy isn't necessary, you can make a conscious exception.
+::: details Why this matters
+Explicit [event declarations](/guide/components/events) document how a component communicates outward and make parent-child interactions easier to follow.
 :::
 
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
-```vue-html
-<ul>
-  <li v-for="todo in todos">
-    {{ todo.text }}
-  </li>
-</ul>
+```js
+const emit = defineEmits()
+
+function submit() {
+  emit('submit', { email: form.email })
+}
 ```
 
 </div>
@@ -201,108 +122,53 @@ In our experience, it's better to _always_ add a unique key, so that you and you
 <div class="style-example style-example-good">
 <h3>Good</h3>
 
-```vue-html
-<ul>
-  <li
-    v-for="todo in todos"
-    :key="todo.id"
-  >
-    {{ todo.text }}
-  </li>
-</ul>
-```
-
-</div>
-
-## Avoid `v-if` with `v-for` {#avoid-v-if-with-v-for}
-
-**Never use `v-if` on the same element as `v-for`.**
-
-There are two common cases where this can be tempting:
-
-- To filter items in a list (e.g. `v-for="user in users" v-if="user.isActive"`). In these cases, replace `users` with a new computed property that returns your filtered list (e.g. `activeUsers`).
-
-- To avoid rendering a list if it should be hidden (e.g. `v-for="user in users" v-if="shouldShowUsers"`). In these cases, move the `v-if` to a container element (e.g. `ul`, `ol`).
-
-::: details Detailed Explanation
-When Vue processes directives, `v-if` has a higher priority than `v-for`, so that this template:
-
-```vue-html
-<ul>
-  <li
-    v-for="user in users"
-    v-if="user.isActive"
-    :key="user.id"
-  >
-    {{ user.name }}
-  </li>
-</ul>
-```
-
-Will throw an error, because the `v-if` directive will be evaluated first and the iteration variable `user` does not exist at this moment.
-
-This could be fixed by iterating over a computed property instead, like this:
-
-<div class="options-api">
-
 ```js
-computed: {
-  activeUsers() {
-    return this.users.filter(user => user.isActive)
-  }
-}
-```
-
-</div>
-
-<div class="composition-api">
-
-```js
-const activeUsers = computed(() => {
-  return users.filter((user) => user.isActive)
+const emit = defineEmits({
+  submit: ({ email }) => typeof email === 'string'
 })
+
+function submit() {
+  emit('submit', { email: form.email })
+}
+```
+
+```ts
+const emit = defineEmits<{
+  (e: 'submit', payload: { email: string }): void
+}>()
+
+function submit() {
+  emit('submit', { email: form.email })
+}
 ```
 
 </div>
 
-```vue-html
-<ul>
-  <li
-    v-for="user in activeUsers"
-    :key="user.id"
-  >
-    {{ user.name }}
-  </li>
-</ul>
-```
+**Notes**
 
-Alternatively, we can use a `<template>` tag with `v-for` to wrap the `<li>` element:
+- An array of event names is acceptable when payload validation would add no real value.
+- In TypeScript, prefer a typed `defineEmits()` declaration so the event contract is checked by the type system as well as documented in the component.
+- If runtime payload validation is also useful, use the object syntax.
 
-```vue-html
-<ul>
-  <template v-for="user in users" :key="user.id">
-    <li v-if="user.isActive">
-      {{ user.name }}
-    </li>
-  </template>
-</ul>
-```
+## Keep parent-child data flow explicit {#keep-parent-child-data-flow-explicit}
 
+Pass data down with props, and communicate requested changes back up with emitted events.
+
+::: details Why this matters
+Vue components are easier to understand and maintain when state ownership is clear. Prop mutation and other implicit parent-child coupling make updates harder to reason about and components harder to reuse.
 :::
 
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
-```vue-html
-<ul>
-  <li
-    v-for="user in users"
-    v-if="user.isActive"
-    :key="user.id"
-  >
-    {{ user.name }}
-  </li>
-</ul>
+```js
+const props = defineProps({
+  open: Boolean
+})
+
+function close() {
+  props.open = false
+}
 ```
 
 </div>
@@ -310,43 +176,31 @@ Alternatively, we can use a `<template>` tag with `v-for` to wrap the `<li>` ele
 <div class="style-example style-example-good">
 <h3>Good</h3>
 
-```vue-html
-<ul>
-  <li
-    v-for="user in activeUsers"
-    :key="user.id"
-  >
-    {{ user.name }}
-  </li>
-</ul>
-```
+```js
+const props = defineProps({
+  open: Boolean
+})
 
-```vue-html
-<ul>
-  <template v-for="user in users" :key="user.id">
-    <li v-if="user.isActive">
-      {{ user.name }}
-    </li>
-  </template>
-</ul>
+const emit = defineEmits(['update:open'])
+
+function close() {
+  emit('update:open', false)
+}
 ```
 
 </div>
+
+**Notes**
+
+- `v-model` still follows this rule. It is prop-and-event communication with shorthand syntax.
+- If a child needs editable local state, derive or initialize local state from the prop instead of mutating the prop itself.
 
 ## Use component-scoped styling {#use-component-scoped-styling}
 
-For applications, styles in a top-level `App` component and in layout components may be global, but all other components should always be scoped.
+Keep component styles within the component boundary unless a style is intentionally global.
 
-This is only relevant for [Single-File Components](/guide/scaling-up/sfc). It does _not_ require that the [`scoped` attribute](https://vue-loader.vuejs.org/guide/scoped-css.html) be used. Scoping could be through [CSS modules](https://vue-loader.vuejs.org/guide/css-modules.html), a class-based strategy such as [BEM](http://getbem.com/), or another library/convention.
-
-**Component libraries, however, should prefer a class-based strategy instead of using the `scoped` attribute.**
-
-This makes overriding internal styles easier, with human-readable class names that don't have too high specificity, but are still very unlikely to result in a conflict.
-
-::: details Detailed Explanation
-If you are developing a large project, working with other developers, or sometimes include 3rd-party HTML/CSS (e.g. from Auth0), consistent scoping will ensure that your styles only apply to the components they are meant for.
-
-Beyond the `scoped` attribute, using unique class names can help ensure that 3rd-party CSS does not apply to your own HTML. For example, many projects use the `button`, `btn`, or `icon` class names, so even if not using a strategy such as BEM, adding an app-specific and/or component-specific prefix (e.g. `ButtonClose-icon`) can provide some protection.
+::: details Why this matters
+Component-scoped styling reduces accidental coupling, makes style ownership clearer, and lowers the chance that a change in one component will unexpectedly affect another.
 :::
 
 <div class="style-example style-example-bad">
@@ -371,7 +225,7 @@ Beyond the `scoped` attribute, using unique class names can help ensure that 3rd
 
 ```vue-html
 <template>
-  <button class="button button-close">×</button>
+  <button class="button-close">×</button>
 </template>
 
 <!-- Using the `scoped` attribute -->
@@ -405,22 +259,49 @@ Beyond the `scoped` attribute, using unique class names can help ensure that 3rd
 </style>
 ```
 
-```vue-html
-<template>
-  <button class="c-Button c-Button--close">×</button>
-</template>
+</div>
 
-<!-- Using the BEM convention -->
-<style>
-.c-Button {
-  border: none;
-  border-radius: 2px;
-}
+**Notes**
 
-.c-Button--close {
-  background-color: red;
-}
-</style>
+- The [`scoped` attribute](/api/sfc-css-features#scoped-css) is not the only option. CSS modules, native [CSS `@scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope), and disciplined class-based conventions such as [BEM](http://getbem.com/) can all work.
+- App-level and layout-level styles may be global when they are intentionally shared.
+
+## Use computed for derived state {#use-computed-for-derived-state}
+
+Use [computed](/guide/essentials/computed) for synchronous derived state, and use [watch](/guide/essentials/watchers), `watchEffect()`, or lifecycle hooks for side effects.
+
+::: details Why this matters
+Computed state should describe what values mean, not perform work. Keeping derivation pure and synchronous makes reactive code easier to reason about and keeps side effects in the places Vue expects them.
+:::
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+const fullName = computed(() => {
+  analytics.track('full-name-read')
+  return `${user.value.firstName} ${user.value.lastName}`
+})
 ```
 
 </div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+const fullName = computed(() => {
+  return `${user.value.firstName} ${user.value.lastName}`
+})
+
+watch(fullName, (value) => {
+  analytics.track('full-name-changed', value)
+})
+```
+
+</div>
+
+**Notes**
+
+- Async reactions, network requests, DOM reads and writes, timers, and subscriptions belong in watchers, `watchEffect()`, or lifecycle hooks.
+- If a value can be expressed from existing reactive state, prefer `computed` over storing and synchronizing another piece of state.

--- a/src/style-guide/rules-essential.md
+++ b/src/style-guide/rules-essential.md
@@ -112,10 +112,8 @@ Explicit [event declarations](/guide/components/events) document how a component
 <h3>Bad</h3>
 
 ```js
-const emit = defineEmits()
-
 function submit() {
-  emit('submit', { email: form.email })
+  $emit('submit', { email: form.email })
 }
 ```
 
@@ -126,7 +124,7 @@ function submit() {
 
 ```js
 const emit = defineEmits({
-  submit: ({ email }) => typeof email === 'string'
+  submit: (payload) => typeof payload?.email === 'string'
 })
 
 function submit() {

--- a/src/style-guide/rules-essential.md
+++ b/src/style-guide/rules-essential.md
@@ -1,5 +1,7 @@
 # Priority A Rules: Essential {#priority-a-rules-essential}
 
+These rules define the most important boundaries in Vue components: what a component exposes, how data flows through it, how its styles are contained, and how derived state is kept separate from side effects. Follow them by default to keep components easier to understand, maintain, and evolve.
+
 ## Use detailed prop definitions {#use-detailed-prop-definitions}
 
 Treat props as part of a component's public contract, and define them as explicitly as practical.

--- a/src/style-guide/rules-essential.md
+++ b/src/style-guide/rules-essential.md
@@ -155,14 +155,8 @@ export default {
 <h3>Bad</h3>
 
 ```vue
-<script setup>
-const form = {
-  email: ''
-}
-</script>
-
 <template>
-  <button @click="$emit('submit', { email: form.email })">Submit</button>
+  <button @click="$emit('submit')">Submit</button>
 </template>
 ```
 
@@ -173,17 +167,11 @@ const form = {
 
 ```vue
 <script setup>
-const form = {
-  email: ''
-}
-
-defineEmits({
-  submit: (payload) => typeof payload?.email === 'string'
-})
+defineEmits(['submit'])
 </script>
 
 <template>
-  <button @click="$emit('submit', { email: form.email })">Submit</button>
+  <button @click="$emit('submit')">Submit</button>
 </template>
 ```
 
@@ -197,7 +185,7 @@ const emit = defineEmits<{
   // Type-based declaration
   (e: 'submit', payload: { email: string }): void
   // Vue 3.3+: alternative, more succinct syntax
-  submit: [payload: { email: string }]
+  // submit: [payload: { email: string }]
 }>()
 </script>
 

--- a/src/style-guide/rules-essential.md
+++ b/src/style-guide/rules-essential.md
@@ -4,7 +4,7 @@ These rules define the most important boundaries in Vue components: what a compo
 
 ## Use detailed prop definitions {#use-detailed-prop-definitions}
 
-Treat props as part of a component's public contract, and define them as explicitly as practical.
+In committed code, props should be treated as a key part of the component's contract and be defined in as much detail as possible.
 
 ::: details Why this matters
 Detailed [prop definitions](/guide/components/props#prop-validation) make a component's API easier to understand, easier to use correctly, and easier to change safely.
@@ -98,7 +98,6 @@ const props = defineProps({
 **Notes**
 
 - In TypeScript, a type-based `defineProps()` declaration is equally acceptable if it expresses the contract clearly.
-- Array syntax may be acceptable while prototyping, but committed components should define a real contract.
 
 ## Declare emitted events {#declare-emitted-events}
 
@@ -134,7 +133,10 @@ function submit() {
 
 ```ts
 const emit = defineEmits<{
+  // type-based definition
   (e: 'submit', payload: { email: string }): void
+  // 3.3+: alternative, more succinct syntax
+  submit: [payload, { email: string}]
 }>()
 
 function submit() {

--- a/src/style-guide/rules-essential.md
+++ b/src/style-guide/rules-essential.md
@@ -10,6 +10,8 @@ In committed code, props should be treated as a key part of the component's cont
 Detailed [prop definitions](/guide/components/props#prop-validation) make a component's API easier to understand, easier to use correctly, and easier to change safely.
 :::
 
+<span class="composition-api">In TypeScript, a type-based `defineProps()` declaration can also be used when the prop contract is fully described by its types.</span>
+
 <div class="options-api">
 
 <div class="style-example style-example-bad">
@@ -95,10 +97,6 @@ const props = defineProps({
 
 </div>
 
-**Notes**
-
-- In TypeScript, a type-based `defineProps()` declaration is equally acceptable if it expresses the contract clearly.
-
 ## Declare emitted events {#declare-emitted-events}
 
 Treat emitted events as part of a component's public contract, and declare them explicitly.
@@ -107,27 +105,65 @@ Treat emitted events as part of a component's public contract, and declare them 
 Explicit [event declarations](/guide/components/events) document how a component communicates outward and make parent-child interactions easier to follow.
 :::
 
-In standard `setup()` usage, declare events with the [`emits`](/guide/components/events#declaring-emitted-events) option. In [`<script setup>`](/api/sfc-script-setup#defineprops-defineemits), declare them with `defineEmits()`.
+In Options API, declare events with the [`emits`](/guide/components/events#declaring-emitted-events) option. In [`<script setup>`](/api/sfc-script-setup#defineprops-defineemits), declare them with `defineEmits()`.
 
 Use the object syntax when event payloads need validation, and an array of event names when they do not.
 
-In TypeScript, prefer a typed `defineEmits()` declaration so the event contract is checked by the type system as well as documented in the component. In Vue 3.3+, the named tuple syntax is usually the more succinct form.
+<span class="composition-api">In TypeScript, a typed `defineEmits()` declaration can also be used so the event contract is checked by the type system as well as documented in the component. Vue 3.3+ also supports a named tuple syntax for the same declaration.</span>
+
+<div class="options-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+export default {
+  methods: {
+    submit(email) {
+      this.$emit('submit', { email })
+    }
+  }
+}
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+export default {
+  emits: {
+    submit: (payload) => typeof payload?.email === 'string'
+  },
+
+  methods: {
+    submit(email) {
+      this.$emit('submit', { email })
+    }
+  }
+}
+```
+
+</div>
+
+</div>
+
+<div class="composition-api">
 
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
 ```vue
-<script>
-export default {
-  setup(props, { emit }) {
-    function submit(email) {
-      emit('submit', { email })
-    }
-
-    return { submit }
-  }
+<script setup>
+const form = {
+  email: ''
 }
 </script>
+
+<template>
+  <button @click="$emit('submit', { email: form.email })">Submit</button>
+</template>
 ```
 
 </div>
@@ -136,49 +172,41 @@ export default {
 <h3>Good</h3>
 
 ```vue
-<script>
-export default {
-  emits: {
-    submit: (payload) => typeof payload?.email === 'string'
-  },
-
-  setup(props, { emit }) {
-    function submit(email) {
-      emit('submit', { email })
-    }
-
-    return { submit }
-  }
-}
-</script>
-```
-
-```vue
 <script setup>
-const emit = defineEmits({
+const form = {
+  email: ''
+}
+
+defineEmits({
   submit: (payload) => typeof payload?.email === 'string'
 })
-
-function submit(email) {
-  emit('submit', { email })
-}
 </script>
+
+<template>
+  <button @click="$emit('submit', { email: form.email })">Submit</button>
+</template>
 ```
 
 ```vue
 <script setup lang="ts">
+const form = {
+  email: ''
+}
+
 const emit = defineEmits<{
   // Type-based declaration
   (e: 'submit', payload: { email: string }): void
   // Vue 3.3+: alternative, more succinct syntax
   submit: [payload: { email: string }]
 }>()
-
-function submit(email: string) {
-  emit('submit', { email })
-}
 </script>
+
+<template>
+  <button @click="emit('submit', { email: form.email })">Submit</button>
+</template>
 ```
+
+</div>
 
 </div>
 
@@ -190,6 +218,56 @@ Pass data down with props, and communicate requested changes back up with emitte
 Vue components are easier to understand and maintain when state ownership is clear. Prop mutation and other implicit parent-child coupling make updates harder to reason about and components harder to reuse.
 :::
 
+This includes `v-model`, which still follows the same prop-and-event communication pattern with shorthand syntax.
+
+If a child needs editable local state, derive or initialize it from the prop instead of mutating the prop itself.
+
+<div class="options-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+export default {
+  props: {
+    open: Boolean
+  },
+
+  methods: {
+    requestClose() {
+      this.open = false
+    }
+  }
+}
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+export default {
+  props: {
+    open: Boolean
+  },
+
+  emits: ['update:open'],
+
+  methods: {
+    requestClose() {
+      this.$emit('update:open', false)
+    }
+  }
+}
+```
+
+</div>
+
+</div>
+
+<div class="composition-api">
+
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
@@ -198,7 +276,7 @@ const props = defineProps({
   open: Boolean
 })
 
-function close() {
+function requestClose() {
   props.open = false
 }
 ```
@@ -215,17 +293,14 @@ const props = defineProps({
 
 const emit = defineEmits(['update:open'])
 
-function close() {
+function requestClose() {
   emit('update:open', false)
 }
 ```
 
 </div>
 
-**Notes**
-
-- `v-model` still follows this rule. It is prop-and-event communication with shorthand syntax.
-- If a child needs editable local state, derive or initialize local state from the prop instead of mutating the prop itself.
+</div>
 
 ## Use component-scoped styling {#use-component-scoped-styling}
 
@@ -257,7 +332,7 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 
 ```vue-html
 <template>
-  <button class="button-close">×</button>
+  <button class="button button-close">×</button>
 </template>
 
 <!-- Using the `scoped` attribute -->
@@ -300,19 +375,64 @@ Component-scoped styling reduces accidental coupling, makes style ownership clea
 
 ## Use computed for derived state {#use-computed-for-derived-state}
 
-Use [computed](/guide/essentials/computed) for synchronous derived state, and use [watch](/guide/essentials/watchers), `watchEffect()`, or lifecycle hooks for side effects.
+Use [computed](/guide/essentials/computed) for synchronous derived state instead of storing and synchronizing it manually, and use [watch](/guide/essentials/watchers), `watchEffect()`, or lifecycle hooks for side effects.
 
 ::: details Why this matters
 Computed state should describe what values mean, not perform work. Keeping derivation pure and synchronous makes reactive code easier to reason about and keeps side effects in the places Vue expects them.
 :::
+
+<div class="options-api">
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```js
+export default {
+  computed: {
+    fullName() {
+      const value = `${this.user.firstName} ${this.user.lastName}`
+      analytics.track('full-name-changed', value)
+      return value
+    }
+  }
+}
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```js
+export default {
+  computed: {
+    fullName() {
+      return `${this.user.firstName} ${this.user.lastName}`
+    }
+  },
+
+  watch: {
+    fullName(value) {
+      analytics.track('full-name-changed', value)
+    }
+  }
+}
+```
+
+</div>
+
+</div>
+
+<div class="composition-api">
 
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
 ```js
 const fullName = computed(() => {
-  analytics.track('full-name-read')
-  return `${user.value.firstName} ${user.value.lastName}`
+  const value = `${user.value.firstName} ${user.value.lastName}`
+  analytics.track('full-name-changed', value)
+  return value
 })
 ```
 
@@ -333,7 +453,4 @@ watch(fullName, (value) => {
 
 </div>
 
-**Notes**
-
-- Async reactions, network requests, DOM reads and writes, timers, and subscriptions belong in watchers, `watchEffect()`, or lifecycle hooks.
-- If a value can be expressed from existing reactive state, prefer `computed` over storing and synchronizing another piece of state.
+</div>

--- a/src/style-guide/rules-essential.md
+++ b/src/style-guide/rules-essential.md
@@ -107,13 +107,27 @@ Treat emitted events as part of a component's public contract, and declare them 
 Explicit [event declarations](/guide/components/events) document how a component communicates outward and make parent-child interactions easier to follow.
 :::
 
+In standard `setup()` usage, declare events with the [`emits`](/guide/components/events#declaring-emitted-events) option. In [`<script setup>`](/api/sfc-script-setup#defineprops-defineemits), declare them with `defineEmits()`.
+
+Use the object syntax when event payloads need validation, and an array of event names when they do not.
+
+In TypeScript, prefer a typed `defineEmits()` declaration so the event contract is checked by the type system as well as documented in the component. In Vue 3.3+, the named tuple syntax is usually the more succinct form.
+
 <div class="style-example style-example-bad">
 <h3>Bad</h3>
 
-```js
-function submit() {
-  $emit('submit', { email: form.email })
+```vue
+<script>
+export default {
+  setup(props, { emit }) {
+    function submit(email) {
+      emit('submit', { email })
+    }
+
+    return { submit }
+  }
 }
+</script>
 ```
 
 </div>
@@ -121,36 +135,52 @@ function submit() {
 <div class="style-example style-example-good">
 <h3>Good</h3>
 
-```js
+```vue
+<script>
+export default {
+  emits: {
+    submit: (payload) => typeof payload?.email === 'string'
+  },
+
+  setup(props, { emit }) {
+    function submit(email) {
+      emit('submit', { email })
+    }
+
+    return { submit }
+  }
+}
+</script>
+```
+
+```vue
+<script setup>
 const emit = defineEmits({
   submit: (payload) => typeof payload?.email === 'string'
 })
 
-function submit() {
-  emit('submit', { email: form.email })
+function submit(email) {
+  emit('submit', { email })
 }
+</script>
 ```
 
-```ts
+```vue
+<script setup lang="ts">
 const emit = defineEmits<{
-  // type-based definition
+  // Type-based declaration
   (e: 'submit', payload: { email: string }): void
-  // 3.3+: alternative, more succinct syntax
-  submit: [payload, { email: string}]
+  // Vue 3.3+: alternative, more succinct syntax
+  submit: [payload: { email: string }]
 }>()
 
-function submit() {
-  emit('submit', { email: form.email })
+function submit(email: string) {
+  emit('submit', { email })
 }
+</script>
 ```
 
 </div>
-
-**Notes**
-
-- An array of event names is acceptable when payload validation would add no real value.
-- In TypeScript, prefer a typed `defineEmits()` declaration so the event contract is checked by the type system as well as documented in the component.
-- If runtime payload validation is also useful, use the object syntax.
 
 ## Keep parent-child data flow explicit {#keep-parent-child-data-flow-explicit}
 

--- a/src/style-guide/rules-recommended.md
+++ b/src/style-guide/rules-recommended.md
@@ -1,7 +1,7 @@
-# Priority C Rules: Recommended {#priority-c-rules-recommended}
+# Priority C Rules: Recommended (Legacy Reference) {#priority-c-rules-recommended}
 
-::: warning Note
-This Vue.js Style Guide is outdated and needs to be reviewed. If you have any questions or suggestions, please [open an issue](https://github.com/vuejs/docs/issues/new).
+::: warning Legacy Reference
+This page is retained for historical reference while the style guide is being revamped. It is not part of the current essential-only scope, and its recommendations should not be treated as reaffirmed guidance.
 :::
 
 Where multiple, equally good options exist, an arbitrary choice can be made to ensure consistency. In these rules, we describe each acceptable option and suggest a default choice. That means you can feel free to make a different choice in your own codebase, as long as you're consistent and have a good reason. Please do have a good reason though! By adapting to the community standard, you will:

--- a/src/style-guide/rules-strongly-recommended.md
+++ b/src/style-guide/rules-strongly-recommended.md
@@ -1,7 +1,7 @@
-# Priority B Rules: Strongly Recommended {#priority-b-rules-strongly-recommended}
+# Priority B Rules: Strongly Recommended (Legacy Reference) {#priority-b-rules-strongly-recommended}
 
-::: warning Note
-This Vue.js Style Guide is outdated and needs to be reviewed. If you have any questions or suggestions, please [open an issue](https://github.com/vuejs/docs/issues/new).
+::: warning Legacy Reference
+This page is retained for historical reference while the style guide is being revamped. It is not part of the current essential-only scope, and its recommendations should not be treated as reaffirmed guidance.
 :::
 
 These rules have been found to improve readability and/or developer experience in most projects. Your code will still run if you violate them, but violations should be rare and well-justified.

--- a/src/style-guide/rules-strongly-recommended.md
+++ b/src/style-guide/rules-strongly-recommended.md
@@ -6,6 +6,42 @@ This page is retained for historical reference while the style guide is being re
 
 These rules have been found to improve readability and/or developer experience in most projects. Your code will still run if you violate them, but violations should be rare and well-justified.
 
+## Use multi-word component names {#use-multi-word-component-names}
+
+**In most projects, user component names should always be multi-word, except for root `App` components.**
+
+This [prevents conflicts](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) with existing and future HTML elements, since all HTML elements are a single word.
+
+In [Single-File Components](/guide/scaling-up/sfc), string templates, and [JSX](/guide/extras/render-function#jsx-tsx), [PascalCase component tags](#component-name-casing-in-templates) can also help make user components more clearly distinct from native elements. In in-DOM templates, where tags must be kebab-case, that distinction is no longer available, so the case for multi-word names is even stronger.
+
+That said, there can be pragmatic exceptions, such as route components in file-based routing.
+
+<div class="style-example style-example-bad">
+<h3>Bad</h3>
+
+```vue-html
+<!-- In Single-File Components, string templates, and JSX -->
+<Item />
+
+<!-- In in-DOM templates -->
+<item></item>
+```
+
+</div>
+
+<div class="style-example style-example-good">
+<h3>Good</h3>
+
+```vue-html
+<!-- In Single-File Components, string templates, and JSX -->
+<TodoItem />
+
+<!-- In in-DOM templates -->
+<todo-item></todo-item>
+```
+
+</div>
+
 ## Component files {#component-files}
 
 **Whenever a build system is available to concatenate files, each component should be in its own file.**

--- a/src/style-guide/rules-use-with-caution.md
+++ b/src/style-guide/rules-use-with-caution.md
@@ -1,7 +1,7 @@
-# Priority D Rules: Use with Caution {#priority-d-rules-use-with-caution}
+# Priority D Rules: Use with Caution (Legacy Reference) {#priority-d-rules-use-with-caution}
 
-::: warning Note
-This Vue.js Style Guide is outdated and needs to be reviewed. If you have any questions or suggestions, please [open an issue](https://github.com/vuejs/docs/issues/new).
+::: warning Legacy Reference
+This page is retained for historical reference while the style guide is being revamped. It is not part of the current essential-only scope, and its recommendations should not be treated as reaffirmed guidance.
 :::
 
 Some features of Vue exist to accommodate rare edge cases or smoother migrations from a legacy code base. When overused however, they can make your code more difficult to maintain or even become a source of bugs. These rules shine a light on potentially risky features, describing when and why they should be avoided.


### PR DESCRIPTION
## Description of Problem
The original Essential Style Guide was designed for JavaScript. In this PR, we will create a Vue Essential Style Guide specifically for TypeScript.

## Proposed Solution
- Please visite `/style-guide/rules-essential-ts.html` to this guide
- Updated style guide to TypeScript friendly
- Added more guides:
  - Access DOM or component instances
  - Avoid destructuring from reactive() directly
  - Watching reactive state
  - Prefer computed over watcher-assigned derived refs
  - Use eager watchers instead of duplicate initial calls

Relared #3370 
