### PR TITLE
chore: fix link to Evan You in FAQ

### DIFF
--- a/src/about/faq.md
+++ b/src/about/faq.md
@@ -2,7 +2,7 @@
 
 ## Who maintains Vue? {#who-maintains-vue}
 
-Vue is an independent, community-driven project. It was created by [Evan You](https://x.com/youyuxi) in 2014 as a personal side project. Today, Vue is actively maintained by [a team of both full-time and volunteer members from all around the world](/about/team), where Evan serves as the project lead. You can learn more about the story of Vue in this [documentary](https://www.youtube.com/watch?v=OrxmtDw4pVI).
+Vue is an independent, community-driven project. It was created by [Evan You](https://x.com/evanyou) in 2014 as a personal side project. Today, Vue is actively maintained by [a team of both full-time and volunteer members from all around the world](/about/team), where Evan serves as the project lead. You can learn more about the story of Vue in this [documentary](https://www.youtube.com/watch?v=OrxmtDw4pVI).
 
 Vue's development is primarily funded through sponsorships and we have been financially sustainable since 2016. If you or your business benefit from Vue, consider [sponsoring us](/sponsor/) to support Vue's development!
 


### PR DESCRIPTION


## Description of Problem

Updated the link to Evan You's profile in the FAQ section.

## Proposed Solution

```diff

- https://x.com/youyuxi
+ https://x.com/evanyou
```

## Additional Information
<img width="720" height="635" alt="image" src="https://github.com/user-attachments/assets/efd78768-0e48-4290-a987-f9bec0654090" />

