### PR TITLE
Fix usage of "bare bones" idiom on routing docs page

### DIFF
--- a/src/guide/scaling-up/routing.md
+++ b/src/guide/scaling-up/routing.md
@@ -23,7 +23,7 @@ Vue is well-suited for building SPAs. For most SPAs, it's recommended to use the
 
 If you only need very simple routing and do not wish to involve a full-featured router library, you can do so with [Dynamic Components](/guide/essentials/component-basics#dynamic-components) and update the current component state by listening to browser [`hashchange` events](https://developer.mozilla.org/en-US/docs/Web/API/Window/hashchange_event) or using the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History).
 
-Here's a bare-bone example:
+Here's a bare-bones example:
 
 <div class="composition-api">
 


### PR DESCRIPTION
## Description of Problem

While reading the routing docs, I noticed that the idiomatic phrase "bare bones" was in the singular rather than in the plural.

## Proposed Solution

Adding an "s" to the word "bone" fixes the issue as implemented in the commit.

## Additional Information

See also https://grammarist.com/idiom/bare-bones/ for more information about this idiom.