### PR TITLE
docs(v-model): document factory-function defaults for objects/arrays

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -96,6 +96,16 @@ const model = defineModel({ required: true })
 const model = defineModel({ default: 0 })
 ```
 
+When the default value is an object or array, return it from a factory function, just as with [prop defaults](/guide/components/props#prop-validation). Otherwise every component instance that falls back to the default shares the **same** reference, and mutating the model in one instance leaks into the others:
+
+```js
+// ❌ every instance shares one object
+const model = defineModel({ default: {} })
+
+// ✅ each instance gets a fresh object
+const model = defineModel({ default: () => ({}) })
+```
+
 :::warning
 If you have a `default` value for `defineModel` prop and you don't provide any value for this prop from the parent component, it can cause a de-synchronization between parent and child components. In the example below, the parent's `myRef` is undefined, but the child's `model` is 1:
 


### PR DESCRIPTION
## What

The `defineModel()` default section on the `v-model` page only documents a primitive default (`default: 0`). Because `defineModel()` declares a regular prop, its `default` is resolved through the same machinery as `defineProps` — so an object/array default that isn't a factory function is **shared across every component instance**, and mutating the model in one instance leaks into the others.

This adds a short note + example right after the existing default example, and links to [Prop Validation](https://vuejs.org/guide/components/props#prop-validation) where the factory-function rule is already stated. The page even uses factory syntax for `modelModifiers`, just never for the value default.

## Repro

[Vue SFC Playground](https://play.vuejs.org/#eNrdVGFv2zYQ/Ss3DYgl1JabZJ8c20OWpdgGJB6SAsVQFQUjniQmFCnwKDmBqv8+kLJsx82yYei+7Bt193R89+4d2+C8quKmxmAWzCk1orJAaOtqmShRVtpYaMFgBh1kRpcwamocbVMXhZD8tmAG+SYdT/di8dfgdyy12jw9R2+CG3iiplOomEFlCSSyBsEWCKXmKKFWHDOhkMNk6cOpKzAi4JixWlp4EOkDgVCJSrUiC3QMC9dAGG0jJ4eR7CtMtoeZT3tdlo7a3GJZSWZxmSiAeXG6XN3dY2pBCouGyS2Po5IzKs7ArjUIRZapFAnI6QKr60vQ/W8hsRJB8Gg2nxanfdF9VZuJ73uRBHScBDB9FXGyQQzUBrEPOSFLiy0pyNESCEuw+nC9pcVFlqEbwUvchrq7q7NDci9ABnbz6Z6GwTg4MMxrRtTqStfKIj+wo7eM0mqS1Sq1Qquh5RkYtLVxfmE0EeRcQ71uLDWaCLBB87QVY5h/b7YF9Ga7cl9huyvadtBFm2tz0WCvKBdkhUrtICIDsuxOuvECae/WoXNImQIq9BoER2WFfRpuNpjDAsK1UFyv48+f3feXLwtoQc3g7RhKVs1A4Ro+IHu4YlUYeSoig/A7g3lcsiouGIW+g7hhssYogiFDaPczY3jzxqXU1viCe+P36Pw52ne8HUEYRrBYQutmvlksRPWM+0ZpR//jp8gBHSSuaioO6gK4BnxWosptAYvFAk4iX1lLjKXOw9HtL+c3lz+DXxmD2Y+jsS/48e0nD/fnY3dR9zdry0Wz3A5znmqOy7abT/0BjtQdVWdHhhlz1p+HgX7ftk6grptPXYW/sPLea/avvZw939wZpExK5FCh2S3uZAmZQSoGet6EVpT/1MX9AMO2i3Zu9tpu5mYwF2TNk7vowNvkXo1dUHD6P/p3mMI3M/C784v3q5s//hsHu36OcnvmJ/oNzGwp1SoTeXxPWgWzwCuVBKkuKyHRrCr30FISzHoNXY5Jqde/+Zg1NY6HeFpg+vBC/J4eXSwJfjdIaBpMgm3OMpOj7dOXt9f4aPeSpea1xFeTN0ha1o5jD/upVlyi2cN5tr/6fRQqf0+XjxYVDU05og7Zjfu+mxovXml9R/c0/sH/l6gu6P4EdGMvaw==)


- Object-literal default (`default: {}`): both instances render the **same object id** — one shared reference.
- Factory default (`default: () => ({})`): each instance renders a **different object id** — a fresh object per instance.
