### PR TITLE
docs: add note about object/array default values in defineModel

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -314,7 +314,7 @@ const myRef = ref()
 </template>
 ```
 
-Also note that, as when using `withDefaults` with `defineProps`, default values for mutable reference types (like arrays or objects) should be wrapped in functions in `defineModel` to avoid accidental modification and external side effects.
+Also, when using `withDefaults` with `defineProps`, default values for mutable reference types (like arrays or objects) should be wrapped in functions in `defineModel` to avoid accidental modification and external side effects.
 :::
 
 ### Modifiers and Transformers {#modifiers-and-transformers}

--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -314,6 +314,7 @@ const myRef = ref()
 </template>
 ```
 
+Also note that, as when using `withDefaults` with `defineProps`, default values for mutable reference types (like arrays or objects) should be wrapped in functions in `defineModel` to avoid accidental modification and external side effects.
 :::
 
 ### Modifiers and Transformers {#modifiers-and-transformers}

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -115,7 +115,7 @@ const myRef = ref()
 </template>
 ```
 
-Also note that, as when using `withDefaults` with `defineProps`, default values for mutable reference types (like arrays or objects) should be wrapped in functions in `defineModel` to avoid accidental modification and external side effects.
+Also, when using `withDefaults` with `defineProps`, default values for mutable reference types (like arrays or objects) should be wrapped in functions in `defineModel` to avoid accidental modification and external side effects.
 :::
 
 </div>

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -115,6 +115,7 @@ const myRef = ref()
 </template>
 ```
 
+Also note that, as when using `withDefaults` with `defineProps`, default values for mutable reference types (like arrays or objects) should be wrapped in functions in `defineModel` to avoid accidental modification and external side effects.
 :::
 
 </div>


### PR DESCRIPTION
## Description of Problem

The `v-model`/`defineModel` documentation does not mention that object/array literals should be avoided as default values, and that wrapped functions should be used instead.

Quote from [Typing Component Props - Props Default Values](https://vuejs.org/guide/typescript/composition-api.html#props-default-values):

> Note that default values for mutable reference types (like arrays or objects) should be wrapped in functions when using `withDefaults` to avoid accidental modification and external side effects. This ensures each component instance gets its own copy of the default value. This is not necessary when using default values with destructure.

## Proposed Solution

Add a short note using the text from the quote above in a `warning` block to the following sections:
1. [Component v-model - Under the Hood](https://vuejs.org/guide/components/v-model.html#under-the-hood)
2. [API Reference - defineModel()](https://vuejs.org/api/sfc-script-setup.html#definemodel)

> Also note that, as when using `withDefaults` with `defineProps`, default values for mutable reference types (like arrays or objects) should be wrapped in functions in `defineModel` to avoid accidental modification and external side effects.

## Additional Information

Since `v-model` uses props/emits under the hood, this will help highlight the connection between them.