### PR TITLE
docs(watchers): clarify watchEffect re-evaluates dependencies on each run (closes #13688)

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -364,6 +364,8 @@ For examples like these, with only one dependency, the benefit of `watchEffect()
 
 - `watchEffect`, on the other hand, combines dependency tracking and side effect into one phase. It automatically tracks every reactive property accessed during its synchronous execution. This is more convenient and typically results in terser code, but makes its reactive dependencies less explicit.
 
+Because dependencies are re-evaluated on **every** run, `watchEffect` can also pick up new dependencies later in its lifetime. For example, when an `if` branch in the callback becomes truthy and accesses a previously untracked ref, that ref is tracked from the next run onwards. Conversely, a ref that stops being accessed after a control-flow change will no longer trigger the callback. This is intended behavior and safe to rely on.
+
 </div>
 
 ## Side Effect Cleanup {#side-effect-cleanup}


### PR DESCRIPTION
## Summary

Add a short paragraph to `guide/essentials/watchers.md` clarifying that `watchEffect` re-evaluates its reactive dependencies on each synchronous run. This means refs reached only via conditional branches join the dependency set on the next tick, and refs that stop being read drop off cleanly — both behaviors are part of the intended design, not accidental side effects.

Closes #13688.

## Why

Issue #13688 reports that the existing wording — "automatically tracks every reactive property accessed during its synchronous execution" — leaves readers unable to judge whether dependencies are recomputed per run (and therefore whether conditional access patterns add/remove deps dynamically) or frozen after the first run.

The proposed addition bridges that gap and reflects the actual runtime behavior of `watchEffect`. No source code changes — documentation only.

## Test plan

- Read `vitepress dev` locally to confirm the new paragraph renders inside the "watch vs. watchEffect" section of `Essentials / Watchers`.
- Confirm the paragraph appears between the existing bullet list and the closing `</div>` for `composition-api` in `src/guide/essentials/watchers.md`.
- Spot-check formatting (Oxford comma, no banned words like "easy" / "just" / "obviously").

## AI assistance

This patch was drafted with the help of an AI coding assistant. The diff was reviewed line-by-line before submission and verified against the Vue docs writing guide (no emoji, plainer language, limited use of tip blocks).
