### PR TITLE
docs: add mergeProps behavior note to props guide

### DIFF
--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -338,6 +338,30 @@ Will be equivalent to:
 <BlogPost :id="post.id" :title="post.title" />
 ```
 
+### Merge Behavior When Combining Bindings {#merge-behavior-when-combining-bindings}
+
+When `v-bind` is used alongside explicit bindings on the same component, Vue internally calls `mergeProps()` to combine them. The merging strategy depends on the key type:
+
+- **Regular props** — the last value wins:
+
+```vue-html
+<!-- title === 'bar' -->
+<BlogPost title="foo" v-bind="{ title: 'bar' }" />
+```
+
+- **Event listeners** — when passing listeners in a `v-bind` object, [use the `onXxx` key convention](/guide/extras/render-function#v-on). All handlers for the same event will be called (see [v-on Listener Inheritance](/guide/components/attrs#v-on-listener-inheritance)):
+
+```vue-html
+<!-- logs 1 and 2 -->
+<BlogPost @click="console.log(1)" v-bind="{ onClick: () => console.log(2) }" />
+```
+
+- **`class` and `style`** follow a similar merge strategy (see [Class and Style Merging](/guide/components/attrs#class-and-style-merging)).
+
+:::tip
+The full merging rules are described in the [`mergeProps()`](/api/render-function#mergeprops) API reference.
+:::
+
 ## One-Way Data Flow {#one-way-data-flow}
 
 All props form a **one-way-down binding** between the child property and the parent one: when the parent property updates, it will flow down to the child, but not the other way around. This prevents child components from accidentally mutating the parent's state, which can make your app's data flow harder to understand.

--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -349,14 +349,14 @@ When `v-bind` is used alongside explicit bindings on the same component, Vue int
 <BlogPost title="foo" v-bind="{ title: 'bar' }" />
 ```
 
-- **Event listeners** — when passing listeners in a `v-bind` object, [use the `onEventName` key convention](/guide/extras/render-function#v-on). All handlers for the same event will be called (see [v-on Listener Inheritance](/guide/components/attrs#v-on-listener-inheritance)):
+- **Event listeners** — when passing listeners in a `v-bind` object, [use the `onEventName` key convention](/guide/extras/render-function#v-on). All handlers for the same event will be called (see [`v-on` Listener Inheritance](/guide/components/attrs#v-on-listener-inheritance)):
 
 ```vue-html
 <!-- logs 1 and 2 -->
 <BlogPost @click="console.log(1)" v-bind="{ onClick: () => console.log(2) }" />
 ```
 
-- **`class` and `style`** follow a similar merge strategy (see [Class and Style Merging](/guide/components/attrs#class-and-style-merging)).
+- **`class` and `style`** follow a similar merge strategy (see [`class` and `style` Merging](/guide/components/attrs#class-and-style-merging)).
 
 :::tip
 The full merging rules are described in the [`mergeProps()`](/api/render-function#mergeprops) API reference.

--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -349,7 +349,7 @@ When `v-bind` is used alongside explicit bindings on the same component, Vue int
 <BlogPost title="foo" v-bind="{ title: 'bar' }" />
 ```
 
-- **Event listeners** — when passing listeners in a `v-bind` object, [use the `onXxx` key convention](/guide/extras/render-function#v-on). All handlers for the same event will be called (see [v-on Listener Inheritance](/guide/components/attrs#v-on-listener-inheritance)):
+- **Event listeners** — when passing listeners in a `v-bind` object, [use the `onEventName` key convention](/guide/extras/render-function#v-on). All handlers for the same event will be called (see [v-on Listener Inheritance](/guide/components/attrs#v-on-listener-inheritance)):
 
 ```vue-html
 <!-- logs 1 and 2 -->


### PR DESCRIPTION
## Description of Problem

When combining explicit bindings (e.g. `@click`) with a `v-bind` object on a component, Vue internally uses `mergeProps()` to combine them. The merging strategy is asymmetric: regular props are overwritten by the last value, while event listeners, `class`, and `style` are merged. This behavior is not documented in the Components Props guide, leaving users without explanation for why multiple handlers fire unexpectedly.

## Proposed Solution

Add a "Merge Behavior When Combining Bindings" subsection to the "Prop Passing Details" section of the Props guide, where the reader already has the right context. The note covers the asymmetric merge strategy and links to the existing documentation in the Render Function API reference and Fallthrough Attributes guide.

## Additional Information

The merging rules are already documented in the [`mergeProps()` API reference](https://vuejs.org/api/render-function#mergeprops) and partially in [Fallthrough Attributes](https://vuejs.org/guide/components/attrs), but neither of those sections addresses the case of explicit `v-bind` usage in a parent template.