### PR TITLE
Update nodejs expected version

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -23,7 +23,7 @@ import { VTCodeGroup, VTCodeGroupTab } from '@vue/theme'
 :::tip Prerequisites
 
 - Familiarity with the command line
-- Install [Node.js](https://nodejs.org/) version `^20.19.0 || >=22.12.0`
+- Install [Node.js](https://nodejs.org/) version `^22.18.0 || >=24.12.0`
   :::
 
 In this section we will introduce how to scaffold a Vue [Single Page Application](/guide/extras/ways-of-using-vue#single-page-application-spa) on your local machine. The created project will be using a build setup based on [Vite](https://vite.dev/) and allow us to use Vue [Single-File Components](/guide/scaling-up/sfc) (SFCs).


### PR DESCRIPTION
Update nodejs expected version according to the error given by create-vue@3.22.4

## Description of Problem

Tried to use `yarn create vue` with yarn 1.22 and node.js 20.20.2 and got the error: 

```
yarn create vue
yarn create v1.22.22
warning package.json: No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
error create-vue@3.22.4: The engine "node" is incompatible with this module. Expected version "^22.18.0 || >=24.12.0". Got "20.20.2"
error Found incompatible module.
```
