### PR TITLE
docs: resolve outstanding TODO stubs in guide and API reference

### DIFF
--- a/src/api/options-state.md
+++ b/src/api/options-state.md
@@ -144,7 +144,8 @@ Declare computed properties to be exposed on the component instance.
 
   type ComputedGetter<T> = (
     this: ComponentPublicInstance,
-    vm: ComponentPublicInstance
+    vm: ComponentPublicInstance,
+    previous?: T
   ) => T
 
   type ComputedSetter<T> = (

--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -278,7 +278,7 @@ type DebuggerEvent = {
 
 ### Computed Debugging {#computed-debugging}
 
-<!-- TODO options API equivalent -->
+<div class="composition-api">
 
 We can debug computed properties by passing `computed()` a second options object with `onTrack` and `onTrigger` callbacks:
 
@@ -310,9 +310,17 @@ count.value++
 `onTrack` and `onTrigger` computed options only work in development mode.
 :::
 
+</div>
+
+<div class="options-api">
+
+Computed debugging options are only available via the Composition API `computed()` function.
+
+</div>
+
 ### Watcher Debugging {#watcher-debugging}
 
-<!-- TODO options API equivalent -->
+<div class="composition-api">
 
 Similar to `computed()`, watchers also support the `onTrack` and `onTrigger` options:
 
@@ -335,6 +343,32 @@ watchEffect(callback, {
   }
 })
 ```
+
+</div>
+
+<div class="options-api">
+
+Watchers declared with the object syntax also support the `onTrack` and `onTrigger` options:
+
+```js
+export default {
+  watch: {
+    source: {
+      handler() {
+        // ...
+      },
+      onTrack(e) {
+        debugger
+      },
+      onTrigger(e) {
+        debugger
+      }
+    }
+  }
+}
+```
+
+</div>
 
 :::tip
 `onTrack` and `onTrigger` watcher options only work in development mode.

--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -186,4 +186,8 @@ The official loader that provides Vue SFC support in webpack. If you are using V
 - [Vue on Codepen](https://codepen.io/pen/editor/vue)
 - [Vue on WebComponents.dev](https://webcomponents.dev/create/cevue)
 
-<!-- TODO ## Backend Framework Integrations -->
+## Backend Framework Integrations {#backend-framework-integrations}
+
+If you are using Vue with [Laravel](https://laravel.com/), the framework ships an official [Vite plugin](https://laravel.com/docs/vite) that handles asset bundling and hot-module replacement out of the box.
+
+For any other backend, refer to Vite's [Backend Integration guide](https://vite.dev/guide/backend-integration.html) to wire it up manually.


### PR DESCRIPTION
## Description of Problem

There were TODO comments still in the guides and this PR helps to fill in those gaps.

## Proposed Solution

- reactivity-in-depth: document the Options API watcher debugging equivalent (onTrack/onTrigger via object syntax) and note that computed debugging is Composition-API only; wrap the existing Composition examples in API-toggle blocks
- options-state: document the previous value passed to computed getters
- tooling: fill in the Backend Framework Integrations section with Laravel's official Vite plugin

## Additional Information

Work inspired from https://github.com/vuejs/docs/pull/3347
