### PR TITLE
fix: remove duplicate border-radius in VueSchoolLink component

### DIFF
--- a/.vitepress/theme/components/VueSchoolLink.vue
+++ b/.vitepress/theme/components/VueSchoolLink.vue
@@ -23,7 +23,6 @@ export default {
   margin: 28px 0;
   background-color: var(--vt-c-bg-soft);
   padding: 1em 1.25em;
-  border-radius: 2px;
   position: relative;
   display: flex;
   border-radius: 8px;


### PR DESCRIPTION
## Description of Problem

the .vueschool style block contains duplicate border-radius declarations. Since border-radius: 8px overrides the earlier border-radius: 2px, the previous declaration is ineffective.

## Proposed Solution

Remove the redundant `border-radius: 2px` and keep only `border-radius: 8px`.

## Additional Information
