### PR TITLE
docs: add descriptive alt text to guide diagrams

### DIFF
--- a/src/guide/components/provide-inject.md
+++ b/src/guide/components/provide-inject.md
@@ -6,7 +6,7 @@
 
 Usually, when we need to pass data from the parent to a child component, we use [props](/guide/components/props). However, imagine the case where we have a large component tree, and a deeply nested component needs something from a distant ancestor component. With only props, we would have to pass the same prop across the entire parent chain:
 
-![prop drilling diagram](./images/prop-drilling.png)
+![Diagram showing props being passed through multiple levels of components just to reach a deeply nested child](./images/prop-drilling.png)
 
 <!-- https://www.figma.com/file/yNDTtReM2xVgjcGVRzChss/prop-drilling -->
 
@@ -14,7 +14,7 @@ Notice although the `<Footer>` component may not care about these props at all, 
 
 We can solve props drilling with `provide` and `inject`. A parent component can serve as a **dependency provider** for all its descendants. Any component in the descendant tree, regardless of how deep it is, can **inject** dependencies provided by components up in its parent chain.
 
-![Provide/inject scheme](./images/provide-inject.png)
+![Diagram showing the provide/inject mechanism where a parent component provides a dependency that can be directly injected by a deeply nested child, bypassing intermediate components](./images/provide-inject.png)
 
 <!-- https://www.figma.com/file/PbTJ9oXis5KUawEOWdy2cE/provide-inject -->
 

--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -26,7 +26,7 @@ The template of `<FancyButton>` looks like this:
 
 The `<slot>` element is a **slot outlet** that indicates where the parent-provided **slot content** should be rendered.
 
-![slot diagram](./images/slots.png)
+![Diagram showing slot content from the parent being injected into the slot outlet in the child component](./images/slots.png)
 
 <!-- https://www.figma.com/file/LjKTYVL97Ck6TEmBbstavX/slot -->
 
@@ -207,7 +207,7 @@ To pass a named slot, we need to use a `<template>` element with the `v-slot` di
 
 `v-slot` has a dedicated shorthand `#`, so `<template v-slot:header>` can be shortened to just `<template #header>`. Think of it as "render this template fragment in the child component's 'header' slot".
 
-![named slots diagram](./images/named-slots.png)
+![Diagram showing multiple named slots in a layout component, with content from the parent being directed to the corresponding header, main, and footer slots](./images/named-slots.png)
 
 <!-- https://www.figma.com/file/2BhP8gVZevttBu9oUmUUyz/named-slot -->
 
@@ -367,7 +367,7 @@ Receiving the slot props is a bit different when using a single default slot vs.
 </MyComponent>
 ```
 
-![scoped slots diagram](./images/scoped-slots.svg)
+![Diagram showing a scoped slot where the child component passes data back to the parent-provided slot content](./images/scoped-slots.svg)
 
 <!-- https://www.figma.com/file/QRneoj8eIdL1kw3WQaaEyc/scoped-slot -->
 

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -6,7 +6,7 @@
 
 Components allow us to split the UI into independent and reusable pieces, and think about each piece in isolation. It's common for an app to be organized into a tree of nested components:
 
-![Component Tree](./images/components.png)
+![Diagram showing a component tree structure with a root component branching into multiple child and nested sub-child components](./images/components.png)
 
 <!-- https://www.figma.com/file/qa7WHDQRWuEZNRs7iZRZSI/components -->
 

--- a/src/guide/essentials/lifecycle.md
+++ b/src/guide/essentials/lifecycle.md
@@ -59,7 +59,7 @@ Do note this doesn't mean that the call must be placed lexically inside `setup()
 
 Below is a diagram for the instance lifecycle. You don't need to fully understand everything going on right now, but as you learn and build more, it will be a useful reference.
 
-![Component lifecycle diagram](./images/lifecycle.png)
+![Diagram showing the full lifecycle of a Vue component, from creation to destruction, including all major lifecycle hooks and the internal processes like template compilation and mounting](./images/lifecycle.png)
 
 <!-- https://www.figma.com/file/Xw3UeNMOralY6NV7gSjWdS/Vue-Lifecycle -->
 

--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -286,6 +286,6 @@ You'll see other examples of modifiers later, [for `v-on`](./event-handling#even
 
 And finally, here's the full directive syntax visualized:
 
-![directive syntax graph](./images/directive.png)
+![Diagram visualizing the full directive syntax, including directive name, argument, modifiers, and value](./images/directive.png)
 
 <!-- https://www.figma.com/file/BGWUknIrtY9HOmbmad0vFr/Directive -->


### PR DESCRIPTION
Replace terse image labels (e.g. "prop drilling diagram") with full descriptive alt text across the guide so screen-reader users get a meaningful description of each diagram's content.

## Description of Problem

## Proposed Solution

## Additional Information

Derived from the original PR https://github.com/vuejs/docs/pull/3347 that is now stale.
