### PR TITLE
docs: update and consolidate Vue frameworks mentions

### DIFF
--- a/src/guide/components/async.md
+++ b/src/guide/components/async.md
@@ -116,7 +116,7 @@ In Vue 3.5+, async components can control when they are hydrated by providing a 
 
 - Vue provides a number of built-in hydration strategies. These built-in strategies need to be individually imported so they can be tree-shaken if not used.
 
-- The design is intentionally low-level for flexibility. Compiler syntax sugar can potentially be built on top of this in the future either in core or in higher level solutions (e.g. Nuxt).
+- The design is intentionally low-level for flexibility. Compiler syntax sugar can potentially be built on top of this in the future either in core or in [Vue frameworks](/guide/quick-start#frameworks).
 
 ### Hydrate on Idle {#hydrate-on-idle}
 

--- a/src/guide/components/async.md
+++ b/src/guide/components/async.md
@@ -116,7 +116,7 @@ In Vue 3.5+, async components can control when they are hydrated by providing a 
 
 - Vue provides a number of built-in hydration strategies. These built-in strategies need to be individually imported so they can be tree-shaken if not used.
 
-- The design is intentionally low-level for flexibility. Compiler syntax sugar can potentially be built on top of this in the future either in core or in [Vue frameworks](/guide/quick-start#frameworks).
+- The design is intentionally low-level for flexibility. Compiler syntax sugar can potentially be built on top of this in the future either in core or in higher level solutions such as [Vue frameworks](/guide/quick-start#frameworks).
 
 ### Hydrate on Idle {#hydrate-on-idle}
 

--- a/src/guide/extras/ways-of-using-vue.md
+++ b/src/guide/extras/ways-of-using-vue.md
@@ -33,7 +33,7 @@ Pure client-side SPAs are problematic when the app is sensitive to SEO and time-
 
 Vue provides first-class APIs to "render" a Vue app into HTML strings on the server. This allows the server to send back already-rendered HTML, allowing end users to see the content immediately while the JavaScript is being downloaded. Vue will then "hydrate" the application on the client side to make it interactive. This is called [Server-Side Rendering (SSR)](/guide/scaling-up/ssr) and it greatly improves Core Web Vital metrics such as [Largest Contentful Paint (LCP)](https://web.dev/lcp/).
 
-You can use [Vue frameworks](/guide/quick-start#frameworks), which are built on top of this paradigm and provide built-in support for SSR.
+There are also higher level [Vue frameworks](/guide/quick-start#frameworks), which are built on top of this paradigm and provide built-in support for SSR for developing full stack applications.
 
 ## JAMStack / SSG {#jamstack-ssg}
 

--- a/src/guide/extras/ways-of-using-vue.md
+++ b/src/guide/extras/ways-of-using-vue.md
@@ -47,7 +47,7 @@ There are two flavors of SSG: single-page and multi-page. Both flavors pre-rende
 
 Single-page SSGs are better suited if you expect non-trivial interactivity, deep session lengths, or persisted elements / state across navigations. Otherwise, multi-page SSG would be the better choice.
 
-[Vue frameworks](/guide/quick-start#frameworks) usually support SSG. Also, the Vue team maintains a static-site generator called [VitePress](https://vitepress.dev/), which powers this website you are reading right now! VitePress supports both flavors of SSG.
+The Vue team maintains a static-site generator called [VitePress](https://vitepress.dev/), which powers this website you are reading right now and support boths flavors of SSG! In addition, be sure to check out other [Vue frameworks](/guide/quick-start#frameworks) that usually support SSG.
 
 ## Beyond the Web {#beyond-the-web}
 

--- a/src/guide/extras/ways-of-using-vue.md
+++ b/src/guide/extras/ways-of-using-vue.md
@@ -33,7 +33,7 @@ Pure client-side SPAs are problematic when the app is sensitive to SEO and time-
 
 Vue provides first-class APIs to "render" a Vue app into HTML strings on the server. This allows the server to send back already-rendered HTML, allowing end users to see the content immediately while the JavaScript is being downloaded. Vue will then "hydrate" the application on the client side to make it interactive. This is called [Server-Side Rendering (SSR)](/guide/scaling-up/ssr) and it greatly improves Core Web Vital metrics such as [Largest Contentful Paint (LCP)](https://web.dev/lcp/).
 
-There are higher-level Vue-based frameworks built on top of this paradigm, such as [Nuxt](https://nuxt.com/), which allow you to develop a fullstack application using Vue and JavaScript.
+You can use [Vue frameworks](/guide/quick-start#frameworks), which are built on top of this paradigm and provide built-in support for SSR.
 
 ## JAMStack / SSG {#jamstack-ssg}
 
@@ -47,7 +47,7 @@ There are two flavors of SSG: single-page and multi-page. Both flavors pre-rende
 
 Single-page SSGs are better suited if you expect non-trivial interactivity, deep session lengths, or persisted elements / state across navigations. Otherwise, multi-page SSG would be the better choice.
 
-The Vue team also maintains a static-site generator called [VitePress](https://vitepress.dev/), which powers this website you are reading right now! VitePress supports both flavors of SSG. [Nuxt](https://nuxt.com/) also supports SSG. You can even mix SSR and SSG for different routes in the same Nuxt app.
+[Vue frameworks](/guide/quick-start#frameworks) usually support SSG. Also, the Vue team maintains a static-site generator called [VitePress](https://vitepress.dev/), which powers this website you are reading right now! VitePress supports both flavors of SSG.
 
 ## Beyond the Web {#beyond-the-web}
 

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -141,9 +141,9 @@ This will create a production-ready build of your app in the project's `./dist` 
 
 There are Vue frameworks which support [SSR](/guide/scaling-up/ssr) and other features out-of-the-box:
 - [Nuxt](https://nuxt.com/)
-- [Quasar](https://quasar.dev/)
 - [Vike](https://vike.dev/)
 - [Astro](https://astro.build/)
+- [Quasar](https://quasar.dev/)
 
 :::tip
 The general recommendation is to use a framework only if you need SSR.

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -137,6 +137,24 @@ This will create a production-ready build of your app in the project's `./dist` 
 
 [Next Steps >](#next-steps)
 
+## Frameworks {#frameworks}
+
+There are Vue frameworks which support [SSR](/guide/scaling-up/ssr) and other features out-of-the-box:
+- [Nuxt](https://nuxt.com/)
+- [Quasar](https://quasar.dev/)
+- [Vike](https://vike.dev/)
+- [Astro](https://astro.build/)
+
+:::tip
+The general recommendation is to use a framework only if you need SSR.
+
+If you don't need SSR, you can simply use [Vite](https://vite.dev/) (this is what the section above [Creating a Vue Application](#creating-a-vue-application) scaffolds).
+:::
+
+:::info
+Vue frameworks typically use Vite under the hood, so directly using Vite instead of a Vue framework is a simpler setup if you don't need SSR. That said, frameworks also support extra features, such as UI themes, which can also be a reason to favor a Vue framework instead of just using Vite.
+:::
+
 ## Using Vue from CDN {#using-vue-from-cdn}
 
 You can use Vue directly from a CDN via a script tag:

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -137,24 +137,6 @@ This will create a production-ready build of your app in the project's `./dist` 
 
 [Next Steps >](#next-steps)
 
-## Frameworks {#frameworks}
-
-There are Vue frameworks which support [SSR](/guide/scaling-up/ssr) and other features out-of-the-box:
-- [Nuxt](https://nuxt.com/)
-- [Vike](https://vike.dev/)
-- [Astro](https://astro.build/)
-- [Quasar](https://quasar.dev/)
-
-:::tip
-The general recommendation is to use a framework only if you need SSR.
-
-If you don't need SSR, you can simply use [Vite](https://vite.dev/) (this is what the section above [Creating a Vue Application](#creating-a-vue-application) scaffolds).
-:::
-
-:::info
-Vue frameworks typically use Vite under the hood, so directly using Vite instead of a Vue framework is a simpler setup if you don't need SSR. That said, frameworks also support extra features, such as UI themes, which can also be a reason to favor a Vue framework instead of just using Vite.
-:::
-
 ## Using Vue from CDN {#using-vue-from-cdn}
 
 You can use Vue directly from a CDN via a script tag:
@@ -414,6 +396,24 @@ Due to security reasons, ES modules can only work over the `http://` protocol, w
 To start a local HTTP server, first make sure you have [Node.js](https://nodejs.org/en/) installed, then run `npx serve` from the command line in the same directory where your HTML file is. You can also use any other HTTP server that can serve static files with the correct MIME types.
 
 You may have noticed that the imported component's template is inlined as a JavaScript string. If you are using VS Code, you can install the [es6-string-html](https://marketplace.visualstudio.com/items?itemName=Tobermory.es6-string-html) extension and prefix the strings with a `/*html*/` comment to get syntax highlighting for them.
+
+## Frameworks {#frameworks}
+
+There are Vue frameworks which support [SSR](/guide/scaling-up/ssr) and other features out-of-the-box:
+- [Nuxt](https://nuxt.com/)
+- [Vike](https://vike.dev/)
+- [Astro](https://astro.build/)
+- [Quasar](https://quasar.dev/)
+
+:::tip
+The general recommendation is to use a framework only if you need SSR.
+
+If you don't need SSR, you can simply use [Vite](https://vite.dev/) (this is what the section above [Creating a Vue Application](#creating-a-vue-application) scaffolds).
+:::
+
+:::info
+Vue frameworks typically use Vite under the hood, so directly using Vite instead of a Vue framework is a simpler setup if you don't need SSR. That said, frameworks also support extra features, such as UI themes, which can also be a reason to favor a Vue framework instead of just using Vite.
+:::
 
 ## Next Steps {#next-steps}
 

--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -214,21 +214,7 @@ Moving from the example to a production-ready SSR app involves a lot more. We wi
 
 - Manage routing, data fetching, and state management stores in a universal manner.
 
-A complete implementation would be quite complex and depends on the build toolchain you have chosen to work with. Therefore, we highly recommend going with a higher-level, opinionated solution that abstracts away the complexity for you. Below we will introduce a few recommended SSR solutions in the Vue ecosystem.
-
-### Nuxt {#nuxt}
-
-[Nuxt](https://nuxt.com/) is a higher-level framework built on top of the Vue ecosystem which provides a streamlined development experience for writing universal Vue applications. Better yet, you can also use it as a static site generator! We highly recommend giving it a try.
-
-### Quasar {#quasar}
-
-[Quasar](https://quasar.dev) is a complete Vue-based solution that allows you to target SPA, SSR, PWA, mobile app, desktop app, and browser extension all using one codebase. It not only handles the build setup, but also provides a full collection of Material Design compliant UI components.
-
-### Vite SSR {#vite-ssr}
-
-Vite provides built-in [support for Vue server-side rendering](https://vite.dev/guide/ssr.html), but it is intentionally low-level. If you wish to go directly with Vite, check out [vite-plugin-ssr](https://vite-plugin-ssr.com/), a community plugin that abstracts away many challenging details for you.
-
-You can also find an example Vue + Vite SSR project using manual setup [here](https://github.com/vitejs/vite-plugin-vue/tree/main/playground/ssr-vue), which can serve as a base to build upon. Note this is only recommended if you are experienced with SSR / build tools and really want to have complete control over the higher-level architecture.
+A complete implementation would be quite complex and depends on the build toolchain you have chosen to work with. Therefore, we highly recommend using [Vue frameworks](/guide/quick-start#frameworks) if you need SSR - they have built-in SSR support.
 
 ## Writing SSR-friendly Code {#writing-ssr-friendly-code}
 

--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -214,7 +214,7 @@ Moving from the example to a production-ready SSR app involves a lot more. We wi
 
 - Manage routing, data fetching, and state management stores in a universal manner.
 
-A complete implementation would be quite complex and depends on the build toolchain you have chosen to work with. Therefore, we highly recommend using [Vue frameworks](/guide/quick-start#frameworks) if you need SSR - they have built-in SSR support.
+A complete implementation would be quite complex and depends on the build toolchain you have chosen to work with. Therefore, we highly recommend using [Vue frameworks](/guide/quick-start#frameworks) if you need SSR since they often have built-in SSR support.
 
 ## Writing SSR-friendly Code {#writing-ssr-friendly-code}
 


### PR DESCRIPTION
## Description of Problem

Follow up of:
- https://github.com/vuejs/docs/issues/3401#issuecomment-4905370315

## Additional Information

I sorted the framework list after project creation date (edit: [except for Quasar](https://github.com/vuejs/docs/pull/3428#issuecomment-4912641914)). But let me if you prefer another framework order.