### PR TITLE
feat(robots-txt): Add a robots.txt

### DIFF
--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Content-Signal: search=yes, ai-train=yes, ai-input=yes
+Disallow:
+
+Sitemap: https://vuejs.org/sitemap.xml 


### PR DESCRIPTION
## Description of Problem
Fixes: #3432 
https://vuejs.org/robots.txt is 404ing 
<img width="1470" height="445" alt="image" src="https://github.com/user-attachments/assets/5b69e30b-99c0-402a-b547-886a0871ba9f" />


## Proposed Solution
Add a robots.txt file to the public folder. 


## Additional Information
This robots.txt file is based on [Nuxt's robots.txt](https://nuxt.com/robots.txt)