### PR TITLE
docs: clarify translation contribution guidance

### DIFF
--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -28,7 +28,7 @@ aside: false
 - [Español / Spanish](https://vue3-spanish-docs.netlify.app/) [[source](https://github.com/icarusgk/vuejs-spanish-docs)]
 - [Deutsch / German](https://de.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-de)]
 
-## Starting a new Translation {#starting-a-new-translation}
+## Contributing to Translations {#contributing-to-translations}
 
 The Vue documentation has recently undergone a major revision, so translations in other languages are still missing or work-in-progress.
 


### PR DESCRIPTION
## Description of Problem

I was looking whether there was language support for Dutch and how I could potentially contribute to it. This section made it sound like I could start a new translation if one didn't exist, but that's no longer the case. I think this section mostly reflects on how to contribute to existing translations.

> Vue core docs are no longer accepting new translations.


## Proposed Solution

Update the title to reflect the current situation, because Vue core docs no longer accepts new translations.

## Additional Information

Link to [Vue Community Translation Guidelines - Translation policy](https://github.com/vuejs-translations/guidelines/blob/main/README.md#translation-policy)
