### PR TITLE
Fix: three incorrect code examples in the guide

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -208,7 +208,7 @@ More details: [Typing Component Emits](/guide/typescript/composition-api#typing-
 </div>
 <div class="options-api">
 
-```js
+```ts
 export default {
   emits: {
     submit(payload: { email: string, password: string }) {

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -524,7 +524,7 @@ export default {
 For `v-model` bindings with both argument and modifiers, the generated prop name will be `arg + "Modifiers"`. For example:
 
 ```vue-html
-<MyComponent v-model:title.capitalize="myText">
+<MyComponent v-model:title.capitalize="myText" />
 ```
 
 The corresponding declarations should be:

--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -580,7 +580,7 @@ To keep each component instance's debounced function independent of the others, 
 export default {
   created() {
     // each instance now has its own copy of debounced handler
-    this.debouncedClick = _.debounce(this.click, 500)
+    this.debouncedClick = debounce(this.click, 500)
   },
   unmounted() {
     // also a good idea to cancel the timer


### PR DESCRIPTION
## Description of Problem

Three errors in code examples across the guide — see issue #3417 for full context.

**1. `guide/essentials/reactivity-fundamentals` — Stateful Methods**

The solution block uses `_.debounce(this.click, 500)`, but `_` is never imported. The preceding block in the same section already has `import { debounce } from 'lodash-es'`, so calling `_.debounce` results in a `ReferenceError` at runtime.

**2. `guide/components/events` — Declaring Emitted Events, Options API**

The Options API `emits` object syntax example contains TypeScript type annotations but is fenced as `js`. The Composition API counterpart directly above it correctly uses `<script setup lang="ts">`.

**3. `guide/components/v-model` — Modifiers for v-model with Arguments, Options API**

The tag `<MyComponent v-model:title.capitalize="myText">` is missing the self-closing `/>`. All other component tags on the page use `/>`.

## Proposed Solution

- `reactivity-fundamentals.md`: replace `_.debounce` with `debounce`
- `events.md`: change code fence from `js` to `ts`
- `v-model.md`: add `/>` to close the component tag

## Additional Information

Closes #3417