### PR TITLE
docs: remove duplicate German entry in WIP languages list

### DIFF
--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -26,7 +26,6 @@ aside: false
 
 - [العربية / Arabic](https://ar.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-ar)]
 - [Español / Spanish](https://vue3-spanish-docs.netlify.app/) [[source](https://github.com/icarusgk/vuejs-spanish-docs)]
-- [Deutsch / German](https://de.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-de)]
 
 ## Starting a new Translation {#starting-a-new-translation}
 


### PR DESCRIPTION
## Description of Problem

German was listed twice in `src/translations/index.md` - once under "Available Languages" and again under "Work in Progress Languages".

## Proposed Solution

Remove the duplicate entry from the WIP list.

## Additional Information