### PR TITLE
chore: fix link to Evan You in Members

### DIFF
--- a/src/about/team/members-core.json
+++ b/src/about/team/members-core.json
@@ -21,7 +21,7 @@
     },
     "socials": {
       "github": "yyx990803",
-      "twitter": "youyuxi"
+      "twitter": "evanyou"
     },
     "sponsor": true
   },


### PR DESCRIPTION
## Description of Problem

While https://github.com/vuejs/docs/pull/3436 fixed the X link in FAQ, it still shows wrong on Members page

## Proposed Solution

Update X user name for Evan You in members-core.json data as well

## Additional Information
